### PR TITLE
Foundations: CI, LICENSE, and core hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-ed:"
+            echo "$unformatted"
+            exit 1
+          fi
+      - name: vet
+        run: go vet ./...
+      - name: build
+        run: go build ./...
+      - name: test
+        run: go test -race ./...

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Owain Lewis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/push/main.go
+++ b/cmd/push/main.go
@@ -7,10 +7,14 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/owainlewis/push/internal/claude"
 	"github.com/owainlewis/push/internal/config"
@@ -19,6 +23,9 @@ import (
 	"github.com/owainlewis/push/internal/store"
 )
 
+// shutdownGrace bounds how long we wait for in-flight runs on exit.
+const shutdownGrace = 30 * time.Second
+
 func main() {
 	configPath := flag.String("config", "config.json", "path to config file")
 	flag.Parse()
@@ -26,6 +33,10 @@ func main() {
 	cfg, err := config.Load(*configPath)
 	if err != nil {
 		log.Fatalf("config: %v", err)
+	}
+
+	if err := preflight(cfg); err != nil {
+		log.Fatalf("preflight: %v", err)
 	}
 
 	st, err := store.Open(cfg.StatePath)
@@ -44,9 +55,45 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := g.Run(ctx); err != nil && ctx.Err() == nil {
+	if err := g.Run(ctx); err != nil {
 		log.Fatalf("gateway: %v", err)
 	}
-	log.Println("shutting down")
-	os.Exit(0)
+
+	log.Println("draining in-flight runs...")
+	g.Shutdown(shutdownGrace)
+	log.Println("shut down cleanly")
+}
+
+// preflight fails fast with actionable messages when the environment is not
+// ready, rather than surfacing opaque errors at the first message.
+func preflight(cfg *config.Config) error {
+	// Messages database must be readable (requires Full Disk Access).
+	f, err := os.Open(cfg.DBPath)
+	if err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("cannot read %s: grant Full Disk Access to your terminal in System Settings -> Privacy & Security -> Full Disk Access", cfg.DBPath)
+		}
+		if os.IsNotExist(err) {
+			return fmt.Errorf("Messages database not found at %s; is iMessage set up on this Mac?", cfg.DBPath)
+		}
+		return fmt.Errorf("open %s: %w", cfg.DBPath, err)
+	}
+	_ = f.Close()
+
+	// Required external tools.
+	for _, bin := range []string{cfg.ClaudeBin, "sqlite3", "osascript"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			return fmt.Errorf("%q not found on PATH: %w", bin, err)
+		}
+	}
+
+	// Writable working directories.
+	if err := os.MkdirAll(cfg.SessionsDir, 0o755); err != nil {
+		return fmt.Errorf("sessions_dir %s not writable: %w", cfg.SessionsDir, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfg.StatePath), 0o755); err != nil {
+		return fmt.Errorf("state_path dir not writable: %w", err)
+	}
+
+	return nil
 }

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
   "db_path": "~/Library/Messages/chat.db",
   "poll_interval": "3s",
+  "run_timeout": "120s",
   "self_handles": ["you@icloud.com", "+15551234567"],
   "allow_from": [],
   "claude_bin": "claude",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 type Config struct {
 	DBPath         string   `json:"db_path"`
 	PollInterval   string   `json:"poll_interval"`
+	RunTimeout     string   `json:"run_timeout"`
 	SelfHandles    []string `json:"self_handles"`
 	AllowFrom      []string `json:"allow_from"`
 	ClaudeBin      string   `json:"claude_bin"`
@@ -53,6 +54,9 @@ func (c *Config) applyDefaults() {
 	if c.PollInterval == "" {
 		c.PollInterval = "3s"
 	}
+	if c.RunTimeout == "" {
+		c.RunTimeout = "120s"
+	}
 	if c.ClaudeBin == "" {
 		c.ClaudeBin = "claude"
 	}
@@ -80,12 +84,20 @@ func (c *Config) validate() error {
 	if _, err := c.PollDuration(); err != nil {
 		return fmt.Errorf("config: invalid poll_interval %q: %w", c.PollInterval, err)
 	}
+	if _, err := c.RunDuration(); err != nil {
+		return fmt.Errorf("config: invalid run_timeout %q: %w", c.RunTimeout, err)
+	}
 	return nil
 }
 
 // PollDuration parses PollInterval into a time.Duration.
 func (c *Config) PollDuration() (time.Duration, error) {
 	return time.ParseDuration(c.PollInterval)
+}
+
+// RunDuration parses RunTimeout into a time.Duration.
+func (c *Config) RunDuration() (time.Duration, error) {
+	return time.ParseDuration(c.RunTimeout)
 }
 
 func expandHome(p string) string {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -26,13 +26,17 @@ type Gateway struct {
 	sender *imessage.Sender
 	runner *claude.Runner
 
-	self  map[string]bool // self_handles set
-	allow map[string]bool // allow_from set
+	self       map[string]bool // self_handles set
+	allow      map[string]bool // allow_from set
+	runTimeout time.Duration   // max wall-clock per claude run
 
 	mu     sync.Mutex
 	queues map[string]chan job // per-thread work queues
 	wg     sync.WaitGroup
 }
+
+// sendTimeout bounds a single osascript reply.
+const sendTimeout = 30 * time.Second
 
 type job struct {
 	thread string
@@ -42,15 +46,17 @@ type job struct {
 
 // New constructs a Gateway from its dependencies.
 func New(cfg *config.Config, st *store.Store, p *imessage.Poller, s *imessage.Sender, r *claude.Runner) *Gateway {
+	runTimeout, _ := cfg.RunDuration()
 	g := &Gateway{
-		cfg:    cfg,
-		store:  st,
-		poller: p,
-		sender: s,
-		runner: r,
-		self:   toSet(cfg.SelfHandles),
-		allow:  toSet(cfg.AllowFrom),
-		queues: map[string]chan job{},
+		cfg:        cfg,
+		store:      st,
+		poller:     p,
+		sender:     s,
+		runner:     r,
+		self:       toSet(cfg.SelfHandles),
+		allow:      toSet(cfg.AllowFrom),
+		runTimeout: runTimeout,
+		queues:     map[string]chan job{},
 	}
 	return g
 }
@@ -74,11 +80,32 @@ func (g *Gateway) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			g.drain()
-			return ctx.Err()
+			// Stop polling. In-flight runs are drained by Shutdown.
+			return nil
 		case <-ticker.C:
 			g.tick(ctx)
 		}
+	}
+}
+
+// Shutdown stops accepting new work and waits up to grace for in-flight runs to
+// finish so a reply is never lost mid-send.
+func (g *Gateway) Shutdown(grace time.Duration) {
+	g.mu.Lock()
+	for _, q := range g.queues {
+		close(q)
+	}
+	g.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		g.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(grace):
+		log.Printf("shutdown: grace period expired with runs still in flight")
 	}
 }
 
@@ -97,7 +124,7 @@ func (g *Gateway) tick(ctx context.Context) {
 		if !ok {
 			continue
 		}
-		g.enqueue(ctx, job{thread: thread, target: target, text: strings.TrimSpace(m.Text)})
+		g.enqueue(job{thread: thread, target: target, text: strings.TrimSpace(m.Text)})
 	}
 	if maxRow > 0 {
 		if err := g.store.SetLastRow(maxRow); err != nil {
@@ -128,41 +155,39 @@ func (g *Gateway) accept(m imessage.Message) (thread, target string, ok bool) {
 	return "", "", false
 }
 
-// enqueue routes a job to its thread worker, starting the worker on demand.
-func (g *Gateway) enqueue(ctx context.Context, j job) {
+// enqueue routes a job to its thread worker, starting the worker on demand. If
+// the thread's queue is full it tells the sender instead of dropping silently.
+func (g *Gateway) enqueue(j job) {
 	g.mu.Lock()
 	q, ok := g.queues[j.thread]
 	if !ok {
 		q = make(chan job, 32)
 		g.queues[j.thread] = q
 		g.wg.Add(1)
-		go g.worker(ctx, j.thread, q)
+		go g.worker(q)
 	}
 	g.mu.Unlock()
 
 	select {
 	case q <- j:
 	default:
-		log.Printf("[%s] queue full, dropping message", j.thread)
+		log.Printf("[%s] queue full, asking sender to resend", j.thread)
+		g.reply(j.target, "I'm a bit behind on this thread — resend that in a moment.")
 	}
 }
 
-// worker processes one thread's jobs strictly in order.
-func (g *Gateway) worker(ctx context.Context, thread string, q chan job) {
+// worker processes one thread's jobs strictly in order, draining the queue when
+// it is closed during shutdown.
+func (g *Gateway) worker(q chan job) {
 	defer g.wg.Done()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case j := <-q:
-			g.handle(ctx, j)
-		}
+	for j := range q {
+		g.handle(j)
 	}
 }
 
-func (g *Gateway) handle(ctx context.Context, j job) {
+func (g *Gateway) handle(j job) {
 	if reply, handled := g.command(j); handled {
-		g.reply(ctx, j.target, reply)
+		g.reply(j.target, reply)
 		return
 	}
 
@@ -178,7 +203,12 @@ func (g *Gateway) handle(ctx context.Context, j job) {
 		return
 	}
 
-	reply, err := g.runner.Run(ctx, claude.Request{
+	// Runs use a background-derived timeout so an OS signal stops new polling
+	// but does not kill a reply mid-flight; the run is bounded by runTimeout.
+	runCtx, cancel := context.WithTimeout(context.Background(), g.runTimeout)
+	defer cancel()
+
+	reply, err := g.runner.Run(runCtx, claude.Request{
 		SessionID:    sessionID,
 		IsNew:        isNew,
 		WorkDir:      workDir,
@@ -186,12 +216,17 @@ func (g *Gateway) handle(ctx context.Context, j job) {
 		Prompt:       j.text,
 	})
 	if err != nil {
+		if runCtx.Err() == context.DeadlineExceeded {
+			log.Printf("[%s] claude run timed out after %s", j.thread, g.runTimeout)
+			g.reply(j.target, "That took too long and was stopped. Try again or simplify the request.")
+			return
+		}
 		log.Printf("[%s] claude error: %v", j.thread, err)
-		g.reply(ctx, j.target, "⚠️ "+claudeErrorMessage(err))
+		g.reply(j.target, "⚠️ "+claudeErrorMessage(err))
 		return
 	}
 	_ = g.store.MarkStarted(j.thread)
-	g.reply(ctx, j.target, reply)
+	g.reply(j.target, reply)
 }
 
 // command handles gateway-level slash commands before anything reaches Claude.
@@ -209,10 +244,12 @@ func (g *Gateway) command(j job) (reply string, handled bool) {
 	}
 }
 
-func (g *Gateway) reply(ctx context.Context, target, text string) {
+func (g *Gateway) reply(target, text string) {
 	if strings.TrimSpace(text) == "" {
 		return
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
+	defer cancel()
 	out := text + g.cfg.ReplyMarker
 	if err := g.sender.Send(ctx, target, out); err != nil {
 		log.Printf("send error to %s: %v", target, err)
@@ -222,14 +259,6 @@ func (g *Gateway) reply(ctx context.Context, target, text string) {
 // sandbox returns the per-thread working directory.
 func (g *Gateway) sandbox(thread string) string {
 	return filepath.Join(g.cfg.SessionsDir, sanitize(thread))
-}
-
-func (g *Gateway) drain() {
-	g.mu.Lock()
-	for _, q := range g.queues {
-		close(q)
-	}
-	g.mu.Unlock()
 }
 
 func ensureDir(path string) error {

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -1,0 +1,83 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/owainlewis/push/internal/config"
+	"github.com/owainlewis/push/internal/imessage"
+)
+
+func testGateway() *Gateway {
+	cfg := &config.Config{
+		SelfHandles: []string{"me@icloud.com"},
+		AllowFrom:   []string{"+15551234567"},
+		ReplyMarker: "\n\n— sent by push",
+		RunTimeout:  "120s",
+	}
+	return New(cfg, nil, nil, nil, nil)
+}
+
+func TestAccept(t *testing.T) {
+	g := testGateway()
+
+	cases := []struct {
+		name       string
+		msg        imessage.Message
+		wantOK     bool
+		wantThread string
+		wantTarget string
+	}{
+		{
+			name:       "self-chat accepted",
+			msg:        imessage.Message{ChatIdentifier: "me@icloud.com", IsFromMe: true, Text: "hi"},
+			wantOK:     true,
+			wantThread: "self:me@icloud.com",
+			wantTarget: "me@icloud.com",
+		},
+		{
+			name:       "allowlisted dm accepted",
+			msg:        imessage.Message{ChatIdentifier: "+15551234567", Handle: "+15551234567", IsFromMe: false, Text: "hi"},
+			wantOK:     true,
+			wantThread: "dm:+15551234567",
+			wantTarget: "+15551234567",
+		},
+		{
+			name:   "non-allowlisted dm dropped",
+			msg:    imessage.Message{ChatIdentifier: "+19998887777", Handle: "+19998887777", IsFromMe: false, Text: "hi"},
+			wantOK: false,
+		},
+		{
+			name:   "our own reply dropped via marker",
+			msg:    imessage.Message{ChatIdentifier: "me@icloud.com", IsFromMe: true, Text: "an answer\n\n— sent by push"},
+			wantOK: false,
+		},
+		{
+			name:   "is_from_me to someone else dropped",
+			msg:    imessage.Message{ChatIdentifier: "+12223334444", Handle: "+12223334444", IsFromMe: true, Text: "hey friend"},
+			wantOK: false,
+		},
+		{
+			name:   "empty text dropped",
+			msg:    imessage.Message{ChatIdentifier: "me@icloud.com", IsFromMe: true, Text: "   "},
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			thread, target, ok := g.accept(tc.msg)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if thread != tc.wantThread {
+				t.Errorf("thread = %q, want %q", thread, tc.wantThread)
+			}
+			if target != tc.wantTarget {
+				t.Errorf("target = %q, want %q", target, tc.wantTarget)
+			}
+		})
+	}
+}

--- a/internal/imessage/poller.go
+++ b/internal/imessage/poller.go
@@ -53,6 +53,8 @@ LEFT JOIN handle h ON m.handle_id = h.ROWID
 LEFT JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
 LEFT JOIN chat c ON c.ROWID = cmj.chat_id
 WHERE m.ROWID > %d
+  AND m.associated_message_type = 0
+  AND m.item_type = 0
 ORDER BY m.ROWID ASC;`
 
 // Poll returns messages with ROWID greater than sinceRowID, oldest first. When


### PR DESCRIPTION
First hardening pass to make push safe to leave running on a VM. Lands the CI gate plus the robustness fixes from the review.

## CI / infra
- **CI (#1)**: GitHub Actions on ubuntu + macos — gofmt check, `go vet`, `go build`, `go test -race`.
- **LICENSE (#3)**: MIT.

## Hardening
- **Per-message timeout (#4)**: each `claude` run gets a `run_timeout` deadline (default 120s). A hung run no longer blocks its thread forever; the sender gets a clear timeout reply.
- **Poller filter (#5)**: query now excludes tapbacks/reactions (`associated_message_type`) and system rows (`item_type`), so only real text messages reach claude.
- **Graceful shutdown (#6)**: `Run` stops polling on SIGINT/SIGTERM; new `Shutdown` closes the per-thread queues and waits up to a grace period for in-flight runs to complete, so a reply is never lost mid-send. Runs use a background-derived context so a signal doesn't kill a reply already in progress.
- **accept() tests (#7)**: table tests covering self-chat, allowlisted DM, non-allowlisted drop, own-reply (marker) drop, is_from_me-to-others drop, empty-text drop.
- **Queue-full notify (#8)**: tells the sender to resend instead of silently dropping.
- **Startup preflight (#9)**: fails fast with actionable messages when chat.db is unreadable (Full Disk Access not granted), `claude`/`sqlite3`/`osascript` are missing from PATH, or working dirs aren't writable.

## Verification
- `gofmt -l .` clean, `go vet ./...` clean, `go build ./...`, `go test -race ./...` all pass locally.
- Filter query validated against a real `chat.db`.

Closes #1
Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
Closes #9

Follow-ups (left open): #2 linter, #10 threat model + tool allowlist, #11 structured logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)