### PR TITLE
Fix session-id collision + add strategy doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ A concrete payoff: push bills your **Claude subscription**, because it just runs
 otherwise it uses your logged-in subscription. No wrapper, no separate billing,
 no provider config.
 
+## Strategy: own the gateway, not the assistant
+
+Personal AI agents are becoming a platform category. Google has Spark. Nous has
+Hermes. OpenAI and Anthropic have agent tools. The risk is betting your whole
+workflow on one assistant app.
+
+push is a hedge against that. The durable layer is the one you own: how messages
+reach you, how your memory is stored, how work is routed. push keeps that layer
+yours and treats the agent as a swappable slot. Today it drives Claude Code
+natively (the best first-party agent, used directly, not wrapped). The gateway
+itself depends on no provider, so the agent stays a choice you can remake.
+
+There is no contradiction with "it's actually Claude Code" above: that is the
+agent layer (use the best agent natively), this is the gateway layer (never let
+one app own your workflow). See [docs/strategy.md](docs/strategy.md) for the full
+argument and the honest gap (the agent slot is still Claude-shaped today).
+
 ## v1 scope
 
 - iMessage only.

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -1,0 +1,61 @@
+# push — Strategy
+
+## The bet
+
+Personal AI agents are becoming a platform category. Google has Spark. Nous has
+Hermes. OpenAI and Anthropic have agent tools. But I do not want to bet my
+workflow on one assistant app. I want a gateway that lets me talk to whichever
+agent is best for the job.
+
+push is that gateway, and it is a long-term hedge against single-provider
+lock-in.
+
+## Own the gateway, not the assistant
+
+The durable thing is not the model. Models change every few months. The durable
+thing is the layer you own: how messages reach you, how your context and memory
+are stored, and how work is routed to an agent. That layer should be yours, not
+rented from whichever assistant app is ahead this quarter.
+
+So push splits the world into two parts:
+
+- **The gateway is yours and provider-independent.** Channels (iMessage today,
+  more later), your memory as plain files you own and version, session and
+  routing state, the poll loop. None of this is tied to a vendor.
+- **The agent is a swappable slot.** Today push drives Claude Code, because it
+  is the best first-party agent available and push uses it natively rather than
+  wrapping it. Tomorrow the same gateway can route to a different agent when a
+  different agent is better for the task.
+
+## Why this is not a contradiction
+
+push's other headline is "it's actually Claude Code, not a third-party wrapper."
+That is about the agent layer: when you choose Claude, you get the real thing,
+not a degraded proxy like Hermes' runtime or OpenClaw's `pi` wrapper. The hedge
+is about the gateway layer: the part you own does not depend on Claude, or on
+anyone.
+
+Put together: use the best agent natively, but never let any one assistant app
+own your workflow. Single-provider apps like Hermes ask you to live inside their
+world. push keeps the world yours and lets the agent be a choice you remake
+whenever you want.
+
+## What this requires (the honest gap)
+
+Today the agent slot is shaped like Claude Code. The session model leans on
+`--session-id` / `--resume`, and memory injection uses `--append-system-prompt`.
+That is fine for v1, but it means "swap the agent" is not yet free.
+
+To make the hedge real, the agent needs a clean contract: an `AgentRunner` seam
+that takes a prompt plus conversation state and returns a reply, with the
+gateway owning the conversation identity rather than borrowing the agent's. The
+file-based memory already helps here, because it is injected, not stored inside
+any agent. Defining that seam is the main piece of work between "Claude Code
+gateway" and "multi-agent gateway."
+
+## Course angle
+
+This doubles as a teaching artifact. The lesson is not "here is how to use one
+assistant app." It is "here is how to build a personal AI gateway you own, so no
+single provider owns your workflow." push is the worked example: small, legible,
+file-based memory, and an agent slot you control.

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -258,7 +258,14 @@ async fn handle(ctx: &Ctx, job: Job) {
     }
 
     let system = memory::load(&ctx.assistant_dir);
-    let req = Request {
+
+    // Mark the session started up front, so a run that fails after Claude has
+    // already created the session never re-attempts `--session-id` and collides.
+    if is_new {
+        let _ = ctx.store.lock().unwrap().mark_started(&job.thread);
+    }
+
+    let req = |is_new| Request {
         session_id: &session_id,
         is_new,
         work_dir: &work_dir,
@@ -266,9 +273,20 @@ async fn handle(ctx: &Ctx, job: Job) {
         prompt: &job.text,
     };
 
-    match ctx.runner.run(req, ctx.run_timeout).await {
+    let mut result = ctx.runner.run(req(is_new), ctx.run_timeout).await;
+    // If the session id already exists (e.g. left over from a previous run or a
+    // different build), resume it instead of trying to create it again.
+    if is_new {
+        if let Err(RunError::Failed(msg)) = &result {
+            if msg.to_lowercase().contains("already in use") {
+                warn!("[{}] session id already existed, resuming", job.thread);
+                result = ctx.runner.run(req(false), ctx.run_timeout).await;
+            }
+        }
+    }
+
+    match result {
         Ok(reply) => {
-            let _ = ctx.store.lock().unwrap().mark_started(&job.thread);
             reply_to(ctx, &job.target, &reply).await;
         }
         Err(RunError::Timeout) => {


### PR DESCRIPTION
## Fix: resume on session-id collision
A run that failed *after* Claude created the session left it marked not-started, so the next message re-attempted `--session-id` and Claude rejected it with "session ID already in use" (surfaced live during testing of the rust build against state left over from the Go prototype). Now:
- The session is marked started up front, so a later failure never re-attempts creation.
- If `--session-id` still collides, the message falls back to `--resume`.

Self-healing: a stuck session recovers on the next message with no `/clear`.

## Docs: strategy
Adds `docs/strategy.md` and a README section: own the gateway, not the assistant. Personal AI agents are a platform category; the hedge is owning the gateway (channels, file-based memory, routing) while the agent stays a swappable slot, filled natively by Claude Code today. Notes the honest gap: the agent slot is still Claude-shaped and needs a generic runner seam (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)