### PR TITLE
Add Factory standards for push

### DIFF
--- a/.factory/AGENTS.md
+++ b/.factory/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+This repository defines push.
+
+push is a tiny messaging gateway that turns coding agents into a personal assistant you text.
+It reads allowed iMessage threads, routes messages to Claude Code or Codex, and sends replies back through Messages.
+
+## Agent Rules
+
+- Keep changes small and easy to review.
+- Prefer simple Rust code and clear module boundaries.
+- Follow the current async Tokio style.
+- Do not push to `main`.
+- Do not merge pull requests.
+- Do not change safety defaults without human review.
+- Do not invent product claims, metrics, pricing, or roadmap promises.
+- Stop when the requested issue or objective is unclear.
+
+## Important Context
+
+- `src/main.rs` owns CLI startup and runtime wiring.
+- `src/config.rs` owns config loading and validation.
+- `src/gateway.rs` owns polling, routing, and reply flow.
+- `src/imessage/` owns Messages database reads and sends.
+- `src/claude.rs` and `src/codex.rs` own backend adapters.
+- `src/store.rs` owns durable conversation state.
+- `assistant/*.example.md` and `config.example.json` are user-facing templates.
+- `site/` is the static project site.
+
+## Verification
+
+Run these checks before opening a pull request when code changes:
+
+```sh
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --locked
+cargo build --locked
+```
+

--- a/.factory/JOURNAL.md
+++ b/.factory/JOURNAL.md
@@ -1,0 +1,9 @@
+# JOURNAL.md
+
+Append-only engineering handover for Factory runs in push.
+
+## 2026-06-29
+
+- Initialized Factory repo contract.
+- Added repo-specific agent instructions, standards, and one default readiness workflow.
+- Registered push in the local Factory config.

--- a/.factory/STANDARDS.md
+++ b/.factory/STANDARDS.md
@@ -1,0 +1,91 @@
+# STANDARDS.md
+
+These standards define repo health for push.
+
+## Purpose
+
+push must clearly explain its mission:
+provide a small personal assistant gateway over iMessage while keeping coding-agent backends replaceable.
+
+## Repository Contract
+
+- Factory repo contract files live under `.factory/`.
+- Standards, workflows, objectives, and journal entries are owned by this repo.
+- Factory may run workflows from this repo, but the repo defines what good means.
+
+## Rust Code
+
+- Keep module boundaries clear.
+- `src/config.rs` owns config shape, defaults, and validation.
+- `src/gateway.rs` owns message loop orchestration.
+- `src/imessage/` owns iMessage read and send behavior.
+- `src/claude.rs` and `src/codex.rs` own agent backend behavior.
+- `src/store.rs` owns persisted session state.
+- Prefer explicit errors with context.
+- Do not add large dependencies without human review.
+
+## Testing
+
+- New behavior must include focused tests when practical.
+- Bug fixes must include regression tests.
+- `cargo test --locked` must pass.
+- Tests that need macOS Messages, Full Disk Access, or live agent CLIs should be isolated or documented as manual checks.
+
+## Formatting and Linting
+
+- `cargo fmt --check` must pass.
+- `cargo clippy --all-targets -- -D warnings` must pass.
+- Code should stay idiomatic and simple.
+
+## Build
+
+- `cargo build --locked` must pass.
+- Release builds should use `cargo build --locked --release`.
+- `Cargo.lock` must stay committed.
+
+## Documentation
+
+- README must explain the current scope honestly.
+- README must document install, run, config, safety, and release commands.
+- `config.example.json` must match the actual config shape.
+- Public claims must be backed by code, docs, tests, issues, or releases.
+- Security and permission risks must be plain, especially iMessage access and headless agent permissions.
+
+## CI
+
+- Pull requests should run Rust format, clippy, tests, and build.
+- CI should not require secrets for normal pull request checks.
+- CI should use the locked dependency graph.
+
+## Release
+
+- Releases should use tags.
+- Release notes should explain user-visible changes.
+- Release artifacts should include the binary, README, LICENSE, and `config.example.json`.
+- Do not publish releases without human review.
+
+## Safety
+
+- Do not broaden `allow_from` behavior without human review.
+- Do not weaken reply loop prevention without human review.
+- Do not change default agent permission modes without human review.
+- Do not commit secrets, private assistant memory, or local config.
+- Do not merge pull requests automatically.
+- Do not push directly to default branches.
+
+## Human Review Required
+
+Human review is required for:
+
+- merging
+- releases
+- public claims
+- pricing
+- product strategy
+- deleting features
+- changing repo purpose
+- changing licenses
+- changing safety defaults
+- changing iMessage permission assumptions
+- changing default backend permission behavior
+

--- a/.factory/WORKFLOWS/standards-check.md
+++ b/.factory/WORKFLOWS/standards-check.md
@@ -1,0 +1,57 @@
+# Standards Check
+
+## Goal
+
+Review push against `.factory/STANDARDS.md`.
+Make the smallest safe change that improves compliance.
+
+Use this one workflow for routine push work.
+The objective should name the area, such as docs, CI, testing, release, or agent readiness.
+
+## Plan Mode
+
+In plan mode:
+
+1. Read `.factory/AGENTS.md`.
+2. Read `.factory/STANDARDS.md`.
+3. Inspect README, docs, Rust code, tests, CI, release workflow, and examples.
+4. Focus on the current objective when one is provided.
+5. Report which standards pass, fail, or need human review.
+6. Name one smallest safe execute-mode change.
+7. Do not edit files.
+8. Do not create branches.
+9. Do not open pull requests.
+
+## Execute Mode
+
+In execute mode:
+
+1. Pick one small fix that does not need human review.
+2. Create a non-default branch.
+3. Make the change.
+4. Run relevant checks.
+5. Commit the change.
+6. Push the branch.
+7. Open a draft pull request.
+8. Include checks run and remaining gaps.
+
+## Stop Rules
+
+Stop and report `blocked` if:
+
+- the change affects safety defaults
+- the change affects repo purpose
+- the fix requires product strategy
+- tests need local iMessage access, secrets, or live agent auth
+- the working tree has unrelated user changes
+
+## Verification
+
+Run when code changes:
+
+```sh
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --locked
+cargo build --locked
+```


### PR DESCRIPTION
## Summary
- add repo-owned Factory standards for push
- add one default standards-check workflow
- add agent instructions and journal scaffold

## Checks
- verified .factory/WORKFLOWS contains only standards-check.md

## Notes
- Not merged by agent. Human review required by repo rules.