### PR TITLE
fix: ignore empty backend session ids

### DIFF
--- a/src/claude.rs
+++ b/src/claude.rs
@@ -67,7 +67,7 @@ impl Runner {
             }
             Ok(r) => Ok(RunOutput {
                 reply: r.result.trim().to_string(),
-                session_id: Some(r.session_id),
+                session_id: non_empty_session_id(&r.session_id).map(str::to_string),
             }),
             Err(_) => {
                 if out.status.success() {
@@ -82,5 +82,29 @@ impl Runner {
                 }
             }
         }
+    }
+}
+
+fn non_empty_session_id(id: &str) -> Option<&str> {
+    let trimmed = id.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ignores_empty_session_id() {
+        assert_eq!(non_empty_session_id(""), None);
+        assert_eq!(non_empty_session_id(" \t\n "), None);
+    }
+
+    #[test]
+    fn keeps_valid_session_id() {
+        assert_eq!(
+            non_empty_session_id(" claude-session "),
+            Some("claude-session")
+        );
     }
 }

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -122,9 +122,12 @@ fn prompt(req: &Request<'_>) -> String {
 fn session_id_from_jsonl(s: &str) -> Option<String> {
     s.lines().find_map(|line| {
         let ev: JsonEvent = serde_json::from_str(line).ok()?;
-        (ev.kind == "thread.started")
-            .then_some(ev.thread_id)
-            .flatten()
+        if ev.kind != "thread.started" {
+            return None;
+        }
+        let thread_id = ev.thread_id?;
+        let thread_id = thread_id.trim();
+        (!thread_id.is_empty()).then(|| thread_id.to_string())
     })
 }
 
@@ -151,6 +154,12 @@ mod tests {
     fn extracts_thread_id() {
         let s = r#"{"type":"thread.started","thread_id":"abc"}"#;
         assert_eq!(session_id_from_jsonl(s), Some("abc".to_string()));
+    }
+
+    #[test]
+    fn ignores_empty_thread_id() {
+        let s = r#"{"type":"thread.started","thread_id":" \t\n "}"#;
+        assert_eq!(session_id_from_jsonl(s), None);
     }
 
     #[test]

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -350,16 +350,14 @@ async fn handle(ctx: &Ctx, job: Job) {
 
     match result {
         Ok(out) => {
-            if is_new && !runner.mark_started_before_run() {
-                if let Err(e) = ctx
-                    .store
-                    .lock()
-                    .unwrap()
-                    .mark_started(&job.thread, out.session_id.as_deref())
-                {
-                    error!("[{}] session save error: {e}", job.thread);
-                    return;
-                }
+            if let Err(e) = ctx
+                .store
+                .lock()
+                .unwrap()
+                .mark_started(&job.thread, out.session_id.as_deref())
+            {
+                error!("[{}] session save error: {e}", job.thread);
+                return;
             }
             if reply_to(ctx, &job.target, &out.reply).await {
                 complete_row(&ctx.store, &ctx.ack, job.row_id);

--- a/src/store.rs
+++ b/src/store.rs
@@ -63,6 +63,18 @@ impl Store {
     ) -> Result<(String, bool)> {
         if let Some(si) = self.state.sessions.get(thread) {
             if si.backend == backend {
+                if si.uuid.trim().is_empty() {
+                    self.state.sessions.insert(
+                        thread.to_string(),
+                        SessionInfo {
+                            uuid: initial_id.clone(),
+                            started: false,
+                            backend: backend.to_string(),
+                        },
+                    );
+                    self.save()?;
+                    return Ok((initial_id, true));
+                }
                 return Ok((si.uuid.clone(), !si.started));
             }
         }
@@ -80,10 +92,14 @@ impl Store {
 
     pub fn mark_started(&mut self, thread: &str, session_id: Option<&str>) -> Result<()> {
         if let Some(si) = self.state.sessions.get_mut(thread) {
+            let session_id = session_id.and_then(non_empty_session_id);
             if let Some(id) = session_id {
                 si.uuid = id.to_string();
             }
             if !si.started {
+                if si.uuid.trim().is_empty() {
+                    return Ok(());
+                }
                 si.started = true;
                 return self.save();
             }
@@ -121,6 +137,11 @@ impl Store {
 
 fn default_backend() -> String {
     "claude".to_string()
+}
+
+fn non_empty_session_id(id: &str) -> Option<&str> {
+    let trimmed = id.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
 }
 
 #[cfg(test)]
@@ -170,6 +191,94 @@ mod tests {
             .session_for("self:me", "codex", String::new())
             .unwrap();
         assert_eq!(resumed, ("codex-thread-id".to_string(), false));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn mark_started_ignores_empty_backend_session_id() {
+        let path = temp_state_path();
+        let mut store = Store::open(&path).unwrap();
+
+        store
+            .session_for("self:me", "claude", "initial-session".to_string())
+            .unwrap();
+        store.mark_started("self:me", Some(" \t\n ")).unwrap();
+
+        let resumed = store
+            .session_for("self:me", "claude", "unused-session".to_string())
+            .unwrap();
+        assert_eq!(resumed, ("initial-session".to_string(), false));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn existing_empty_backend_session_id_starts_fresh_session() {
+        let path = temp_state_path();
+        std::fs::write(
+            &path,
+            r#"{
+  "sessions": {
+    "self:me": {
+      "uuid": "",
+      "started": true,
+      "backend": "claude"
+    }
+  }
+}"#,
+        )
+        .unwrap();
+        let mut store = Store::open(&path).unwrap();
+
+        let fresh = store
+            .session_for("self:me", "claude", "fresh-session".to_string())
+            .unwrap();
+        assert_eq!(fresh, ("fresh-session".to_string(), true));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn existing_empty_unstarted_backend_session_id_starts_fresh_session() {
+        let path = temp_state_path();
+        std::fs::write(
+            &path,
+            r#"{
+  "sessions": {
+    "self:me": {
+      "uuid": "",
+      "started": false,
+      "backend": "claude"
+    }
+  }
+}"#,
+        )
+        .unwrap();
+        let mut store = Store::open(&path).unwrap();
+
+        let fresh = store
+            .session_for("self:me", "claude", "fresh-session".to_string())
+            .unwrap();
+        assert_eq!(fresh, ("fresh-session".to_string(), true));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn mark_started_does_not_activate_empty_backend_session_id() {
+        let path = temp_state_path();
+        let mut store = Store::open(&path).unwrap();
+
+        store
+            .session_for("self:me", "codex", String::new())
+            .unwrap();
+        store.mark_started("self:me", Some("")).unwrap();
+
+        let fresh = store
+            .session_for("self:me", "codex", String::new())
+            .unwrap();
+        assert_eq!(fresh, (String::new(), true));
 
         let _ = std::fs::remove_file(path);
     }


### PR DESCRIPTION
## Summary

- Ignore empty or whitespace-only backend session ids from Claude JSON output.
- Treat stored empty session ids as missing so future runs start fresh instead of resuming with an empty token.
- Let successful runner output update the stored session id, preserving valid Claude-returned ids and valid Codex thread ids.
- Reject empty Codex `thread_id` values during JSONL parsing.

## Why

Empty backend session ids could be saved as active resume tokens, causing later runs to resume with an empty id.

## Test plan

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- Independent code review: no blockers found
- Independent acceptance verification: all #35 criteria satisfied

## Risks

Low. This changes session id normalization and persistence behavior. The main thing to review is that backends do not intentionally use leading or trailing whitespace in session ids.

## Related issue

Closes #35
