### PR TITLE
test: add agent runner contract coverage

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -24,6 +24,7 @@ pub struct RunOutput {
 }
 
 /// What went wrong, separated so the gateway can phrase timeouts differently.
+#[derive(Debug)]
 pub enum RunError {
     Timeout,
     Failed(String),

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -93,6 +93,24 @@ fn non_empty_session_id(id: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
+    use crate::agent::Request;
+    use crate::test_support::{
+        assert_runner_contract, sh_arg, temp_dir, temp_path, ContractCase, ContractRequest,
+        ContractRunner, FakeCli, RunnerContract,
+    };
+
+    impl ContractRunner for Runner {
+        fn run<'a>(
+            &'a self,
+            req: Request<'a>,
+            timeout: Duration,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<RunOutput, RunError>> + 'a>>
+        {
+            Box::pin(self.run(req, timeout))
+        }
+    }
 
     #[test]
     fn ignores_empty_session_id() {
@@ -106,5 +124,254 @@ mod tests {
             non_empty_session_id(" claude-session "),
             Some("claude-session")
         );
+    }
+
+    #[tokio::test]
+    async fn satisfies_runner_contract() {
+        assert_runner_contract(RunnerContract {
+            name: "Claude",
+            new_session: contract_new_session,
+            resumed_session: contract_resumed_session,
+            failed_run: contract_failed_run,
+            timeout_run: contract_timeout_run,
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn runs_new_session_with_push_owned_session_id() {
+        let args_path = temp_path("claude-args");
+        let work_dir = temp_dir("claude-work");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nprintf '%s\\n' '{{\"result\":\" hello \",\"session_id\":\"claude-returned\"}}'\n",
+            sh_arg(&args_path)
+        );
+        let cli = FakeCli::new("claude", &script);
+        let runner = Runner {
+            bin: cli.bin(),
+            permission_mode: "bypassPermissions".to_string(),
+        };
+
+        let out = runner
+            .run(
+                Request {
+                    session_id: "push-session",
+                    is_new: true,
+                    work_dir: work_dir.to_str().unwrap(),
+                    system_append: "assistant context",
+                    prompt: "hello",
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(out.reply, "hello");
+        assert_eq!(out.session_id, Some("claude-returned".to_string()));
+        let args = read_args(&args_path);
+        assert_arg_pair(&args, "--session-id", "push-session");
+        assert_arg_pair(&args, "--permission-mode", "bypassPermissions");
+        assert_arg_pair(&args, "--append-system-prompt", "assistant context");
+        assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[tokio::test]
+    async fn runs_resumed_session_with_resume_flag() {
+        let args_path = temp_path("claude-resume-args");
+        let work_dir = temp_dir("claude-resume-work");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nprintf '%s\\n' '{{\"result\":\"resumed\",\"session_id\":\"claude-returned\"}}'\n",
+            sh_arg(&args_path)
+        );
+        let cli = FakeCli::new("claude", &script);
+        let runner = Runner {
+            bin: cli.bin(),
+            permission_mode: "default".to_string(),
+        };
+
+        let out = runner
+            .run(
+                Request {
+                    session_id: "existing-session",
+                    is_new: false,
+                    work_dir: work_dir.to_str().unwrap(),
+                    system_append: "",
+                    prompt: "continue",
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(out.reply, "resumed");
+        let args = read_args(&args_path);
+        assert_arg_pair(&args, "--resume", "existing-session");
+        assert!(!args.contains(&"--session-id".to_string()));
+        assert!(!args.contains(&"--append-system-prompt".to_string()));
+    }
+
+    #[tokio::test]
+    async fn reports_cli_json_error() {
+        let work_dir = temp_dir("claude-error-work");
+        let cli = FakeCli::new(
+            "claude",
+            "#!/bin/sh\nprintf '%s\\n' '{\"is_error\":true,\"result\":\"api down\"}'\nexit 1\n",
+        );
+        let runner = Runner {
+            bin: cli.bin(),
+            permission_mode: "default".to_string(),
+        };
+
+        let err = match runner
+            .run(request(work_dir.to_str().unwrap()), Duration::from_secs(5))
+            .await
+        {
+            Err(err) => err,
+            Ok(_) => panic!("expected Claude run to fail"),
+        };
+
+        assert_failed(err, "api down");
+    }
+
+    #[tokio::test]
+    async fn reports_timeout() {
+        let work_dir = temp_dir("claude-timeout-work");
+        let cli = FakeCli::new("claude", "#!/bin/sh\nsleep 2\n");
+        let runner = Runner {
+            bin: cli.bin(),
+            permission_mode: "default".to_string(),
+        };
+
+        let err = match runner
+            .run(
+                request(work_dir.to_str().unwrap()),
+                Duration::from_millis(10),
+            )
+            .await
+        {
+            Err(err) => err,
+            Ok(_) => panic!("expected Claude run to time out"),
+        };
+
+        assert_timeout(err);
+    }
+
+    fn request(work_dir: &str) -> Request<'_> {
+        Request {
+            session_id: "session",
+            is_new: true,
+            work_dir,
+            system_append: "",
+            prompt: "hello",
+        }
+    }
+
+    fn read_args(path: &std::path::Path) -> Vec<String> {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn assert_arg_pair(args: &[String], flag: &str, value: &str) {
+        let idx = args
+            .iter()
+            .position(|arg| arg == flag)
+            .unwrap_or_else(|| panic!("missing flag {flag} in {args:?}"));
+        assert_eq!(args.get(idx + 1).map(String::as_str), Some(value));
+    }
+
+    fn assert_failed(err: RunError, expected: &str) {
+        match err {
+            RunError::Failed(msg) => assert_eq!(msg, expected),
+            RunError::Timeout => panic!("expected failed error, got timeout"),
+        }
+    }
+
+    fn assert_timeout(err: RunError) {
+        match err {
+            RunError::Timeout => {}
+            RunError::Failed(msg) => panic!("expected timeout, got failed: {msg}"),
+        }
+    }
+
+    fn contract_new_session() -> ContractCase {
+        let work_dir = temp_dir("claude-contract-new");
+        let cli = FakeCli::new(
+            "claude",
+            "#!/bin/sh\nprintf '%s\\n' '{\"result\":\"new reply\",\"session_id\":\"claude-session\"}'\n",
+        );
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(Runner {
+                bin,
+                permission_mode: "default".to_string(),
+            }),
+            request: contract_request(work_dir, true),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn contract_resumed_session() -> ContractCase {
+        let work_dir = temp_dir("claude-contract-resume");
+        let cli = FakeCli::new(
+            "claude",
+            "#!/bin/sh\nprintf '%s\\n' '{\"result\":\"resumed reply\",\"session_id\":\"claude-session\"}'\n",
+        );
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(Runner {
+                bin,
+                permission_mode: "default".to_string(),
+            }),
+            request: contract_request(work_dir, false),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn contract_failed_run() -> ContractCase {
+        let work_dir = temp_dir("claude-contract-fail");
+        let cli = FakeCli::new(
+            "claude",
+            "#!/bin/sh\nprintf '%s\\n' '{\"is_error\":true,\"result\":\"failed\"}'\nexit 1\n",
+        );
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(Runner {
+                bin,
+                permission_mode: "default".to_string(),
+            }),
+            request: contract_request(work_dir, true),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn contract_timeout_run() -> ContractCase {
+        let work_dir = temp_dir("claude-contract-timeout");
+        let cli = FakeCli::new("claude", "#!/bin/sh\nsleep 2\n");
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(Runner {
+                bin,
+                permission_mode: "default".to_string(),
+            }),
+            request: contract_request(work_dir, true),
+            timeout: Duration::from_millis(10),
+        }
+    }
+
+    fn contract_request(work_dir: std::path::PathBuf, is_new: bool) -> ContractRequest {
+        ContractRequest {
+            session_id: "contract-session".to_string(),
+            is_new,
+            work_dir,
+            system_append: String::new(),
+            prompt: "hello".to_string(),
+        }
     }
 }

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -149,6 +149,24 @@ fn agent_message_from_line(line: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
+    use crate::agent::Request;
+    use crate::test_support::{
+        assert_runner_contract, sh_arg, temp_dir, temp_path, ContractCase, ContractRequest,
+        ContractRunner, FakeCli, RunnerContract,
+    };
+
+    impl ContractRunner for Runner {
+        fn run<'a>(
+            &'a self,
+            req: Request<'a>,
+            timeout: Duration,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<RunOutput, RunError>> + 'a>>
+        {
+            Box::pin(self.run(req, timeout))
+        }
+    }
 
     #[test]
     fn extracts_thread_id() {
@@ -170,5 +188,285 @@ mod tests {
             r#"{"type":"item.completed","item":{"type":"agent_message","text":"two"}}"#
         );
         assert_eq!(last_agent_message_from_jsonl(s), Some("two".to_string()));
+    }
+
+    #[tokio::test]
+    async fn satisfies_runner_contract() {
+        assert_runner_contract(RunnerContract {
+            name: "Codex",
+            new_session: contract_new_session,
+            resumed_session: contract_resumed_session,
+            failed_run: contract_failed_run,
+            timeout_run: contract_timeout_run,
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn runs_new_session_and_reads_jsonl_thread_id() {
+        let args_path = temp_path("codex-args");
+        let work_dir = temp_dir("codex-work");
+        let script = codex_success_script(&args_path, "codex reply", Some("codex-thread"));
+        let cli = FakeCli::new("codex", &script);
+        let runner = runner(cli.bin());
+
+        let out = runner
+            .run(
+                Request {
+                    session_id: "",
+                    is_new: true,
+                    work_dir: work_dir.to_str().unwrap(),
+                    system_append: "assistant context",
+                    prompt: "hello",
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(out.reply, "codex reply");
+        assert_eq!(out.session_id, Some("codex-thread".to_string()));
+        let args = read_args(&args_path);
+        assert_arg_pair(&args, "--ask-for-approval", "never");
+        assert_arg_pair(&args, "--sandbox", "workspace-write");
+        assert_arg_present(&args, "exec");
+        assert_arg_present(&args, "--json");
+        assert_arg_pair(&args, "-C", work_dir.to_str().unwrap());
+        assert_arg_pair(&args, "--add-dir", work_dir.to_str().unwrap());
+        let raw_args = std::fs::read_to_string(&args_path).unwrap();
+        assert!(raw_args.contains("Assistant context:"));
+        assert!(raw_args.contains("User message:\nhello"));
+    }
+
+    #[tokio::test]
+    async fn runs_resumed_session_with_resume_command() {
+        let args_path = temp_path("codex-resume-args");
+        let work_dir = temp_dir("codex-resume-work");
+        let script = codex_success_script(&args_path, "resumed reply", None);
+        let cli = FakeCli::new("codex", &script);
+        let runner = runner(cli.bin());
+
+        let out = runner
+            .run(
+                Request {
+                    session_id: "existing-thread",
+                    is_new: false,
+                    work_dir: work_dir.to_str().unwrap(),
+                    system_append: "",
+                    prompt: "continue",
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(out.reply, "resumed reply");
+        assert_eq!(out.session_id, None);
+        let args = read_args(&args_path);
+        assert_arg_sequence(&args, &["exec", "resume"]);
+        assert_arg_present(&args, "existing-thread");
+        assert!(!args.contains(&"-C".to_string()));
+    }
+
+    #[tokio::test]
+    async fn reports_non_zero_exit_stderr() {
+        let work_dir = temp_dir("codex-error-work");
+        let cli = FakeCli::new(
+            "codex",
+            "#!/bin/sh\nprintf '%s\\n' 'codex failed' >&2\nexit 2\n",
+        );
+        let runner = runner(cli.bin());
+
+        let err = match runner
+            .run(request(work_dir.to_str().unwrap()), Duration::from_secs(5))
+            .await
+        {
+            Err(err) => err,
+            Ok(_) => panic!("expected Codex run to fail"),
+        };
+
+        assert_failed(err, "codex failed");
+    }
+
+    #[tokio::test]
+    async fn reports_timeout() {
+        let work_dir = temp_dir("codex-timeout-work");
+        let cli = FakeCli::new("codex", "#!/bin/sh\nsleep 2\n");
+        let runner = runner(cli.bin());
+
+        let err = match runner
+            .run(
+                request(work_dir.to_str().unwrap()),
+                Duration::from_millis(10),
+            )
+            .await
+        {
+            Err(err) => err,
+            Ok(_) => panic!("expected Codex run to time out"),
+        };
+
+        assert_timeout(err);
+    }
+
+    fn runner(bin: String) -> Runner {
+        Runner {
+            bin,
+            sandbox: "workspace-write".to_string(),
+            approval_policy: "never".to_string(),
+            model: None,
+        }
+    }
+
+    fn request(work_dir: &str) -> Request<'_> {
+        Request {
+            session_id: "",
+            is_new: true,
+            work_dir,
+            system_append: "",
+            prompt: "hello",
+        }
+    }
+
+    fn codex_success_script(
+        args_path: &std::path::Path,
+        reply: &str,
+        thread_id: Option<&str>,
+    ) -> String {
+        let thread_event = thread_id
+            .map(|id| {
+                format!("printf '%s\\n' '{{\"type\":\"thread.started\",\"thread_id\":\"{id}\"}}'\n")
+            })
+            .unwrap_or_default();
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nout=''\nprev=''\nfor arg in \"$@\"; do\n  if [ \"$prev\" = '-o' ]; then out=\"$arg\"; fi\n  prev=\"$arg\"\ndone\nprintf '%s\\n' {} > \"$out\"\n{}",
+            sh_arg(args_path),
+            shell_string(reply),
+            thread_event
+        )
+    }
+
+    fn shell_string(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+
+    fn read_args(path: &std::path::Path) -> Vec<String> {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn assert_arg_pair(args: &[String], flag: &str, value: &str) {
+        let idx = args
+            .iter()
+            .position(|arg| arg == flag)
+            .unwrap_or_else(|| panic!("missing flag {flag} in {args:?}"));
+        assert_eq!(args.get(idx + 1).map(String::as_str), Some(value));
+    }
+
+    fn assert_arg_present(args: &[String], value: &str) {
+        assert!(
+            args.iter().any(|arg| arg == value),
+            "missing {value} in {args:?}"
+        );
+    }
+
+    fn assert_arg_sequence(args: &[String], values: &[&str]) {
+        assert!(
+            args.windows(values.len())
+                .any(|window| window.iter().map(String::as_str).eq(values.iter().copied())),
+            "missing sequence {values:?} in {args:?}"
+        );
+    }
+
+    fn assert_failed(err: RunError, expected: &str) {
+        match err {
+            RunError::Failed(msg) => assert_eq!(msg, expected),
+            RunError::Timeout => panic!("expected failed error, got timeout"),
+        }
+    }
+
+    fn assert_timeout(err: RunError) {
+        match err {
+            RunError::Timeout => {}
+            RunError::Failed(msg) => panic!("expected timeout, got failed: {msg}"),
+        }
+    }
+
+    fn contract_new_session() -> ContractCase {
+        let work_dir = temp_dir("codex-contract-new");
+        let cli = FakeCli::new(
+            "codex",
+            &codex_success_script(
+                &temp_path("codex-contract-new-args"),
+                "new reply",
+                Some("codex-thread"),
+            ),
+        );
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(runner(bin)),
+            request: contract_request(work_dir, true),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn contract_resumed_session() -> ContractCase {
+        let work_dir = temp_dir("codex-contract-resume");
+        let cli = FakeCli::new(
+            "codex",
+            &codex_success_script(
+                &temp_path("codex-contract-resume-args"),
+                "resumed reply",
+                None,
+            ),
+        );
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(runner(bin)),
+            request: contract_request(work_dir, false),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn contract_failed_run() -> ContractCase {
+        let work_dir = temp_dir("codex-contract-fail");
+        let cli = FakeCli::new("codex", "#!/bin/sh\nprintf '%s\\n' 'failed' >&2\nexit 1\n");
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(runner(bin)),
+            request: contract_request(work_dir, true),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn contract_timeout_run() -> ContractCase {
+        let work_dir = temp_dir("codex-contract-timeout");
+        let cli = FakeCli::new("codex", "#!/bin/sh\nsleep 2\n");
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(runner(bin)),
+            request: contract_request(work_dir, true),
+            timeout: Duration::from_millis(10),
+        }
+    }
+
+    fn contract_request(work_dir: std::path::PathBuf, is_new: bool) -> ContractRequest {
+        ContractRequest {
+            session_id: if is_new {
+                String::new()
+            } else {
+                "existing-thread".to_string()
+            },
+            is_new,
+            work_dir,
+            system_append: String::new(),
+            prompt: "hello".to_string(),
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ mod gateway;
 mod imessage;
 mod memory;
 mod store;
+#[cfg(test)]
+mod test_support;
 
 use std::path::{Path, PathBuf};
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,151 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use uuid::Uuid;
+
+use crate::agent::{Request, RunError, RunOutput};
+
+pub struct FakeCli {
+    root: PathBuf,
+    bin: PathBuf,
+}
+
+impl FakeCli {
+    pub fn new(name: &str, script: &str) -> Self {
+        let root = temp_dir(&format!("fake-{name}"));
+        let bin = root.join(name);
+        std::fs::write(&bin, script).unwrap();
+        make_executable(&bin);
+        Self { root, bin }
+    }
+
+    pub fn bin(&self) -> String {
+        self.bin.to_string_lossy().to_string()
+    }
+
+    fn keep_alive(&self) {}
+}
+
+impl Drop for FakeCli {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+pub fn temp_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("push-test-{name}-{}", Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+pub fn temp_path(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("push-test-{name}-{}", Uuid::new_v4()))
+}
+
+pub fn sh_arg(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub struct RunnerContract {
+    pub name: &'static str,
+    pub new_session: fn() -> ContractCase,
+    pub resumed_session: fn() -> ContractCase,
+    pub failed_run: fn() -> ContractCase,
+    pub timeout_run: fn() -> ContractCase,
+}
+
+pub struct ContractCase {
+    pub fake_cli: FakeCli,
+    pub runner: Box<dyn ContractRunner>,
+    pub request: ContractRequest,
+    pub timeout: Duration,
+}
+
+pub struct ContractRequest {
+    pub session_id: String,
+    pub is_new: bool,
+    pub work_dir: PathBuf,
+    pub system_append: String,
+    pub prompt: String,
+}
+
+impl ContractRequest {
+    fn as_request(&self) -> Request<'_> {
+        Request {
+            session_id: &self.session_id,
+            is_new: self.is_new,
+            work_dir: self.work_dir.to_str().unwrap(),
+            system_append: &self.system_append,
+            prompt: &self.prompt,
+        }
+    }
+}
+
+pub trait ContractRunner {
+    fn run<'a>(
+        &'a self,
+        req: Request<'a>,
+        timeout: Duration,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<RunOutput, RunError>> + 'a>>;
+}
+
+pub async fn assert_runner_contract(contract: RunnerContract) {
+    let case = (contract.new_session)();
+    case.fake_cli.keep_alive();
+    let out = case
+        .runner
+        .run(case.request.as_request(), case.timeout)
+        .await
+        .unwrap_or_else(|err| panic!("{} new session failed: {err:?}", contract.name));
+    assert!(
+        !out.reply.trim().is_empty(),
+        "{} new session returned an empty reply",
+        contract.name
+    );
+
+    let case = (contract.resumed_session)();
+    case.fake_cli.keep_alive();
+    let out = case
+        .runner
+        .run(case.request.as_request(), case.timeout)
+        .await
+        .unwrap_or_else(|err| panic!("{} resumed session failed: {err:?}", contract.name));
+    assert!(
+        !out.reply.trim().is_empty(),
+        "{} resumed session returned an empty reply",
+        contract.name
+    );
+
+    let case = (contract.failed_run)();
+    case.fake_cli.keep_alive();
+    match case
+        .runner
+        .run(case.request.as_request(), case.timeout)
+        .await
+    {
+        Err(RunError::Failed(_)) => {}
+        Err(RunError::Timeout) => panic!("{} failed run timed out", contract.name),
+        Ok(_) => panic!("{} failed run succeeded", contract.name),
+    }
+
+    let case = (contract.timeout_run)();
+    case.fake_cli.keep_alive();
+    match case
+        .runner
+        .run(case.request.as_request(), case.timeout)
+        .await
+    {
+        Err(RunError::Timeout) => {}
+        Err(RunError::Failed(msg)) => panic!("{} timeout failed: {msg}", contract.name),
+        Ok(_) => panic!("{} timeout run succeeded", contract.name),
+    }
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut perms = std::fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).unwrap();
+}


### PR DESCRIPTION
## Summary

- Add fake CLI test support for runner contract tests.
- Add shared `RunnerContract` coverage for new session, resumed session, failed run, and timeout behavior.
- Exercise Claude Code runner command shape and JSON error handling without invoking the real Claude CLI.
- Exercise Codex JSONL parsing, output-file reply handling, resume command shape, stderr failure, and timeout behavior without invoking the real Codex CLI.
- Derive `Debug` for `RunError` to improve test diagnostics.

## Why

Milestone 1 needs the existing agent backend behavior locked down before adding more providers or broadening the gateway.

## Test plan

- `cargo fmt --check`
- `cargo test` (37 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- Independent code review: no blockers found
- Independent acceptance verification: all #26 criteria satisfied

## Risks

Low. This is test-only except for deriving `Debug` on `RunError`.

## Related issue

Closes #26
