### PR TITLE
feat: add push doctor checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,14 @@ cd push
 cp config.example.json config.json
 # edit config.json: set self_handles and choose "agent": "claude" or "codex"
 cargo build --release
+./target/release/push doctor --config config.json
 ./target/release/push
 ```
 
 Then text yourself in Messages. The reply comes back in the same thread.
+
+`push doctor` checks the config, state and session directories, iMessage
+database access, `osascript`, and the configured backend binary.
 
 ## Releases
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod store;
 #[cfg(test)]
 mod test_support;
 
+use std::fmt;
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
@@ -21,51 +22,295 @@ use anyhow::{bail, Context, Result};
 async fn main() -> Result<()> {
     tracing_subscriber::fmt().with_target(false).init();
 
-    let cfg = config::Config::load(&config_path()).context("config")?;
+    let args = Args::parse(std::env::args().skip(1).collect())?;
+    if args.command == Command::Doctor {
+        return doctor(&args.config_path);
+    }
+    let cfg = config::Config::load(&args.config_path).context("config")?;
     preflight(&cfg).context("preflight")?;
     gateway::Gateway::new(cfg).context("init")?.run().await
 }
 
-fn config_path() -> String {
-    let args: Vec<String> = std::env::args().collect();
-    for pair in args.windows(2) {
-        if pair[0] == "--config" {
-            return pair[1].clone();
+#[derive(Debug, PartialEq, Eq)]
+struct Args {
+    command: Command,
+    config_path: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Command {
+    Run,
+    Doctor,
+}
+
+impl Args {
+    fn parse(args: Vec<String>) -> Result<Self> {
+        let mut command = Command::Run;
+        let mut config_path = "config.json".to_string();
+        let mut i = 0;
+        while i < args.len() {
+            match args[i].as_str() {
+                "doctor" if command == Command::Run => {
+                    command = Command::Doctor;
+                    i += 1;
+                }
+                "--config" => {
+                    let Some(path) = args.get(i + 1) else {
+                        bail!("--config requires a path");
+                    };
+                    config_path = path.clone();
+                    i += 2;
+                }
+                other => bail!("unknown argument {other:?}; expected doctor or --config <path>"),
+            }
         }
+        Ok(Self {
+            command,
+            config_path,
+        })
     }
-    "config.json".to_string()
 }
 
 /// Fails fast with actionable messages when the environment is not ready.
 fn preflight(cfg: &config::Config) -> Result<()> {
-    match std::fs::File::open(&cfg.db_path) {
-        Ok(_) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => bail!(
-            "cannot read {}: grant Full Disk Access to your terminal in System Settings -> Privacy & Security -> Full Disk Access",
-            cfg.db_path
-        ),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            bail!("Messages database not found at {}; is iMessage set up on this Mac?", cfg.db_path)
-        }
-        Err(e) => bail!("open {}: {e}", cfg.db_path),
+    let report = run_checks(cfg);
+    if report.is_ok() {
+        return Ok(());
     }
+    let failed = report
+        .checks
+        .into_iter()
+        .find(|check| matches!(check.status, CheckStatus::Fail))
+        .expect("failed report has at least one failure");
+    bail!("{}: {}", failed.name, failed.message);
+}
 
-    let mut bins = cfg.required_agent_bins().context("agent")?;
+fn doctor(config_path: &str) -> Result<()> {
+    let cfg = match config::Config::load(config_path) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            let report = CheckReport {
+                checks: vec![Check::fail(
+                    "config",
+                    format!(
+                        "cannot load {config_path}: {e}. Create the file from config.example.json or fix the invalid value."
+                    ),
+                )],
+            };
+            print!("{report}");
+            bail!("doctor found 1 failed check");
+        }
+    };
+    let report = run_checks(&cfg);
+    print!("{report}");
+    if report.is_ok() {
+        Ok(())
+    } else {
+        bail!("doctor found {} failed check(s)", report.failed_count())
+    }
+}
+
+fn run_checks(cfg: &config::Config) -> CheckReport {
+    let mut checks = Vec::new();
+    check_config(cfg, &mut checks);
+    check_state_dir(cfg, &mut checks);
+    check_sessions_dir(cfg, &mut checks);
+    check_imessage_db(cfg, &mut checks);
+    check_bins(cfg, &mut checks);
+    CheckReport { checks }
+}
+
+fn check_config(cfg: &config::Config, checks: &mut Vec<Check>) {
+    checks.push(Check::pass(
+        "config",
+        format!(
+            "agent={}, self_handles={}, allow_from={}",
+            cfg.agent,
+            cfg.self_handles.len(),
+            cfg.allow_from.len()
+        ),
+    ));
+}
+
+fn check_state_dir(cfg: &config::Config, checks: &mut Vec<Check>) {
+    if let Some(parent) = Path::new(&cfg.state_path).parent() {
+        match ensure_writable_dir(parent) {
+            Ok(()) => checks.push(Check::pass(
+                "state directory",
+                format!("{} is writable", parent.display()),
+            )),
+            Err(e) => checks.push(Check::fail(
+                "state directory",
+                format!(
+                    "cannot create {}: {e}. Create it or choose a writable state_path.",
+                    parent.display()
+                ),
+            )),
+        }
+    } else {
+        checks.push(Check::pass(
+            "state directory",
+            "state_path has no parent directory",
+        ));
+    }
+}
+
+fn check_sessions_dir(cfg: &config::Config, checks: &mut Vec<Check>) {
+    match ensure_writable_dir(Path::new(&cfg.sessions_dir)) {
+        Ok(()) => checks.push(Check::pass(
+            "sessions directory",
+            format!("{} is writable", cfg.sessions_dir),
+        )),
+        Err(e) => checks.push(Check::fail(
+            "sessions directory",
+            format!(
+                "cannot create {}: {e}. Create it or choose a writable sessions_dir.",
+                cfg.sessions_dir
+            ),
+        )),
+    }
+}
+
+fn check_imessage_db(cfg: &config::Config, checks: &mut Vec<Check>) {
+    match std::fs::File::open(&cfg.db_path) {
+        Ok(_) => checks.push(Check::pass(
+            "iMessage database",
+            format!("{} is readable", cfg.db_path),
+        )),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => checks.push(Check::fail(
+            "iMessage database",
+            format!(
+                "cannot read {}. Grant Full Disk Access to your terminal in System Settings > Privacy & Security > Full Disk Access.",
+                cfg.db_path
+            ),
+        )),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => checks.push(Check::fail(
+            "iMessage database",
+            format!(
+                "Messages database not found at {}. Sign in to iMessage or set db_path.",
+                cfg.db_path
+            ),
+        )),
+        Err(e) => checks.push(Check::fail(
+            "iMessage database",
+            format!(
+                "cannot open {}: {e}. Check db_path and Messages permissions, then rerun doctor.",
+                cfg.db_path
+            ),
+        )),
+    }
+}
+
+fn ensure_writable_dir(dir: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    let probe = dir.join(format!(".push-doctor-write-test-{}", std::process::id()));
+    std::fs::write(&probe, b"ok")?;
+    std::fs::remove_file(probe)?;
+    Ok(())
+}
+
+fn check_bins(cfg: &config::Config, checks: &mut Vec<Check>) {
+    check_bins_with(cfg, checks, which);
+}
+
+fn check_bins_with(
+    cfg: &config::Config,
+    checks: &mut Vec<Check>,
+    finder: impl Fn(&str) -> Option<PathBuf>,
+) {
+    let mut bins = match cfg.required_agent_bins() {
+        Ok(bins) => bins,
+        Err(e) => {
+            checks.push(Check::fail("agent binaries", format!("{e}")));
+            return;
+        }
+    };
     bins.push("osascript");
     bins.sort_unstable();
     bins.dedup();
     for bin in bins {
-        if which(bin).is_none() {
-            bail!("{bin:?} not found on PATH");
+        match finder(bin) {
+            Some(path) => checks.push(Check::pass(
+                format!("binary {bin}"),
+                format!("found at {}", path.display()),
+            )),
+            None => checks.push(Check::fail(
+                format!("binary {bin}"),
+                format!(
+                    "{bin:?} not found on PATH. Install it or update the matching config field."
+                ),
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CheckReport {
+    checks: Vec<Check>,
+}
+
+impl CheckReport {
+    fn is_ok(&self) -> bool {
+        self.checks
+            .iter()
+            .all(|check| matches!(check.status, CheckStatus::Pass))
+    }
+
+    fn failed_count(&self) -> usize {
+        self.checks
+            .iter()
+            .filter(|check| matches!(check.status, CheckStatus::Fail))
+            .count()
+    }
+}
+
+impl fmt::Display for CheckReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "push doctor")?;
+        for check in &self.checks {
+            let marker = match check.status {
+                CheckStatus::Pass => "PASS",
+                CheckStatus::Fail => "FAIL",
+            };
+            writeln!(f, "[{marker}] {}: {}", check.name, check.message)?;
+        }
+        if self.is_ok() {
+            writeln!(f, "All checks passed.")
+        } else {
+            writeln!(f, "{} check(s) failed.", self.failed_count())
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Check {
+    name: String,
+    status: CheckStatus,
+    message: String,
+}
+
+impl Check {
+    fn pass(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Pass,
+            message: message.into(),
         }
     }
 
-    std::fs::create_dir_all(&cfg.sessions_dir)
-        .with_context(|| format!("sessions_dir {} not writable", cfg.sessions_dir))?;
-    if let Some(parent) = Path::new(&cfg.state_path).parent() {
-        std::fs::create_dir_all(parent).context("state_path dir not writable")?;
+    fn fail(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Fail,
+            message: message.into(),
+        }
     }
-    Ok(())
+}
+
+#[derive(Debug)]
+enum CheckStatus {
+    Pass,
+    Fail,
 }
 
 fn which(bin: &str) -> Option<PathBuf> {
@@ -77,4 +322,155 @@ fn which(bin: &str) -> Option<PathBuf> {
     std::env::split_paths(&paths)
         .map(|dir| dir.join(bin))
         .find(|cand| cand.is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AssistantProfile, Config};
+    use crate::test_support::{temp_dir, temp_path};
+
+    #[test]
+    fn parses_doctor_with_config_path() {
+        let args = Args::parse(vec![
+            "doctor".to_string(),
+            "--config".to_string(),
+            "custom.json".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            args,
+            Args {
+                command: Command::Doctor,
+                config_path: "custom.json".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_missing_config_path_arg() {
+        let err = Args::parse(vec!["--config".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("--config requires a path"));
+    }
+
+    #[test]
+    fn doctor_reports_config_load_failure() {
+        let path = temp_path("missing-config");
+
+        let err = doctor(path.to_str().unwrap()).unwrap_err();
+
+        assert!(err.to_string().contains("doctor found 1 failed check"));
+    }
+
+    #[test]
+    fn doctor_reports_invalid_json_config() {
+        let path = temp_path("invalid-json-config");
+        std::fs::write(&path, "{").unwrap();
+
+        let err = doctor(path.to_str().unwrap()).unwrap_err();
+
+        assert!(err.to_string().contains("doctor found 1 failed check"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn doctor_reports_invalid_config_value() {
+        let path = temp_path("invalid-value-config");
+        std::fs::write(
+            &path,
+            r#"{
+  "self_handles": ["me@icloud.com"],
+  "agent": "bogus"
+}"#,
+        )
+        .unwrap();
+
+        let err = doctor(path.to_str().unwrap()).unwrap_err();
+
+        assert!(err.to_string().contains("doctor found 1 failed check"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn binary_checks_report_present_and_missing_bins() {
+        let cfg = test_config();
+        let mut checks = Vec::new();
+
+        check_bins_with(&cfg, &mut checks, |bin| {
+            (bin == "/fake/codex").then(|| PathBuf::from(bin))
+        });
+
+        assert!(checks.iter().any(|check| {
+            check.name == "binary /fake/codex" && matches!(check.status, CheckStatus::Pass)
+        }));
+        assert!(checks.iter().any(|check| {
+            check.name == "binary osascript" && matches!(check.status, CheckStatus::Fail)
+        }));
+    }
+
+    #[test]
+    fn run_checks_reports_config_and_writable_paths() {
+        let db_path = temp_path("chat-db");
+        std::fs::write(&db_path, "").unwrap();
+        let state_path = temp_path("state-dir").join("state.json");
+        let sessions_dir = temp_dir("sessions-dir");
+        let mut cfg = test_config();
+        cfg.db_path = db_path.to_string_lossy().to_string();
+        cfg.state_path = state_path.to_string_lossy().to_string();
+        cfg.sessions_dir = sessions_dir.to_string_lossy().to_string();
+
+        let report = run_checks(&cfg);
+
+        assert!(report
+            .checks
+            .iter()
+            .any(|check| check.name == "config" && matches!(check.status, CheckStatus::Pass)));
+        assert!(report.checks.iter().any(|check| {
+            check.name == "state directory" && matches!(check.status, CheckStatus::Pass)
+        }));
+        assert!(report.checks.iter().any(|check| {
+            check.name == "sessions directory" && matches!(check.status, CheckStatus::Pass)
+        }));
+        assert!(report.checks.iter().any(|check| {
+            check.name == "iMessage database" && matches!(check.status, CheckStatus::Pass)
+        }));
+
+        let _ = std::fs::remove_file(db_path);
+        let _ = std::fs::remove_file(state_path);
+        let _ = std::fs::remove_dir_all(sessions_dir);
+    }
+
+    #[test]
+    fn writable_dir_check_writes_probe_file() {
+        let dir = temp_dir("doctor-writable");
+
+        ensure_writable_dir(&dir).unwrap();
+
+        assert!(std::fs::read_dir(&dir).unwrap().next().is_none());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    fn test_config() -> Config {
+        Config {
+            db_path: "/fake/chat.db".to_string(),
+            poll_interval: "1s".to_string(),
+            run_timeout: "1s".to_string(),
+            self_handles: vec!["me@icloud.com".to_string()],
+            allow_from: Vec::new(),
+            agent: "codex".to_string(),
+            routes: Vec::new(),
+            assistant: AssistantProfile::default(),
+            claude_bin: "/fake/claude".to_string(),
+            claude_permission_mode: "bypassPermissions".to_string(),
+            codex_bin: "/fake/codex".to_string(),
+            codex_sandbox: "workspace-write".to_string(),
+            codex_approval_policy: "never".to_string(),
+            codex_model: None,
+            sessions_dir: "/fake/sessions".to_string(),
+            state_path: "/fake/state.json".to_string(),
+            assistant_dir: "/fake/assistant".to_string(),
+            reply_marker: "\n\n-- sent by push".to_string(),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add `push doctor` with pass/fail checks for config, writable state/session directories, iMessage DB access, `osascript`, and configured backend binaries.
- Reuse the same check machinery from startup preflight.
- Add concrete next-step text for failures.
- Document the command in the README.
- Add tests for CLI parsing, config load/validation failures, binary validation, and writable directory probing.

## Why

Users need one command that explains why push can or cannot run before starting the long-lived gateway.

## Test plan

- `cargo fmt --check`
- `cargo test` (46 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- Independent code review: no blockers found
- Independent acceptance verification: all #23 criteria satisfied

## Risks

Medium. Startup preflight now uses the shared doctor checks, so error wording changes and directory checks use a write probe.

## Related issue

Closes #23
