### PR TITLE
Harden iMessage channel filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ Then text yourself in Messages. The reply comes back in the same thread.
 `push doctor` checks the config, state and session directories, iMessage
 database access, `osascript`, and the configured backend binary.
 
+## iMessage Support
+
+push supports one-to-one iMessage conversations: self-chat and allowlisted
+direct messages. Group chats are not supported in v1 and are ignored.
+
+The iMessage channel reads `~/Library/Messages/chat.db` directly, so the process
+needs Full Disk Access on macOS. It assumes the recent macOS Messages schema with
+`message`, `handle`, `chat`, `chat_message_join`, and `chat_handle_join` tables;
+`push doctor` and the runtime report database access or query failures. Tapbacks,
+system rows, blank messages, messages from non-allowlisted senders, and push's
+own marked replies are ignored. Phone numbers are matched after removing
+formatting, and email handles are matched case-insensitively.
+
+`state.json` stores the last completed Messages row and backend sessions. On
+restart, push resumes after the last completed row and keeps existing backend
+sessions when the selected backend has not changed.
+
 ## Releases
 
 Tagged releases publish binary archives for Linux and macOS on

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -28,6 +28,29 @@ struct CliResult {
 impl Runner {
     /// Executes one turn and returns Claude's reply text, or a RunError.
     pub async fn run(&self, req: Request<'_>, timeout: Duration) -> Result<RunOutput, RunError> {
+        let out = match tokio::time::timeout(timeout, self.output_with_retry(req)).await {
+            Err(_) => return Err(RunError::Timeout),
+            Ok(Err(e)) => return Err(RunError::Failed(format!("spawn claude: {e}"))),
+            Ok(Ok(o)) => o,
+        };
+
+        self.parse_output(out)
+    }
+
+    async fn output_with_retry(&self, req: Request<'_>) -> std::io::Result<std::process::Output> {
+        let mut attempts = 0;
+        loop {
+            match self.command(&req).output().await {
+                Err(e) if e.raw_os_error() == Some(26) && attempts < 3 => {
+                    attempts += 1;
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                }
+                result => return result,
+            }
+        }
+    }
+
+    fn command(&self, req: &Request<'_>) -> Command {
         let mut cmd = Command::new(&self.bin);
         cmd.arg("-p")
             .arg(req.prompt)
@@ -47,13 +70,10 @@ impl Runner {
         }
         cmd.current_dir(req.work_dir);
         cmd.kill_on_drop(true);
+        cmd
+    }
 
-        let out = match tokio::time::timeout(timeout, cmd.output()).await {
-            Err(_) => return Err(RunError::Timeout),
-            Ok(Err(e)) => return Err(RunError::Failed(format!("spawn claude: {e}"))),
-            Ok(Ok(o)) => o,
-        };
-
+    fn parse_output(&self, out: std::process::Output) -> Result<RunOutput, RunError> {
         // claude prints its JSON envelope to stdout even when it exits non-zero
         // (e.g. an API error), so parse stdout regardless of exit status.
         match serde_json::from_slice::<CliResult>(&out.stdout) {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -6,7 +6,7 @@
 //! messages. Workers share only the store, behind a mutex, for tiny bookkeeping
 //! writes. Everything else is message passing.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -42,14 +42,17 @@ struct Job {
 
 /// Decides which messages to act on. Kept separate so it is trivially testable.
 struct Filter {
-    self_set: HashSet<String>,
-    allow_set: HashSet<String>,
+    self_set: HashMap<String, String>,
+    allow_set: HashMap<String, String>,
     reply_marker: String,
 }
 
 impl Filter {
     /// Returns `(thread_key, reply_target)` for an accepted message.
     fn accept(&self, m: &Message) -> Option<(String, String)> {
+        if m.is_group {
+            return None;
+        }
         if m.text.trim().is_empty() {
             return None;
         }
@@ -57,18 +60,54 @@ impl Filter {
         if !self.reply_marker.is_empty() && m.text.contains(&self.reply_marker) {
             return None;
         }
+        let chat = normalize_handle(&m.chat_identifier);
+        let handle = normalize_handle(&m.handle);
         // Self-chat: you texting yourself.
-        if self.self_set.contains(&m.chat_identifier) {
-            return Some((
-                format!("self:{}", m.chat_identifier),
-                m.chat_identifier.clone(),
-            ));
+        if let Some(thread_handle) = self.self_set.get(&chat) {
+            return Some((format!("self:{thread_handle}"), m.chat_identifier.clone()));
         }
         // Inbound DM from an allowed sender.
-        if !m.is_from_me && self.allow_set.contains(&m.handle) {
-            return Some((format!("dm:{}", m.handle), m.handle.clone()));
+        if !m.is_from_me {
+            if let Some(thread_handle) = self.allow_set.get(&handle) {
+                return Some((format!("dm:{thread_handle}"), m.handle.clone()));
+            }
         }
         None
+    }
+}
+
+fn normalize_handle(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.contains('@') {
+        return trimmed.to_ascii_lowercase();
+    }
+    let mut out = String::new();
+    for c in trimmed.chars() {
+        if c.is_ascii_digit() {
+            out.push(c);
+        }
+    }
+    if out.is_empty() {
+        trimmed.to_ascii_lowercase()
+    } else {
+        out
+    }
+}
+
+fn thread_handle(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.contains('@') {
+        return trimmed.to_ascii_lowercase();
+    }
+    let mut out = String::new();
+    if trimmed.starts_with('+') {
+        out.push('+');
+    }
+    out.push_str(&normalize_handle(trimmed));
+    if out == "+" {
+        trimmed.to_ascii_lowercase()
+    } else {
+        out
     }
 }
 
@@ -128,8 +167,16 @@ impl Gateway {
             sent_replies: Arc::new(Mutex::new(Vec::new())),
         };
         let filter = Filter {
-            self_set: cfg.self_handles.iter().cloned().collect(),
-            allow_set: cfg.allow_from.iter().cloned().collect(),
+            self_set: cfg
+                .self_handles
+                .iter()
+                .map(|s| (normalize_handle(s), thread_handle(s)))
+                .collect(),
+            allow_set: cfg
+                .allow_from
+                .iter()
+                .map(|s| (normalize_handle(s), thread_handle(s)))
+                .collect(),
             reply_marker: cfg.reply_marker.clone(),
         };
         let poll_interval = cfg.poll_interval_dur()?;
@@ -592,8 +639,12 @@ mod tests {
 
     fn filter() -> Filter {
         Filter {
-            self_set: ["me@icloud.com".to_string()].into_iter().collect(),
-            allow_set: ["+15551234567".to_string()].into_iter().collect(),
+            self_set: [("me@icloud.com".to_string(), "me@icloud.com".to_string())]
+                .into_iter()
+                .collect(),
+            allow_set: [("15551234567".to_string(), "+15551234567".to_string())]
+                .into_iter()
+                .collect(),
             reply_marker: "\n\n-- sent by push".to_string(),
         }
     }
@@ -605,6 +656,14 @@ mod tests {
             chat_identifier: chat.to_string(),
             text: text.to_string(),
             is_from_me: from_me,
+            is_group: false,
+        }
+    }
+
+    fn group_msg(chat: &str, handle: &str, from_me: bool, text: &str) -> Message {
+        Message {
+            is_group: true,
+            ..msg(chat, handle, from_me, text)
         }
     }
 
@@ -679,6 +738,71 @@ mod tests {
     }
 
     #[test]
+    fn formatted_phone_allowlist_matches_normalized_handle() {
+        let got = filter().accept(&msg("+1 (555) 123-4567", "+1 (555) 123-4567", false, "hi"));
+        assert_eq!(
+            got,
+            Some((
+                "dm:+15551234567".to_string(),
+                "+1 (555) 123-4567".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn bare_phone_matches_allowlist_with_plus() {
+        let filter = Filter {
+            self_set: HashMap::new(),
+            allow_set: ["+15551234567"]
+                .into_iter()
+                .map(|s| (normalize_handle(s), thread_handle(s)))
+                .collect(),
+            reply_marker: String::new(),
+        };
+
+        let got = filter.accept(&msg("15551234567", "15551234567", false, "hi"));
+
+        assert_eq!(
+            got,
+            Some(("dm:+15551234567".to_string(), "15551234567".to_string()))
+        );
+    }
+
+    #[test]
+    fn plus_phone_matches_bare_allowlist() {
+        let filter = Filter {
+            self_set: HashMap::new(),
+            allow_set: ["15551234567"]
+                .into_iter()
+                .map(|s| (normalize_handle(s), thread_handle(s)))
+                .collect(),
+            reply_marker: String::new(),
+        };
+
+        let got = filter.accept(&msg("+1 (555) 123-4567", "+1 (555) 123-4567", false, "hi"));
+
+        assert_eq!(
+            got,
+            Some((
+                "dm:15551234567".to_string(),
+                "+1 (555) 123-4567".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn email_self_chat_matching_is_case_insensitive() {
+        let got = filter().accept(&msg("ME@ICLOUD.COM", "", true, "hi"));
+        assert_eq!(
+            got,
+            Some((
+                "self:me@icloud.com".to_string(),
+                "ME@ICLOUD.COM".to_string()
+            ))
+        );
+    }
+
+    #[test]
     fn non_allowlisted_dropped() {
         assert_eq!(
             filter().accept(&msg("+19998887777", "+19998887777", false, "hi")),
@@ -704,6 +828,14 @@ mod tests {
     fn empty_text_dropped() {
         assert_eq!(
             filter().accept(&msg("me@icloud.com", "", true, "   ")),
+            None
+        );
+    }
+
+    #[test]
+    fn group_chat_dropped_even_from_allowlisted_sender() {
+        assert_eq!(
+            filter().accept(&group_msg("chat123456789", "+15551234567", false, "hi")),
             None
         );
     }
@@ -960,6 +1092,7 @@ mod tests {
             chat_identifier: chat.to_string(),
             text: text.to_string(),
             is_from_me,
+            is_group: false,
         }
     }
 }

--- a/src/imessage/poller.rs
+++ b/src/imessage/poller.rs
@@ -13,6 +13,8 @@ pub struct Message {
     pub handle: String,
     /// The chat's identifier (the handle for 1:1 chats).
     pub chat_identifier: String,
+    /// Group chats are intentionally out of scope for the iMessage channel.
+    pub is_group: bool,
     pub text: String,
     pub is_from_me: bool,
 }
@@ -27,7 +29,8 @@ pub struct Poller {
 // and system rows like group renames or joins (item_type).
 const SELECT_NEW: &str = "\
 SELECT m.ROWID, m.text, m.attributedBody, m.is_from_me, \
-       COALESCE(h.id, ''), COALESCE(c.chat_identifier, '') \
+       COALESCE(h.id, ''), COALESCE(c.chat_identifier, ''), \
+       COALESCE((SELECT COUNT(*) FROM chat_handle_join chj WHERE chj.chat_id = c.ROWID), 0) \
 FROM message m \
 LEFT JOIN handle h ON m.handle_id = h.ROWID \
 LEFT JOIN chat_message_join cmj ON cmj.message_id = m.ROWID \
@@ -55,6 +58,7 @@ impl Poller {
             let text: Option<String> = row.get(1)?;
             let body: Option<Vec<u8>> = row.get(2)?;
             let is_from_me: i64 = row.get(3)?;
+            let participant_count: i64 = row.get(6)?;
             Ok(Message {
                 row_id: row.get(0)?,
                 text: text.unwrap_or_else(|| {
@@ -63,6 +67,7 @@ impl Poller {
                 }),
                 handle: row.get(4)?,
                 chat_identifier: row.get(5)?,
+                is_group: participant_count > 1,
                 is_from_me: is_from_me == 1,
             })
         })?;
@@ -81,5 +86,152 @@ impl Poller {
             r.get(0)
         })?;
         Ok(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::temp_path;
+    use rusqlite::Connection;
+
+    #[test]
+    fn poll_decodes_text_filters_system_rows_and_marks_groups() {
+        let path = temp_path("chat-db");
+        let conn = Connection::open(&path).unwrap();
+        create_schema(&conn);
+        insert_handle(&conn, 1, "+15551234567");
+        insert_handle(&conn, 2, "+15557654321");
+        insert_chat(&conn, 1, "+15551234567");
+        insert_chat(&conn, 2, "chat123456789");
+        insert_chat_handle(&conn, 1, 1);
+        insert_chat_handle(&conn, 2, 1);
+        insert_chat_handle(&conn, 2, 2);
+        insert_message(&conn, 1, Some("hello"), None, 0, 0, 0, 1, 1);
+        insert_message(&conn, 2, Some("tapback"), None, 0, 2000, 0, 1, 1);
+        insert_message(&conn, 3, Some("system"), None, 0, 0, 1, 1, 1);
+        insert_message(&conn, 4, Some("group"), None, 0, 0, 0, 1, 2);
+        drop(conn);
+
+        let got = Poller::new(path.to_string_lossy().to_string())
+            .poll(0)
+            .unwrap();
+
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].row_id, 1);
+        assert_eq!(got[0].text, "hello");
+        assert!(!got[0].is_group);
+        assert_eq!(got[1].row_id, 4);
+        assert!(got[1].is_group);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn poll_uses_attributed_body_when_text_is_null() {
+        let path = temp_path("chat-db-attributed");
+        let conn = Connection::open(&path).unwrap();
+        create_schema(&conn);
+        insert_handle(&conn, 1, "owain@example.com");
+        insert_chat(&conn, 1, "owain@example.com");
+        insert_chat_handle(&conn, 1, 1);
+        insert_message(
+            &conn,
+            1,
+            None,
+            Some(&attributed_blob("from body")),
+            0,
+            0,
+            0,
+            1,
+            1,
+        );
+        drop(conn);
+
+        let got = Poller::new(path.to_string_lossy().to_string())
+            .poll(0)
+            .unwrap();
+
+        assert_eq!(got[0].text, "from body");
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    fn create_schema(conn: &Connection) {
+        conn.execute_batch(
+            "
+            CREATE TABLE message (
+                ROWID INTEGER PRIMARY KEY,
+                text TEXT,
+                attributedBody BLOB,
+                is_from_me INTEGER NOT NULL,
+                associated_message_type INTEGER NOT NULL,
+                item_type INTEGER NOT NULL,
+                handle_id INTEGER
+            );
+            CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT NOT NULL);
+            CREATE TABLE chat (ROWID INTEGER PRIMARY KEY, chat_identifier TEXT NOT NULL);
+            CREATE TABLE chat_message_join (message_id INTEGER NOT NULL, chat_id INTEGER NOT NULL);
+            CREATE TABLE chat_handle_join (chat_id INTEGER NOT NULL, handle_id INTEGER NOT NULL);
+            ",
+        )
+        .unwrap();
+    }
+
+    fn insert_handle(conn: &Connection, row_id: i64, id: &str) {
+        conn.execute(
+            "INSERT INTO handle (ROWID, id) VALUES (?1, ?2)",
+            (row_id, id),
+        )
+        .unwrap();
+    }
+
+    fn insert_chat(conn: &Connection, row_id: i64, id: &str) {
+        conn.execute(
+            "INSERT INTO chat (ROWID, chat_identifier) VALUES (?1, ?2)",
+            (row_id, id),
+        )
+        .unwrap();
+    }
+
+    fn insert_chat_handle(conn: &Connection, chat_id: i64, handle_id: i64) {
+        conn.execute(
+            "INSERT INTO chat_handle_join (chat_id, handle_id) VALUES (?1, ?2)",
+            (chat_id, handle_id),
+        )
+        .unwrap();
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_message(
+        conn: &Connection,
+        row_id: i64,
+        text: Option<&str>,
+        body: Option<&[u8]>,
+        is_from_me: i64,
+        associated_message_type: i64,
+        item_type: i64,
+        handle_id: i64,
+        chat_id: i64,
+    ) {
+        conn.execute(
+            "INSERT INTO message (ROWID, text, attributedBody, is_from_me, associated_message_type, item_type, handle_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            (row_id, text, body, is_from_me, associated_message_type, item_type, handle_id),
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chat_message_join (message_id, chat_id) VALUES (?1, ?2)",
+            (row_id, chat_id),
+        )
+        .unwrap();
+    }
+
+    fn attributed_blob(text: &str) -> Vec<u8> {
+        let mut b = b"\x04\x0bstreamtyped\x81NSString\x01\x94\x84\x01".to_vec();
+        b.push(0x2b);
+        b.push(text.len() as u8);
+        b.extend_from_slice(text.as_bytes());
+        b
     }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -11,10 +11,18 @@ pub struct FakeCli {
 
 impl FakeCli {
     pub fn new(name: &str, script: &str) -> Self {
+        use std::io::Write;
+
         let root = temp_dir(&format!("fake-{name}"));
         let bin = root.join(name);
-        std::fs::write(&bin, script).unwrap();
-        make_executable(&bin);
+        let tmp = root.join(format!("{name}.tmp"));
+        {
+            let mut file = std::fs::File::create(&tmp).unwrap();
+            file.write_all(script.as_bytes()).unwrap();
+            file.sync_all().unwrap();
+        }
+        make_executable(&tmp);
+        std::fs::rename(&tmp, &bin).unwrap();
         Self { root, bin }
     }
 


### PR DESCRIPTION
Closes #20

## Summary
- document iMessage setup, database assumptions, ignored rows, unsupported group chats, and restart behavior
- normalize phone and email matching while keeping stable thread keys for routes and sessions
- filter group chats explicitly and add SQLite-backed poller tests for tapbacks, system rows, group detection, and attributedBody fallback

## Acceptance
- iMessage setup and failure modes are documented in README.
- Empty rows, tapbacks, system rows, and push-marked self replies are handled predictably.
- Restart behavior remains covered by ack/state tests and existing fake-channel replay test.
- Group chats are explicit as unsupported and ignored.

## Verification
- `cargo fmt --check`
- `cargo test` (53 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## Review
- Fresh code review: no blocking findings after fixing thread-key compatibility.
- Fresh acceptance verification: all issue criteria satisfied, no blockers.
