### PR TITLE
Add local audit log

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ settings, pushes to `main` deploy the site automatically.
   "claude_disallowed_tools": [],
   "codex_bin": "codex",
   "codex_sandbox": "workspace-write",
-  "codex_approval_policy": "never"
+  "codex_approval_policy": "never",
+  "audit_log_path": "~/.push/audit.jsonl",
+  "audit_log_content": false
 }
 ```
 
@@ -211,3 +213,17 @@ read-only assistant, or `[""]` to disable tools for pure text replies.
 without a prompt, and `claude_disallowed_tools` maps to `--disallowed-tools`,
 which denies matching tools. The shorter `tools`, `allowed_tools`, and
 `disallowed_tools` names are also accepted.
+
+## Audit Log
+
+push writes a structured JSONL audit log to `audit_log_path`, which defaults to
+`~/.push/audit.jsonl`. Each line is one event, such as `message_accepted`,
+`message_ignored`, `backend_run_started`, `backend_run_failed`, `reply_sent`, or
+`message_completed`.
+
+By default, audit events include metadata only: row id, channel, thread,
+backend, routing or error reason, target handle, and message or reply character
+count. Message and reply text are not stored unless `audit_log_content` is set
+to `true`. Keep the audit log local and protect it like service logs because it
+can still contain handles, thread ids, file paths, backend errors, and optional
+message content.

--- a/config.example.json
+++ b/config.example.json
@@ -26,6 +26,8 @@
   "codex_model": null,
   "sessions_dir": "~/.push/sessions",
   "state_path": "~/.push/state.json",
+  "audit_log_path": "~/.push/audit.jsonl",
+  "audit_log_content": false,
   "assistant_dir": "./assistant",
   "reply_marker": "\n\n-- sent by push"
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,6 +167,11 @@ now means "backend session id".
 If the configured backend changes for a thread, push starts a fresh backend
 session instead of trying to resume the old runtime's session.
 
+`audit_log_path` stores a local JSONL event stream for production debugging.
+Audit events record message metadata, routing decisions, backend run starts and
+failures, reply delivery metadata, and row completion. Message and reply text
+are redacted by default; `audit_log_content` opts into content logging.
+
 ## Assistant Context
 
 push loads:

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -146,6 +146,8 @@ Codex assistant context is passed as part of the prompt wrapper.
 | `codex_model` | Optional Codex model override. |
 | `sessions_dir` | Per-thread working dirs. |
 | `state_path` | JSON state path. |
+| `audit_log_path` | Local JSONL audit log path. |
+| `audit_log_content` | Whether audit events include message and reply text. |
 | `assistant_dir` | Directory with `User.md` and `Memory.md`. |
 | `reply_marker` | Footer used to skip push's own replies. |
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -22,6 +22,7 @@ Use absolute paths in service files. The service user needs:
 
 - access to the configured `config.json`
 - write access to `state_path`
+- write access to `audit_log_path`
 - write access to `sessions_dir`
 - read access to `assistant_dir`
 - access to `claude` or `codex` on `PATH`
@@ -169,6 +170,7 @@ settings. Keep `allow_from` narrow, use the least-powerful backend permissions
 that still work, and consider Claude Code `claude_tools`,
 `claude_allowed_tools`, and `claude_disallowed_tools` when running headlessly.
 
-Store config files, state files, backend credentials, and logs with permissions
-appropriate for the service user. Logs may contain prompts, backend errors, file
-paths, or message text.
+Store config files, state files, audit logs, backend credentials, and service
+logs with permissions appropriate for the service user. Logs may contain
+prompts, backend errors, file paths, handles, or message text when content
+logging is enabled.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,0 +1,344 @@
+//! Local JSONL audit log for production debugging.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::config::AgentBackend;
+use crate::imessage::Message;
+
+#[derive(Clone)]
+pub struct AuditLog {
+    path: String,
+    include_content: bool,
+    lock: Arc<Mutex<()>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditEvent {
+    pub ts_ms: u64,
+    pub event: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub row_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handle: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chat_identifier: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_from_me: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_group: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_new_session: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<AuditContent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reply: Option<AuditContent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditContent {
+    pub chars: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+
+impl AuditLog {
+    pub fn new(path: String, include_content: bool) -> Self {
+        Self {
+            path,
+            include_content,
+            lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    pub fn record(&self, event: AuditEvent) -> Result<()> {
+        let _guard = self.lock.lock().unwrap();
+        if let Some(parent) = Path::new(&self.path).parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create audit log directory {}", parent.display()))?;
+        }
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .with_context(|| format!("open audit log {}", self.path))?;
+        serde_json::to_writer(&mut file, &event).context("write audit event")?;
+        use std::io::Write;
+        writeln!(file).context("finish audit event")?;
+        Ok(())
+    }
+
+    pub fn inbound(&self, msg: &Message) -> AuditEvent {
+        AuditEvent {
+            ts_ms: now_ms(),
+            event: "message_inbound".to_string(),
+            row_id: Some(msg.row_id),
+            channel: Some("imessage".to_string()),
+            thread: None,
+            backend: None,
+            reason: None,
+            target: None,
+            handle: Some(msg.handle.clone()),
+            chat_identifier: Some(msg.chat_identifier.clone()),
+            is_from_me: Some(msg.is_from_me),
+            is_group: Some(msg.is_group),
+            is_new_session: None,
+            message: Some(content(&msg.text, self.include_content)),
+            reply: None,
+            error: None,
+        }
+    }
+
+    pub fn ignored(&self, msg: &Message, reason: impl Into<String>) -> AuditEvent {
+        let mut event = self.inbound(msg);
+        event.event = "message_ignored".to_string();
+        event.reason = Some(reason.into());
+        event
+    }
+
+    pub fn accepted(&self, msg: &Message, thread: &str, backend: AgentBackend) -> AuditEvent {
+        let mut event = self.inbound(msg);
+        event.event = "message_accepted".to_string();
+        event.thread = Some(thread.to_string());
+        event.backend = Some(backend.as_str().to_string());
+        event
+    }
+
+    pub fn backend_started(
+        &self,
+        row_id: i64,
+        thread: &str,
+        backend: AgentBackend,
+        is_new_session: bool,
+    ) -> AuditEvent {
+        AuditEvent::base(
+            "backend_run_started",
+            Some(row_id),
+            Some(thread),
+            Some(backend),
+        )
+        .with_new_session(is_new_session)
+    }
+
+    pub fn backend_completed(
+        &self,
+        row_id: i64,
+        thread: &str,
+        backend: AgentBackend,
+        reply: &str,
+    ) -> AuditEvent {
+        let mut event = AuditEvent::base(
+            "backend_run_completed",
+            Some(row_id),
+            Some(thread),
+            Some(backend),
+        );
+        event.reply = Some(content(reply, self.include_content));
+        event
+    }
+
+    pub fn failed(
+        &self,
+        event_name: &'static str,
+        row_id: i64,
+        thread: &str,
+        backend: Option<AgentBackend>,
+        error: impl Into<String>,
+    ) -> AuditEvent {
+        let mut event = AuditEvent::base(event_name, Some(row_id), Some(thread), backend);
+        event.error = Some(error.into());
+        event
+    }
+
+    pub fn reply_sent(
+        &self,
+        row_id: i64,
+        thread: &str,
+        target: &str,
+        backend: Option<AgentBackend>,
+        reply: &str,
+    ) -> AuditEvent {
+        let mut event = AuditEvent::base("reply_sent", Some(row_id), Some(thread), backend);
+        event.target = Some(target.to_string());
+        event.reply = Some(content(reply, self.include_content));
+        event
+    }
+
+    pub fn reply_failed(
+        &self,
+        row_id: i64,
+        thread: &str,
+        target: &str,
+        backend: Option<AgentBackend>,
+        error: impl Into<String>,
+    ) -> AuditEvent {
+        let mut event = AuditEvent::base("reply_failed", Some(row_id), Some(thread), backend);
+        event.target = Some(target.to_string());
+        event.error = Some(error.into());
+        event
+    }
+
+    pub fn completed(&self, row_id: i64, reason: impl Into<String>) -> AuditEvent {
+        let mut event = AuditEvent::base("message_completed", Some(row_id), None, None);
+        event.reason = Some(reason.into());
+        event
+    }
+}
+
+impl AuditEvent {
+    fn base(
+        event: &'static str,
+        row_id: Option<i64>,
+        thread: Option<&str>,
+        backend: Option<AgentBackend>,
+    ) -> Self {
+        Self {
+            ts_ms: now_ms(),
+            event: event.to_string(),
+            row_id,
+            channel: Some("imessage".to_string()),
+            thread: thread.map(str::to_string),
+            backend: backend.map(|b| b.as_str().to_string()),
+            reason: None,
+            target: None,
+            handle: None,
+            chat_identifier: None,
+            is_from_me: None,
+            is_group: None,
+            is_new_session: None,
+            message: None,
+            reply: None,
+            error: None,
+        }
+    }
+
+    fn with_new_session(mut self, is_new_session: bool) -> Self {
+        self.is_new_session = Some(is_new_session);
+        self
+    }
+}
+
+fn content(text: &str, include: bool) -> AuditContent {
+    AuditContent {
+        chars: text.chars().count(),
+        text: include.then(|| text.to_string()),
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::temp_path;
+
+    fn msg() -> Message {
+        Message {
+            row_id: 42,
+            handle: "+15551234567".to_string(),
+            chat_identifier: "+15551234567".to_string(),
+            is_group: false,
+            text: "secret request".to_string(),
+            is_from_me: false,
+        }
+    }
+
+    #[test]
+    fn accepted_event_redacts_content_by_default() {
+        let audit = AuditLog::new("audit.jsonl".to_string(), false);
+
+        let event = audit.accepted(&msg(), "dm:+15551234567", AgentBackend::Claude);
+
+        assert_eq!(event.event, "message_accepted");
+        assert_eq!(event.thread.as_deref(), Some("dm:+15551234567"));
+        assert_eq!(event.backend.as_deref(), Some("claude"));
+        assert_eq!(event.message.unwrap().text, None);
+    }
+
+    #[test]
+    fn content_logging_is_opt_in() {
+        let audit = AuditLog::new("audit.jsonl".to_string(), true);
+
+        let event = audit.ignored(&msg(), "not_allowlisted");
+
+        assert_eq!(event.event, "message_ignored");
+        assert_eq!(event.reason.as_deref(), Some("not_allowlisted"));
+        assert_eq!(
+            event.message.unwrap().text.as_deref(),
+            Some("secret request")
+        );
+    }
+
+    #[test]
+    fn failed_and_completed_events_include_debug_context() {
+        let audit = AuditLog::new("audit.jsonl".to_string(), false);
+
+        let failed = audit.failed(
+            "backend_run_failed",
+            42,
+            "dm:+15551234567",
+            Some(AgentBackend::Codex),
+            "timeout",
+        );
+        let completed = audit.completed(42, "ignored");
+
+        assert_eq!(failed.backend.as_deref(), Some("codex"));
+        assert_eq!(failed.error.as_deref(), Some("timeout"));
+        assert_eq!(completed.event, "message_completed");
+        assert_eq!(completed.reason.as_deref(), Some("ignored"));
+    }
+
+    #[test]
+    fn reply_failures_include_backend_context_when_known() {
+        let audit = AuditLog::new("audit.jsonl".to_string(), false);
+
+        let failed = audit.reply_failed(
+            42,
+            "dm:+15551234567",
+            "+15551234567",
+            Some(AgentBackend::Codex),
+            "send failed",
+        );
+
+        assert_eq!(failed.event, "reply_failed");
+        assert_eq!(failed.backend.as_deref(), Some("codex"));
+        assert_eq!(failed.target.as_deref(), Some("+15551234567"));
+        assert_eq!(failed.error.as_deref(), Some("send failed"));
+    }
+
+    #[test]
+    fn writes_jsonl_events() {
+        let path = temp_path("audit-jsonl");
+        let audit = AuditLog::new(path.to_string_lossy().to_string(), false);
+
+        audit.record(audit.completed(42, "completed")).unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let event: AuditEvent = serde_json::from_str(raw.trim()).unwrap();
+        assert_eq!(event.event, "message_completed");
+        assert_eq!(event.row_id, Some(42));
+
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,10 @@ pub struct Config {
     pub sessions_dir: String,
     #[serde(default = "default_state_path")]
     pub state_path: String,
+    #[serde(default = "default_audit_log_path")]
+    pub audit_log_path: String,
+    #[serde(default)]
+    pub audit_log_content: bool,
     #[serde(default = "default_assistant_dir")]
     pub assistant_dir: String,
     #[serde(default = "default_reply_marker")]
@@ -60,6 +64,7 @@ impl Config {
         c.db_path = expand_home(&c.db_path);
         c.sessions_dir = expand_home(&c.sessions_dir);
         c.state_path = expand_home(&c.state_path);
+        c.audit_log_path = expand_home(&c.audit_log_path);
         c.assistant_dir = expand_home(&c.assistant_dir);
         c.validate()?;
         Ok(c)
@@ -236,6 +241,9 @@ fn default_sessions_dir() -> String {
 }
 fn default_state_path() -> String {
     "~/.push/state.json".to_string()
+}
+fn default_audit_log_path() -> String {
+    "~/.push/audit.jsonl".to_string()
 }
 fn default_assistant_dir() -> String {
     "./assistant".to_string()

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -16,6 +16,7 @@ use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
 use crate::agent::{Request, RunError, Runner};
+use crate::audit::{AuditEvent, AuditLog};
 use crate::claude;
 use crate::codex;
 use crate::config::{AgentBackend, AssistantProfile, Config};
@@ -74,6 +75,20 @@ impl Filter {
         }
         None
     }
+
+    fn reject_reason(&self, m: &Message) -> &'static str {
+        if m.is_group {
+            "group_chat"
+        } else if m.text.trim().is_empty() {
+            "empty_text"
+        } else if !self.reply_marker.is_empty() && m.text.contains(&self.reply_marker) {
+            "reply_marker"
+        } else if m.is_from_me {
+            "from_me_to_other"
+        } else {
+            "not_allowlisted"
+        }
+    }
 }
 
 fn normalize_handle(s: &str) -> String {
@@ -123,6 +138,7 @@ struct Ctx {
     sessions_dir: String,
     assistant_dir: String,
     assistant: AssistantProfile,
+    audit: Arc<AuditLog>,
     #[cfg(test)]
     setup_failure_replies: Arc<Mutex<Vec<String>>>,
     #[cfg(test)]
@@ -151,6 +167,10 @@ impl Gateway {
         let store = Arc::new(Mutex::new(Store::open(&cfg.state_path)?));
         let ack = Arc::new(Mutex::new(AckState::default()));
         let runners = Arc::new(runners(&cfg));
+        let audit = Arc::new(AuditLog::new(
+            cfg.audit_log_path.clone(),
+            cfg.audit_log_content,
+        ));
         let ctx = Ctx {
             store: store.clone(),
             ack: ack.clone(),
@@ -161,6 +181,7 @@ impl Gateway {
             sessions_dir: cfg.sessions_dir.clone(),
             assistant_dir: cfg.assistant_dir.clone(),
             assistant: cfg.assistant.clone(),
+            audit,
             #[cfg(test)]
             setup_failure_replies: Arc::new(Mutex::new(Vec::new())),
             #[cfg(test)]
@@ -281,10 +302,18 @@ impl Gateway {
                     Ok(v) => v,
                     Err(e) => {
                         error!("[{thread}] route error: {e}");
-                        self.complete_row(m.row_id);
+                        self.audit(self.ctx.audit.failed(
+                            "message_route_failed",
+                            m.row_id,
+                            &thread,
+                            None,
+                            e.to_string(),
+                        ));
+                        self.complete_row(m.row_id, "route_error");
                         continue;
                     }
                 };
+                self.audit(self.ctx.audit.accepted(m, &thread, backend));
                 self.route(
                     m.row_id,
                     thread,
@@ -295,11 +324,12 @@ impl Gateway {
                 )
                 .await;
             } else {
-                self.complete_row(m.row_id);
+                self.audit(self.ctx.audit.ignored(m, self.filter.reject_reason(m)));
+                self.complete_row(m.row_id, "ignored");
             }
         }
         if max_row > 0 && msgs.is_empty() {
-            self.complete_row(max_row);
+            self.complete_row(max_row, "empty_poll");
         }
     }
 
@@ -332,20 +362,50 @@ impl Gateway {
         );
         if full {
             warn!("[{thread}] queue full, asking sender to resend");
-            let _ = reply_to(
+            self.audit(self.ctx.audit.failed(
+                "message_queue_failed",
+                row_id,
+                &thread,
+                Some(backend),
+                "queue full",
+            ));
+            if reply_to(
                 &self.ctx,
                 &target,
                 "I'm a bit behind on this thread - resend that in a moment.",
             )
-            .await;
-            self.complete_row(row_id);
+            .await
+            {
+                self.audit(self.ctx.audit.reply_sent(
+                    row_id,
+                    &thread,
+                    &target,
+                    Some(backend),
+                    "I'm a bit behind on this thread - resend that in a moment.",
+                ));
+                self.complete_row(row_id, "queue_full");
+            } else {
+                self.audit(self.ctx.audit.reply_failed(
+                    row_id,
+                    &thread,
+                    &target,
+                    Some(backend),
+                    "queue full reply failed",
+                ));
+                self.complete_row(row_id, "queue_full_reply_failed");
+            }
         } else {
             self.ack.lock().unwrap().in_flight.insert(row_id);
         }
     }
 
-    fn complete_row(&self, row_id: i64) {
+    fn complete_row(&self, row_id: i64, reason: &str) {
+        self.audit(self.ctx.audit.completed(row_id, reason));
         complete_row(&self.store, &self.ack, row_id);
+    }
+
+    fn audit(&self, event: AuditEvent) {
+        audit(&self.ctx, event);
     }
 }
 
@@ -359,7 +419,28 @@ async fn worker(ctx: Ctx, mut rx: mpsc::Receiver<Job>) {
 async fn handle(ctx: &Ctx, job: Job) {
     if let Some(reply) = command(ctx, &job) {
         if reply_to(ctx, &job.target, &reply).await {
-            complete_row(&ctx.store, &ctx.ack, job.row_id);
+            audit(
+                ctx,
+                ctx.audit.reply_sent(
+                    job.row_id,
+                    &job.thread,
+                    &job.target,
+                    Some(job.backend),
+                    &reply,
+                ),
+            );
+            complete_job(ctx, &job, "command");
+        } else {
+            audit(
+                ctx,
+                ctx.audit.reply_failed(
+                    job.row_id,
+                    &job.thread,
+                    &job.target,
+                    Some(job.backend),
+                    "command reply failed",
+                ),
+            );
         }
         return;
     }
@@ -370,7 +451,17 @@ async fn handle(ctx: &Ctx, job: Job) {
             job.thread,
             job.backend.as_str()
         );
-        complete_row(&ctx.store, &ctx.ack, job.row_id);
+        audit(
+            ctx,
+            ctx.audit.failed(
+                "backend_run_failed",
+                job.row_id,
+                &job.thread,
+                Some(job.backend),
+                "no runner configured",
+            ),
+        );
+        complete_job(ctx, &job, "missing_runner");
         return;
     };
 
@@ -386,6 +477,16 @@ async fn handle(ctx: &Ctx, job: Job) {
         Ok(v) => v,
         Err(e) => {
             error!("[{}] session error: {e}", job.thread);
+            audit(
+                ctx,
+                ctx.audit.failed(
+                    "backend_setup_failed",
+                    job.row_id,
+                    &job.thread,
+                    Some(job.backend),
+                    e.to_string(),
+                ),
+            );
             complete_setup_failure(ctx, &job, SESSION_SETUP_FAILURE).await;
             return;
         }
@@ -394,6 +495,16 @@ async fn handle(ctx: &Ctx, job: Job) {
     let work_dir = sandbox(&ctx.sessions_dir, &job.thread);
     if let Err(e) = std::fs::create_dir_all(&work_dir) {
         error!("[{}] sandbox error: {e}", job.thread);
+        audit(
+            ctx,
+            ctx.audit.failed(
+                "backend_setup_failed",
+                job.row_id,
+                &job.thread,
+                Some(job.backend),
+                e.to_string(),
+            ),
+        );
         complete_setup_failure(ctx, &job, SANDBOX_SETUP_FAILURE).await;
         return;
     }
@@ -414,6 +525,11 @@ async fn handle(ctx: &Ctx, job: Job) {
         prompt: &job.text,
     };
 
+    audit(
+        ctx,
+        ctx.audit
+            .backend_started(job.row_id, &job.thread, job.backend, is_new),
+    );
     let mut result = runner.run(req(is_new), ctx.run_timeout).await;
     // If the session id already exists (e.g. left over from a previous run or a
     // different build), resume it instead of trying to create it again.
@@ -428,6 +544,11 @@ async fn handle(ctx: &Ctx, job: Job) {
 
     match result {
         Ok(out) => {
+            audit(
+                ctx,
+                ctx.audit
+                    .backend_completed(job.row_id, &job.thread, job.backend, &out.reply),
+            );
             if let Err(e) = ctx
                 .store
                 .lock()
@@ -435,14 +556,55 @@ async fn handle(ctx: &Ctx, job: Job) {
                 .mark_started(&job.thread, out.session_id.as_deref())
             {
                 error!("[{}] session save error: {e}", job.thread);
+                audit(
+                    ctx,
+                    ctx.audit.failed(
+                        "backend_session_save_failed",
+                        job.row_id,
+                        &job.thread,
+                        Some(job.backend),
+                        e.to_string(),
+                    ),
+                );
                 return;
             }
             if reply_to(ctx, &job.target, &out.reply).await {
-                complete_row(&ctx.store, &ctx.ack, job.row_id);
+                audit(
+                    ctx,
+                    ctx.audit.reply_sent(
+                        job.row_id,
+                        &job.thread,
+                        &job.target,
+                        Some(job.backend),
+                        &out.reply,
+                    ),
+                );
+                complete_job(ctx, &job, "completed");
+            } else {
+                audit(
+                    ctx,
+                    ctx.audit.reply_failed(
+                        job.row_id,
+                        &job.thread,
+                        &job.target,
+                        Some(job.backend),
+                        "backend reply failed",
+                    ),
+                );
             }
         }
         Err(RunError::Timeout) => {
             warn!("[{}] {} run timed out", job.thread, runner.label());
+            audit(
+                ctx,
+                ctx.audit.failed(
+                    "backend_run_failed",
+                    job.row_id,
+                    &job.thread,
+                    Some(job.backend),
+                    format!("{} run timed out", runner.label()),
+                ),
+            );
             if reply_to(
                 ctx,
                 &job.target,
@@ -450,13 +612,65 @@ async fn handle(ctx: &Ctx, job: Job) {
             )
             .await
             {
-                complete_row(&ctx.store, &ctx.ack, job.row_id);
+                audit(
+                    ctx,
+                    ctx.audit.reply_sent(
+                        job.row_id,
+                        &job.thread,
+                        &job.target,
+                        Some(job.backend),
+                        "That took too long and was stopped. Try again or simplify the request.",
+                    ),
+                );
+                complete_job(ctx, &job, "timeout");
+            } else {
+                audit(
+                    ctx,
+                    ctx.audit.reply_failed(
+                        job.row_id,
+                        &job.thread,
+                        &job.target,
+                        Some(job.backend),
+                        "timeout reply failed",
+                    ),
+                );
             }
         }
         Err(RunError::Failed(msg)) => {
             error!("[{}] {} error: {msg}", job.thread, runner.label());
+            audit(
+                ctx,
+                ctx.audit.failed(
+                    "backend_run_failed",
+                    job.row_id,
+                    &job.thread,
+                    Some(job.backend),
+                    msg.clone(),
+                ),
+            );
             if reply_to(ctx, &job.target, &format!("⚠️ {}", short(&msg))).await {
-                complete_row(&ctx.store, &ctx.ack, job.row_id);
+                audit(
+                    ctx,
+                    ctx.audit.reply_sent(
+                        job.row_id,
+                        &job.thread,
+                        &job.target,
+                        Some(job.backend),
+                        &format!("⚠️ {}", short(&msg)),
+                    ),
+                );
+                complete_job(ctx, &job, "backend_failed");
+            } else {
+                audit(
+                    ctx,
+                    ctx.audit.reply_failed(
+                        job.row_id,
+                        &job.thread,
+                        &job.target,
+                        Some(job.backend),
+                        "failure reply failed",
+                    ),
+                );
             }
         }
     }
@@ -474,17 +688,52 @@ async fn complete_setup_failure(ctx: &Ctx, job: &Job, reply: &str) {
         .push(reply.to_string());
 
     #[cfg(not(test))]
-    if !reply_to(ctx, &job.target, reply).await {
-        warn!(
-            "[{}] setup failure reply was not sent; completing row {}",
-            job.thread, job.row_id
-        );
+    {
+        if reply_to(ctx, &job.target, reply).await {
+            audit(
+                ctx,
+                ctx.audit.reply_sent(
+                    job.row_id,
+                    &job.thread,
+                    &job.target,
+                    Some(job.backend),
+                    reply,
+                ),
+            );
+        } else {
+            audit(
+                ctx,
+                ctx.audit.reply_failed(
+                    job.row_id,
+                    &job.thread,
+                    &job.target,
+                    Some(job.backend),
+                    "setup failure reply failed",
+                ),
+            );
+            warn!(
+                "[{}] setup failure reply was not sent; completing row {}",
+                job.thread, job.row_id
+            );
+        }
     }
+    audit(ctx, ctx.audit.completed(job.row_id, "setup_failed"));
     complete_setup_failure_row(&ctx.store, &ctx.ack, job.row_id);
 }
 
 fn complete_setup_failure_row(store: &Arc<Mutex<Store>>, ack: &Arc<Mutex<AckState>>, row_id: i64) {
     complete_row(store, ack, row_id);
+}
+
+fn complete_job(ctx: &Ctx, job: &Job, reason: &str) {
+    audit(ctx, ctx.audit.completed(job.row_id, reason));
+    complete_row(&ctx.store, &ctx.ack, job.row_id);
+}
+
+fn audit(ctx: &Ctx, event: AuditEvent) {
+    if let Err(e) = ctx.audit.record(event) {
+        error!("audit log error: {e}");
+    }
 }
 
 /// Handles gateway-level slash commands before anything reaches the agent.
@@ -707,6 +956,12 @@ mod tests {
             sessions_dir,
             assistant_dir: String::new(),
             assistant: AssistantProfile::default(),
+            audit: Arc::new(AuditLog::new(
+                temp_path("setup-failure-audit")
+                    .to_string_lossy()
+                    .to_string(),
+                false,
+            )),
             setup_failure_replies: Arc::new(Mutex::new(Vec::new())),
             sent_replies: Arc::new(Mutex::new(Vec::new())),
         }
@@ -969,6 +1224,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn fake_channel_e2e_replies_once_ignores_unallowlisted_and_reuses_session() {
         let state_path = temp_state_path();
+        let audit_path = format!("{state_path}.audit.jsonl");
         let sessions_dir = temp_path("e2e-sessions");
         let assistant_dir = temp_path("e2e-assistant");
         std::fs::create_dir_all(&assistant_dir).unwrap();
@@ -1026,6 +1282,29 @@ mod tests {
                 }
             ]
         );
+        let events = audit_events(&audit_path);
+        assert!(events.iter().any(|e| {
+            e.event == "message_ignored"
+                && e.row_id == Some(1)
+                && e.reason.as_deref() == Some("not_allowlisted")
+        }));
+        assert!(events.iter().any(|e| {
+            e.event == "message_accepted"
+                && e.row_id == Some(2)
+                && e.thread.as_deref() == Some("dm:+15551234567")
+                && e.backend.as_deref() == Some("codex")
+        }));
+        assert!(events.iter().any(|e| {
+            e.event == "backend_run_completed"
+                && e.row_id == Some(2)
+                && e.reply.as_ref().is_some_and(|c| c.text.is_none())
+        }));
+        assert!(events
+            .iter()
+            .any(|e| e.event == "reply_sent" && e.row_id == Some(2)));
+        assert!(events
+            .iter()
+            .any(|e| e.event == "message_completed" && e.row_id == Some(3)));
 
         let replay_calls = Arc::new(Mutex::new(Vec::new()));
         let mut replay_gateway = Gateway::new(test_config(
@@ -1051,6 +1330,7 @@ mod tests {
         assert!(replay_calls.lock().unwrap().is_empty());
 
         let _ = std::fs::remove_file(state_path);
+        let _ = std::fs::remove_file(audit_path);
         let _ = std::fs::remove_dir_all(sessions_dir);
         let _ = std::fs::remove_dir_all(assistant_dir);
     }
@@ -1076,9 +1356,19 @@ mod tests {
             codex_model: None,
             sessions_dir: sessions_dir.to_string(),
             state_path: state_path.to_string(),
+            audit_log_path: format!("{state_path}.audit.jsonl"),
+            audit_log_content: false,
             assistant_dir: assistant_dir.to_string(),
             reply_marker: "\n\n-- sent by push".to_string(),
         }
+    }
+
+    fn audit_events(path: &str) -> Vec<crate::audit::AuditEvent> {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
     }
 
     fn fake_runners(calls: Arc<Mutex<Vec<FakeRunCall>>>) -> HashMap<AgentBackend, Runner> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 //! coding-agent backend, and texts the reply back.
 
 mod agent;
+mod audit;
 mod claude;
 mod codex;
 mod config;
@@ -115,6 +116,7 @@ fn run_checks(cfg: &config::Config) -> CheckReport {
     check_config(cfg, &mut checks);
     check_state_dir(cfg, &mut checks);
     check_sessions_dir(cfg, &mut checks);
+    check_audit_log_dir(cfg, &mut checks);
     check_imessage_db(cfg, &mut checks);
     check_bins(cfg, &mut checks);
     CheckReport { checks }
@@ -168,6 +170,29 @@ fn check_sessions_dir(cfg: &config::Config, checks: &mut Vec<Check>) {
                 cfg.sessions_dir
             ),
         )),
+    }
+}
+
+fn check_audit_log_dir(cfg: &config::Config, checks: &mut Vec<Check>) {
+    if let Some(parent) = Path::new(&cfg.audit_log_path).parent() {
+        match ensure_writable_dir(parent) {
+            Ok(()) => checks.push(Check::pass(
+                "audit log directory",
+                format!("{} is writable", parent.display()),
+            )),
+            Err(e) => checks.push(Check::fail(
+                "audit log directory",
+                format!(
+                    "cannot create {}: {e}. Create it or choose a writable audit_log_path.",
+                    parent.display()
+                ),
+            )),
+        }
+    } else {
+        checks.push(Check::pass(
+            "audit log directory",
+            "audit_log_path has no parent directory",
+        ));
     }
 }
 
@@ -495,6 +520,10 @@ mod tests {
         let mut cfg = test_config();
         cfg.db_path = db_path.to_string_lossy().to_string();
         cfg.state_path = state_path.to_string_lossy().to_string();
+        cfg.audit_log_path = state_path
+            .with_extension("audit.jsonl")
+            .to_string_lossy()
+            .to_string();
         cfg.sessions_dir = sessions_dir.to_string_lossy().to_string();
 
         let report = run_checks(&cfg);
@@ -510,11 +539,15 @@ mod tests {
             check.name == "sessions directory" && matches!(check.status, CheckStatus::Pass)
         }));
         assert!(report.checks.iter().any(|check| {
+            check.name == "audit log directory" && matches!(check.status, CheckStatus::Pass)
+        }));
+        assert!(report.checks.iter().any(|check| {
             check.name == "iMessage database" && matches!(check.status, CheckStatus::Pass)
         }));
 
         let _ = std::fs::remove_file(db_path);
         let _ = std::fs::remove_file(state_path);
+        let _ = std::fs::remove_file(cfg.audit_log_path);
         let _ = std::fs::remove_dir_all(sessions_dir);
     }
 
@@ -549,6 +582,8 @@ mod tests {
             codex_model: None,
             sessions_dir: "/fake/sessions".to_string(),
             state_path: "/fake/state.json".to_string(),
+            audit_log_path: "/fake/audit.jsonl".to_string(),
+            audit_log_content: false,
             assistant_dir: "/fake/assistant".to_string(),
             reply_marker: "\n\n-- sent by push".to_string(),
         }


### PR DESCRIPTION
Closes #25.

## Summary
- add a local JSONL audit log with configurable `audit_log_path`
- keep message and reply text redacted by default, with `audit_log_content` as an explicit opt-in
- record accepted and ignored messages, route and backend failures, backend starts and completions, reply delivery metadata, and message completion
- add `push doctor` coverage for the audit log directory and document service permissions

## Verification
- `cargo fmt --check`
- `cargo test` (62 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## Review
- independent code review: no remaining blockers or important issues
- independent acceptance check: #25 acceptance criteria satisfied
