### PR TITLE
feat(config): group channel settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Or build from source:
 git clone https://github.com/owainlewis/push.git
 cd push
 cp config.toml.example config.toml
-# edit config.toml: set self_handles and choose agent = "claude" or "codex"
+# edit config.toml: replace the Telegram user ID
+export TELEGRAM_BOT_TOKEN='your-bot-token'
 cargo build --release
 ./target/release/push doctor --config config.toml
 ./target/release/push
@@ -146,10 +147,10 @@ mutable and are not accepted as security identities. Keep the bot token in the
 
 ```toml
 channel = "telegram"
-telegram_bot_token_env = "TELEGRAM_BOT_TOKEN"
-telegram_allow_user_ids = [123456789]
-telegram_allow_chat_ids = []
 agent = "codex"
+
+[telegram]
+allow_user_ids = [123456789]
 ```
 
 See [Telegram Setup and Security](docs/telegram.md) for BotFather setup, finding
@@ -189,11 +190,8 @@ settings, pushes to `main` deploy the site automatically.
 ```toml
 channel = "imessage"
 agent = "codex"
-self_handles = ["you@icloud.com", "+15551234567"]
-allow_from = []
-telegram_bot_token_env = "TELEGRAM_BOT_TOKEN"
-telegram_allow_user_ids = []
-telegram_allow_chat_ids = []
+
+# Advanced shared and backend settings use their existing top-level names.
 claude_bin = "claude"
 claude_permission_mode = "bypassPermissions"
 claude_allowed_tools = []
@@ -203,6 +201,15 @@ codex_sandbox = "workspace-write"
 codex_approval_policy = "never"
 audit_log_path = "~/.push/audit.jsonl"
 audit_log_content = false
+
+[imessage]
+self_handles = ["you@icloud.com"]
+allow_from = ["+15551234567"]
+
+[telegram]
+bot_token_env = "TELEGRAM_BOT_TOKEN"
+allow_user_ids = [123456789]
+allow_chat_ids = []
 
 [[routes]]
 thread = "imessage:self:you@icloud.com"
@@ -217,6 +224,9 @@ preferences = ["Prefer concise replies."]
 ```
 
 `channel` can be `imessage` or `telegram`. `agent` can be `claude` or `codex`.
+Channel settings belong under `[imessage]` and `[telegram]`. Existing flat
+channel keys remain accepted for compatibility, but do not set the same option
+in both places.
 Routes can override the backend by channel or exact channel-qualified thread:
 
 ```toml
@@ -240,11 +250,12 @@ of committing a config that contains credentials.
 ## Safety
 
 An inbound text is an instruction to an agent with tool access. The trust
-boundary is the sender filter: iMessage uses `self_handles` and `allow_from`;
-Telegram uses stable numeric `telegram_allow_user_ids` and
-`telegram_allow_chat_ids`. These fields decide who can
+boundary is the sender filter: iMessage uses `imessage.self_handles` and
+`imessage.allow_from`;
+Telegram uses stable numeric `telegram.allow_user_ids` and
+`telegram.allow_chat_ids`. These fields decide who can
 ask the configured backend to read files, edit files, run shell commands, call
-MCP servers, or use any other backend tool. Keep `allow_from` tight, and treat a
+MCP servers, or use any other backend tool. Keep `imessage.allow_from` tight, and treat a
 lost or shared phone, forwarded iMessage account, or compromised allowed sender
 as able to instruct the agent.
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,37 +1,7 @@
-channel = "imessage"
-db_path = "~/Library/Messages/chat.db"
-poll_interval = "3s"
-run_timeout = "120s"
-self_handles = ["you@icloud.com", "+15551234567"]
-allow_from = []
-telegram_bot_token_env = "TELEGRAM_BOT_TOKEN"
-telegram_allow_user_ids = []
-telegram_allow_chat_ids = []
-agent = "claude"
-claude_bin = "claude"
-claude_permission_mode = "bypassPermissions"
-claude_allowed_tools = []
-claude_disallowed_tools = []
-codex_bin = "codex"
-codex_sandbox = "workspace-write"
-codex_approval_policy = "never"
-sessions_dir = "~/.push/sessions"
-state_path = "~/.push/state.json"
-audit_log_path = "~/.push/audit.jsonl"
-audit_log_content = false
-assistant_dir = "./assistant"
-reply_marker = "\n\n-- sent by push"
-
-[[routes]]
-thread = "imessage:self:you@icloud.com"
+# Telegram quick start. The bot token comes from TELEGRAM_BOT_TOKEN.
+channel = "telegram"
 agent = "codex"
 
-[assistant]
-name = "push"
-tone = "short, direct, and useful"
-business = "Describe your business or work context here."
-projects = ["push"]
-preferences = [
-  "Prefer concise replies.",
-  "Use the configured agent tools instead of gateway plugins.",
-]
+[telegram]
+# Replace this once with your numeric Telegram user ID.
+allow_user_ids = [123456789]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,8 +206,9 @@ backend session.
 ## Security Posture
 
 An allowed inbound message can cause an agent to run tools. The sender filter is
-the trust boundary. iMessage uses `self_handles` and `allow_from`; Telegram uses
-stable numeric `telegram_allow_user_ids` and `telegram_allow_chat_ids`.
+the trust boundary. iMessage uses `imessage.self_handles` and
+`imessage.allow_from`; Telegram uses stable numeric `telegram.allow_user_ids`
+and `telegram.allow_chat_ids`.
 
 Backend permissions are adapter-specific:
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -130,11 +130,14 @@ Codex assistant context is passed as part of the prompt wrapper.
 | `agent` | `claude` or `codex`. |
 | `routes` | Exact thread to backend overrides. |
 | `assistant` | Structured assistant profile fields. |
-| `db_path` | Path to Messages `chat.db`. |
+| `imessage.db_path` | Path to Messages `chat.db`. |
 | `poll_interval` | How often to poll. |
 | `run_timeout` | Max backend run time. |
-| `self_handles` | User's own iMessage handles. |
-| `allow_from` | Other allowed senders. |
+| `imessage.self_handles` | User's own iMessage handles. |
+| `imessage.allow_from` | Other allowed senders. |
+| `telegram.bot_token_env` | Environment variable containing the bot token. |
+| `telegram.allow_user_ids` | Allowed private-chat sender IDs. |
+| `telegram.allow_chat_ids` | Allowed private chat IDs. |
 | `claude_bin` | Claude Code binary. |
 | `claude_permission_mode` | Claude Code permission mode. |
 | `claude_tools` | Optional Claude Code available tool list. |

--- a/docs/services.md
+++ b/docs/services.md
@@ -171,7 +171,7 @@ is completed.
 
 Managed services run without a person watching the terminal. An allowed sender
 can instruct the configured backend to use its tools, subject to your backend
-settings. Keep `allow_from` narrow, use the least-powerful backend permissions
+settings. Keep `imessage.allow_from` narrow, use the least-powerful backend permissions
 that still work, and consider Claude Code `claude_tools`,
 `claude_allowed_tools`, and `claude_disallowed_tools` when running headlessly.
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -31,17 +31,19 @@ Use a Telegram-only config:
 
 ```toml
 channel = "telegram"
-telegram_bot_token_env = "TELEGRAM_BOT_TOKEN"
-telegram_allow_user_ids = [123456789]
-telegram_allow_chat_ids = []
 agent = "codex"
+
+[telegram]
+allow_user_ids = [123456789]
 
 [[routes]]
 thread = "telegram:dm:123456789"
 agent = "claude"
 ```
 
-`telegram_bot_token` is supported for constrained deployments, but the
+The token environment variable defaults to `TELEGRAM_BOT_TOKEN`. Set
+`telegram.bot_token_env` only when you need a different variable name.
+`telegram.bot_token` is supported for constrained deployments, but the
 environment-variable form is safer because it keeps the credential out of the
 config file. push never prints the token. Run:
 
@@ -59,8 +61,8 @@ Telegram-only preflight does not open `chat.db` and does not require macOS or
 An incoming Telegram update reaches the agent only when all of these are true:
 
 - it is a normal text message in a private chat
-- its numeric sender id is in `telegram_allow_user_ids`, or its numeric chat id
-  is in `telegram_allow_chat_ids`
+- its numeric sender id is in `telegram.allow_user_ids`, or its numeric chat id
+  is in `telegram.allow_chat_ids`
 - the text is not empty
 
 Group chats, channels, forum topics, edited messages, and other update types are

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,7 +70,30 @@ impl Config {
     /// Load, expand `~` in path fields, and validate the config at `path`.
     pub fn load(path: &str) -> Result<Config> {
         let raw = std::fs::read_to_string(path).with_context(|| format!("read config {path}"))?;
-        let mut c: Config = toml::from_str(&raw).context("parse TOML config")?;
+        let mut value: toml::Value = toml::from_str(&raw).context("parse TOML config")?;
+        let root = value
+            .as_table_mut()
+            .context("config must be a TOML table")?;
+        flatten_provider_section(
+            root,
+            "imessage",
+            &[
+                ("db_path", "db_path"),
+                ("self_handles", "self_handles"),
+                ("allow_from", "allow_from"),
+            ],
+        )?;
+        flatten_provider_section(
+            root,
+            "telegram",
+            &[
+                ("bot_token", "telegram_bot_token"),
+                ("bot_token_env", "telegram_bot_token_env"),
+                ("allow_user_ids", "telegram_allow_user_ids"),
+                ("allow_chat_ids", "telegram_allow_chat_ids"),
+            ],
+        )?;
+        let mut c: Config = value.try_into().context("parse TOML config")?;
         c.db_path = expand_home(&c.db_path);
         c.sessions_dir = expand_home(&c.sessions_dir);
         c.state_path = expand_home(&c.state_path);
@@ -151,24 +174,24 @@ impl Config {
         match self.channel_kind()? {
             ChannelKind::IMessage => {
                 if self.self_handles.is_empty() && self.allow_from.is_empty() {
-                    bail!("set at least one of self_handles or allow_from for iMessage");
+                    bail!("set imessage.self_handles or imessage.allow_from for iMessage");
                 }
             }
             ChannelKind::Telegram => {
                 if self.telegram_allow_user_ids.is_empty()
                     && self.telegram_allow_chat_ids.is_empty()
                 {
-                    bail!("set telegram_allow_user_ids or telegram_allow_chat_ids for Telegram");
+                    bail!("set telegram.allow_user_ids or telegram.allow_chat_ids for Telegram");
                 }
                 if self
                     .telegram_bot_token
                     .as_deref()
                     .is_some_and(|v| v.trim().is_empty())
                 {
-                    bail!("telegram_bot_token cannot be empty");
+                    bail!("telegram.bot_token cannot be empty");
                 }
                 if self.telegram_bot_token_env.trim().is_empty() {
-                    bail!("telegram_bot_token_env cannot be empty");
+                    bail!("telegram.bot_token_env cannot be empty");
                 }
             }
         }
@@ -217,6 +240,35 @@ impl Config {
         self.run_timeout_dur()?;
         Ok(())
     }
+}
+
+fn flatten_provider_section(
+    root: &mut toml::Table,
+    section: &str,
+    fields: &[(&str, &str)],
+) -> Result<()> {
+    let Some(value) = root.remove(section) else {
+        return Ok(());
+    };
+    let table = value
+        .as_table()
+        .with_context(|| format!("[{section}] must be a TOML table"))?;
+
+    for (key, value) in table {
+        let Some((_, destination)) = fields.iter().find(|(source, _)| source == key) else {
+            let expected = fields
+                .iter()
+                .map(|(source, _)| *source)
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!("unknown [{section}] setting {key:?}; expected one of: {expected}");
+        };
+        if root.contains_key(*destination) {
+            bail!("set {destination} either at the top level or as [{section}].{key}, not both");
+        }
+        root.insert((*destination).to_string(), value.clone());
+    }
+    Ok(())
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ fn check_config(cfg: &config::Config, checks: &mut Vec<Check>) {
     checks.push(Check::pass(
         "config",
         format!(
-            "channel={}, agent={}, self_handles={}, allow_from={}, telegram_allow_user_ids={}, telegram_allow_chat_ids={}",
+            "channel={}, agent={}, imessage.self_handles={}, imessage.allow_from={}, telegram.allow_user_ids={}, telegram.allow_chat_ids={}",
             cfg.channel,
             cfg.agent,
             cfg.self_handles.len(),
@@ -221,14 +221,14 @@ fn check_imessage_db(cfg: &config::Config, checks: &mut Vec<Check>) {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => checks.push(Check::fail(
             "iMessage database",
             format!(
-                "Messages database not found at {}. Sign in to iMessage or set db_path.",
+                "Messages database not found at {}. Sign in to iMessage or set imessage.db_path.",
                 cfg.db_path
             ),
         )),
         Err(e) => checks.push(Check::fail(
             "iMessage database",
             format!(
-                "cannot open {}: {e}. Check db_path and Messages permissions, then rerun doctor.",
+                "cannot open {}: {e}. Check imessage.db_path and Messages permissions, then rerun doctor.",
                 cfg.db_path
             ),
         )),
@@ -245,7 +245,7 @@ fn check_telegram_config(cfg: &config::Config, checks: &mut Vec<Check>) {
         checks.push(Check::fail(
             "Telegram bot token",
             format!(
-                "not configured. Set {} or telegram_bot_token without printing the token.",
+                "not configured. Set {} or telegram.bot_token without printing the token.",
                 cfg.telegram_bot_token_env
             ),
         ));
@@ -413,19 +413,89 @@ mod tests {
     }
 
     #[test]
-    fn example_toml_loads_routes_and_assistant_profile() {
+    fn example_toml_is_a_minimal_telegram_config() {
         let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("config.toml.example");
 
         let cfg = Config::load(path.to_str().unwrap()).unwrap();
 
-        assert_eq!(cfg.channel, "imessage");
-        assert_eq!(cfg.routes.len(), 1);
-        assert_eq!(cfg.routes[0].agent, "codex");
-        assert_eq!(cfg.assistant.name, "push");
-        assert_eq!(cfg.assistant.projects, ["push"]);
+        assert_eq!(cfg.channel, "telegram");
+        assert_eq!(cfg.agent, "codex");
         assert_eq!(cfg.telegram_bot_token_env, "TELEGRAM_BOT_TOKEN");
-        assert!(cfg.telegram_allow_user_ids.is_empty());
+        assert_eq!(cfg.telegram_allow_user_ids, [123456789]);
         assert!(cfg.telegram_allow_chat_ids.is_empty());
+    }
+
+    #[test]
+    fn provider_sections_load_channel_settings() {
+        let path = temp_path("provider-section-config");
+        std::fs::write(
+            &path,
+            r#"channel = "telegram"
+agent = "codex"
+
+[imessage]
+db_path = "/tmp/messages.db"
+self_handles = ["me@example.com"]
+
+[telegram]
+bot_token_env = "PUSH_TEST_TOKEN"
+allow_user_ids = [7]
+allow_chat_ids = [9]
+"#,
+        )
+        .unwrap();
+
+        let cfg = Config::load(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(cfg.db_path, "/tmp/messages.db");
+        assert_eq!(cfg.self_handles, ["me@example.com"]);
+        assert_eq!(cfg.telegram_bot_token_env, "PUSH_TEST_TOKEN");
+        assert_eq!(cfg.telegram_allow_user_ids, [7]);
+        assert_eq!(cfg.telegram_allow_chat_ids, [9]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn provider_sections_reject_duplicate_flat_settings() {
+        let path = temp_path("duplicate-provider-config");
+        std::fs::write(
+            &path,
+            r#"channel = "telegram"
+agent = "codex"
+telegram_allow_user_ids = [7]
+
+[telegram]
+allow_user_ids = [9]
+"#,
+        )
+        .unwrap();
+
+        let err = Config::load(path.to_str().unwrap()).unwrap_err();
+
+        assert!(err.to_string().contains("not both"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn legacy_flat_telegram_settings_remain_supported() {
+        let path = temp_path("legacy-flat-telegram-config");
+        std::fs::write(
+            &path,
+            r#"channel = "telegram"
+agent = "codex"
+telegram_bot_token_env = "LEGACY_TOKEN"
+telegram_allow_user_ids = [7]
+telegram_allow_chat_ids = [9]
+"#,
+        )
+        .unwrap();
+
+        let cfg = Config::load(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(cfg.telegram_bot_token_env, "LEGACY_TOKEN");
+        assert_eq!(cfg.telegram_allow_user_ids, [7]);
+        assert_eq!(cfg.telegram_allow_chat_ids, [9]);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add canonical [telegram] and [imessage] TOML sections
- keep existing flat channel keys compatible
- reduce config.toml.example to a minimal Telegram quick start
- align setup, validation, doctor output, and security docs with the section form

## Why

The previous example exposed nearly every default and made a first Telegram smoke test harder than necessary. Provider-specific sections make the required settings easier to find and understand.

## Test plan

- cargo fmt --check
- git diff --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --locked (89 passed)
- independent diff review, including follow-up re-review

## Risks

Config loading now normalizes provider sections into the existing internal fields. Duplicate flat and section settings are rejected to avoid ambiguous precedence. Focused tests cover nested settings and legacy flat compatibility.

## Related issue

None.