### PR TITLE
feat(telegram): add native feedback and reply formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,11 @@ sessions when the selected backend has not changed.
 Telegram uses Bot API long polling, so push opens no public port and needs no
 webhook server. Private chats are supported first. Group chats, forum topics,
 and non-text updates are ignored before they can reach the agent. Replies go to
-the chat that originated the accepted message, and replies over Telegram's
-4,096-character text limit are sent as ordered Unicode-safe chunks.
+the chat that originated the accepted message. Replies up to Telegram's 32,768
+character rich-message limit use native Rich Markdown, so headings, lists,
+links, quotes, tables, and code render instead of appearing as raw Markdown.
+Larger replies fall back to ordered, Unicode-safe 4,096-character plain-text
+chunks.
 
 Use stable numeric Telegram user or chat ids in the allowlist. Usernames are
 mutable and are not accepted as security identities. Keep the bot token in the

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -20,6 +20,12 @@ pub struct RawMessage {
     pub is_supported: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutboundChunk {
+    pub text: String,
+    pub rich_markdown: bool,
+}
+
 #[derive(Clone)]
 pub enum Channel {
     IMessage {
@@ -159,22 +165,39 @@ impl Channel {
         }
     }
 
-    pub fn outbound_chunks(&self, text: &str, marker: &str) -> Vec<String> {
+    pub fn outbound_chunks(&self, text: &str, marker: &str) -> Vec<OutboundChunk> {
         if text.trim().is_empty() {
             return Vec::new();
         }
-        let output = format!("{text}{marker}");
         match self {
-            Self::IMessage { .. } => vec![output],
-            Self::Telegram(_) => crate::telegram::split_text(&output),
+            Self::IMessage { .. } => vec![OutboundChunk {
+                text: format!("{text}{marker}"),
+                rich_markdown: false,
+            }],
+            Self::Telegram(_) if text.chars().count() <= crate::telegram::RICH_TEXT_LIMIT => {
+                vec![OutboundChunk {
+                    text: text.to_string(),
+                    rich_markdown: true,
+                }]
+            }
+            Self::Telegram(_) => crate::telegram::split_text(text)
+                .into_iter()
+                .map(|text| OutboundChunk {
+                    text,
+                    rich_markdown: false,
+                })
+                .collect(),
         }
     }
 
     #[cfg_attr(test, allow(dead_code))]
-    pub async fn send_chunk(&self, target: &str, text: &str) -> Result<()> {
+    pub async fn send_chunk(&self, target: &str, chunk: &OutboundChunk) -> Result<()> {
         match self {
-            Self::IMessage { sender, .. } => sender.send(target, text).await,
-            Self::Telegram(telegram) => telegram.send(target, text).await,
+            Self::IMessage { sender, .. } => sender.send(target, &chunk.text).await,
+            Self::Telegram(telegram) if chunk.rich_markdown => {
+                telegram.send_rich(target, &chunk.text).await
+            }
+            Self::Telegram(telegram) => telegram.send_plain(target, &chunk.text).await,
         }
     }
 
@@ -266,22 +289,49 @@ mod tests {
     }
 
     #[test]
-    fn telegram_marker_and_reply_never_exceed_limit() {
-        let chunks = telegram().outbound_chunks(
-            &"x".repeat(crate::telegram::TEXT_LIMIT),
-            "\n\n-- sent by push",
-        );
+    fn telegram_omits_imessage_marker_and_reply_never_exceeds_limit() {
+        let marker = "\n\n-- sent by push";
+        let chunks = telegram().outbound_chunks(&"x".repeat(crate::telegram::TEXT_LIMIT), marker);
 
-        assert_eq!(chunks.len(), 2);
-        assert!(chunks
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].rich_markdown);
+        assert!(chunks.iter().all(|chunk| !chunk.text.contains(marker)));
+        assert_eq!(chunks[0].text, "x".repeat(crate::telegram::TEXT_LIMIT));
+
+        let long =
+            telegram().outbound_chunks(&"x".repeat(crate::telegram::RICH_TEXT_LIMIT + 1), marker);
+        assert!(long.iter().all(|chunk| !chunk.rich_markdown));
+        assert!(long
             .iter()
-            .all(|chunk| chunk.encode_utf16().count() <= crate::telegram::TEXT_LIMIT));
+            .all(|chunk| { chunk.text.encode_utf16().count() <= crate::telegram::TEXT_LIMIT }));
+    }
+
+    #[test]
+    fn telegram_keeps_markdown_structures_whole_or_falls_back_to_plain_chunks() {
+        let structured = format!(
+            "{}\n```rust\nlet value = 1;\n```\n[link](https://example.com)\n| a | b |\n| - | - |\n| 1 | 2 |",
+            "x".repeat(crate::telegram::TEXT_LIMIT)
+        );
+        let rich = telegram().outbound_chunks(&structured, "ignored");
+
+        assert_eq!(rich.len(), 1);
+        assert!(rich[0].rich_markdown);
+        assert_eq!(rich[0].text, structured);
+
+        let oversized = format!(
+            "{}\n```rust\nlet value = 1;\n```\n[link](https://example.com)\n| a | b |\n| - | - |",
+            "x".repeat(crate::telegram::RICH_TEXT_LIMIT)
+        );
+        let plain = telegram().outbound_chunks(&oversized, "ignored");
+
+        assert!(plain.len() > 1);
+        assert!(plain.iter().all(|chunk| !chunk.rich_markdown));
         assert_eq!(
-            chunks.concat(),
-            format!(
-                "{}\n\n-- sent by push",
-                "x".repeat(crate::telegram::TEXT_LIMIT)
-            )
+            plain
+                .into_iter()
+                .map(|chunk| chunk.text)
+                .collect::<String>(),
+            oversized
         );
     }
 
@@ -296,8 +346,8 @@ mod tests {
         };
 
         assert_eq!(
-            channel.outbound_chunks("hello", "\n\n-- sent by push"),
-            ["hello\n\n-- sent by push"]
+            channel.outbound_chunks("hello", "\n\n-- sent by push")[0].text,
+            "hello\n\n-- sent by push"
         );
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -177,6 +177,17 @@ impl Channel {
             Self::Telegram(telegram) => telegram.send(target, text).await,
         }
     }
+
+    pub fn supports_typing(&self) -> bool {
+        matches!(self, Self::Telegram(_))
+    }
+
+    pub async fn send_typing(&self, target: &str) -> Result<()> {
+        match self {
+            Self::IMessage { .. } => Ok(()),
+            Self::Telegram(telegram) => telegram.send_typing(target).await,
+        }
+    }
 }
 
 pub(crate) fn normalize_handle(value: &str) -> String {
@@ -232,6 +243,7 @@ mod tests {
 
     #[test]
     fn telegram_accepts_allowlisted_private_user_or_chat() {
+        assert!(telegram().supports_typing());
         assert_eq!(
             telegram().accept(&telegram_message(7, 7, false)),
             Some(("telegram:dm:7".to_string(), "7".to_string()))

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -7,6 +7,7 @@
 //! writes. Everything else is message passing.
 
 use std::collections::{BTreeSet, HashMap};
+use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -28,6 +29,7 @@ const QUEUE_DEPTH: usize = 32;
 #[cfg(not(test))]
 const SEND_TIMEOUT: Duration = Duration::from_secs(30);
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(30);
+const TYPING_REFRESH: Duration = Duration::from_secs(4);
 const SESSION_SETUP_FAILURE: &str =
     "Push could not prepare this conversation. Check the local logs, then resend.";
 const SANDBOX_SETUP_FAILURE: &str =
@@ -219,6 +221,10 @@ impl Gateway {
                     }
                 };
                 self.audit(self.ctx.audit.accepted(m, &thread, backend));
+                info!(
+                    "[{thread}] new message accepted; routing to {}",
+                    backend.as_str()
+                );
                 self.route(
                     m.row_id,
                     thread,
@@ -324,6 +330,11 @@ async fn worker(ctx: Ctx, mut rx: mpsc::Receiver<Job>) {
 async fn handle(ctx: &Ctx, job: Job) {
     if let Some(reply) = command(ctx, &job) {
         if reply_to(ctx, &job.target, &reply).await {
+            info!(
+                "[{}] command reply sent via {}",
+                job.thread,
+                ctx.channel.id()
+            );
             audit(
                 ctx,
                 ctx.audit.reply_sent(
@@ -435,20 +446,52 @@ async fn handle(ctx: &Ctx, job: Job) {
         ctx.audit
             .backend_started(job.row_id, &job.thread, job.backend, is_new),
     );
-    let mut result = runner.run(req(is_new), ctx.run_timeout).await;
-    // If the session id already exists (e.g. left over from a previous run or a
-    // different build), resume it instead of trying to create it again.
-    if is_new {
-        if let Err(RunError::Failed(msg)) = &result {
-            if msg.to_lowercase().contains("already in use") {
-                warn!("[{}] session id already existed, resuming", job.thread);
-                result = runner.run(req(false), ctx.run_timeout).await;
+    info!(
+        "[{}] sending message to {} (new_session={is_new})",
+        job.thread,
+        runner.label()
+    );
+    let run = async {
+        let mut result = runner.run(req(is_new), ctx.run_timeout).await;
+        // If the session id already exists (e.g. left over from a previous run
+        // or a different build), resume it instead of trying to create it again.
+        if is_new {
+            if let Err(RunError::Failed(msg)) = &result {
+                if msg.to_lowercase().contains("already in use") {
+                    warn!("[{}] session id already existed, resuming", job.thread);
+                    result = runner.run(req(false), ctx.run_timeout).await;
+                }
             }
         }
-    }
+        result
+    };
+    let result = if ctx.channel.supports_typing() {
+        let channel = ctx.channel.clone();
+        let target = job.target.clone();
+        let thread = job.thread.clone();
+        run_with_periodic_activity(run, TYPING_REFRESH, move || {
+            let channel = channel.clone();
+            let target = target.clone();
+            let thread = thread.clone();
+            async move {
+                if let Err(e) = channel.send_typing(&target).await {
+                    warn!("[{thread}] Telegram typing update failed: {e}");
+                }
+            }
+        })
+        .await
+    } else {
+        run.await
+    };
 
     match result {
         Ok(out) => {
+            info!(
+                "[{}] {} completed; reply_chars={}",
+                job.thread,
+                runner.label(),
+                out.reply.chars().count()
+            );
             audit(
                 ctx,
                 ctx.audit
@@ -474,6 +517,7 @@ async fn handle(ctx: &Ctx, job: Job) {
                 return;
             }
             if reply_to(ctx, &job.target, &out.reply).await {
+                info!("[{}] reply sent via {}", job.thread, ctx.channel.id());
                 audit(
                     ctx,
                     ctx.audit.reply_sent(
@@ -576,6 +620,34 @@ async fn handle(ctx: &Ctx, job: Job) {
                         "failure reply failed",
                     ),
                 );
+            }
+        }
+    }
+}
+
+async fn run_with_periodic_activity<O, A, AF>(
+    operation: O,
+    refresh: Duration,
+    mut activity: A,
+) -> O::Output
+where
+    O: Future,
+    A: FnMut() -> AF,
+    AF: Future<Output = ()>,
+{
+    tokio::pin!(operation);
+    let mut ticker = tokio::time::interval(refresh);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            output = &mut operation => return output,
+            _ = ticker.tick() => {
+                let activity = activity();
+                tokio::pin!(activity);
+                tokio::select! {
+                    output = &mut operation => return output,
+                    _ = &mut activity => {}
+                }
             }
         }
     }
@@ -799,7 +871,59 @@ mod tests {
     use crate::channel::{normalize_handle, thread_handle};
     use crate::imessage::{Poller, Sender};
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use uuid::Uuid;
+
+    #[tokio::test]
+    async fn periodic_activity_refreshes_until_operation_completes() {
+        let (complete, completed) = tokio::sync::oneshot::channel();
+        let complete = Arc::new(Mutex::new(Some(complete)));
+        let activity_count = Arc::new(AtomicUsize::new(0));
+        let count = activity_count.clone();
+
+        let output = tokio::time::timeout(
+            Duration::from_secs(1),
+            run_with_periodic_activity(completed, Duration::from_millis(1), move || {
+                let complete = complete.clone();
+                let count = count.clone();
+                async move {
+                    if count.fetch_add(1, Ordering::SeqCst) + 1 == 3 {
+                        if let Some(complete) = complete.lock().unwrap().take() {
+                            let _ = complete.send("done");
+                        }
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("activity loop should finish")
+        .expect("operation should complete");
+
+        assert_eq!(output, "done");
+        assert!(activity_count.load(Ordering::SeqCst) >= 3);
+        let final_count = activity_count.load(Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert_eq!(activity_count.load(Ordering::SeqCst), final_count);
+    }
+
+    #[tokio::test]
+    async fn stalled_activity_does_not_delay_operation() {
+        let output = tokio::time::timeout(
+            Duration::from_millis(100),
+            run_with_periodic_activity(
+                async {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    "done"
+                },
+                Duration::from_secs(1),
+                std::future::pending::<()>,
+            ),
+        )
+        .await
+        .expect("stalled activity should not block the operation");
+
+        assert_eq!(output, "done");
+    }
 
     fn filter() -> Channel {
         Channel::IMessage {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -743,10 +743,11 @@ async fn reply_to(ctx: &Ctx, target: &str, text: &str) -> bool {
     let chunks = ctx.channel.outbound_chunks(text, &ctx.reply_marker);
     #[cfg(test)]
     {
-        ctx.sent_replies
-            .lock()
-            .unwrap()
-            .extend(chunks.into_iter().map(|chunk| (target.to_string(), chunk)));
+        ctx.sent_replies.lock().unwrap().extend(
+            chunks
+                .into_iter()
+                .map(|chunk| (target.to_string(), chunk.text)),
+        );
         true
     }
     #[cfg(not(test))]
@@ -1439,10 +1440,7 @@ mod tests {
         assert_eq!(calls.lock().unwrap()[0].prompt, "hello");
         assert_eq!(
             gateway.ctx.sent_replies.lock().unwrap().as_slice(),
-            [(
-                "7".to_string(),
-                "fake reply: hello\n\n-- sent by push".to_string()
-            )]
+            [("7".to_string(), "fake reply: hello".to_string())]
         );
 
         let _ = std::fs::remove_file(&state_path);

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -13,10 +13,16 @@ use serde_json::{json, Value};
 use crate::channel::RawMessage;
 
 pub const TEXT_LIMIT: usize = 4096;
+pub const RICH_TEXT_LIMIT: usize = 32768;
 const LONG_POLL_SECONDS: u64 = 25;
 const HTTP_TIMEOUT_SECONDS: u64 = LONG_POLL_SECONDS + 10;
 
-type TransportFuture<'a> = Pin<Box<dyn Future<Output = Result<Value>> + Send + 'a>>;
+struct TransportResponse {
+    status: u16,
+    body: Value,
+}
+
+type TransportFuture<'a> = Pin<Box<dyn Future<Output = Result<TransportResponse>> + Send + 'a>>;
 
 trait Transport: Send + Sync {
     fn post<'a>(&'a self, token: &'a str, method: &'static str, body: Value)
@@ -44,13 +50,11 @@ impl Transport for ReqwestTransport {
                 .send()
                 .await
                 .map_err(|_| anyhow::anyhow!("Telegram {method} request failed"))?;
-            if !response.status().is_success() {
-                bail!("Telegram {method} returned HTTP {}", response.status());
-            }
-            response
-                .json()
-                .await
-                .map_err(|_| anyhow::anyhow!("Telegram {method} returned invalid JSON"))
+            let status = response.status().as_u16();
+            let body = response.json().await.map_err(|_| {
+                anyhow::anyhow!("Telegram {method} returned HTTP {status} with invalid JSON")
+            })?;
+            Ok(TransportResponse { status, body })
         })
     }
 }
@@ -106,7 +110,7 @@ impl Telegram {
     }
 
     async fn get_updates(&self, offset: i64, timeout: u64) -> Result<Vec<RawMessage>> {
-        let value = self
+        let transport_response = self
             .transport
             .post(
                 &self.token,
@@ -118,10 +122,13 @@ impl Telegram {
                 }),
             )
             .await?;
-        let response: ApiResponse<Vec<Update>> = serde_json::from_value(value)
+        let response: ApiResponse<Vec<Update>> = serde_json::from_value(transport_response.body)
             .map_err(|_| anyhow::anyhow!("Telegram getUpdates returned an invalid response"))?;
         if !response.ok {
-            bail!("Telegram getUpdates was rejected by the Bot API");
+            bail!(
+                "Telegram getUpdates returned HTTP {}",
+                transport_response.status
+            );
         }
         Ok(response
             .result
@@ -144,8 +151,43 @@ impl Telegram {
                 .is_some_and(|id| self.allow_chat_ids.contains(&id))
     }
 
-    pub async fn send(&self, target: &str, text: &str) -> Result<()> {
-        let value = self
+    pub async fn send_rich(&self, target: &str, text: &str) -> Result<()> {
+        let transport_response = self
+            .transport
+            .post(
+                &self.token,
+                "sendRichMessage",
+                json!({
+                    "chat_id": target,
+                    "rich_message": {"markdown": text}
+                }),
+            )
+            .await?;
+        let response: ApiResponse<Value> = serde_json::from_value(transport_response.body)
+            .map_err(|_| {
+                anyhow::anyhow!("Telegram sendRichMessage returned an invalid response")
+            })?;
+        if !response.ok {
+            if transport_response.status == 400 {
+                return self.send_plain_chunks(target, text).await;
+            }
+            bail!(
+                "Telegram sendRichMessage returned HTTP {}",
+                transport_response.status
+            );
+        }
+        Ok(())
+    }
+
+    async fn send_plain_chunks(&self, target: &str, text: &str) -> Result<()> {
+        for chunk in split_text(text) {
+            self.send_plain(target, &chunk).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn send_plain(&self, target: &str, text: &str) -> Result<()> {
+        let transport_response = self
             .transport
             .post(
                 &self.token,
@@ -153,16 +195,19 @@ impl Telegram {
                 json!({"chat_id": target, "text": text}),
             )
             .await?;
-        let response: ApiResponse<Value> = serde_json::from_value(value)
+        let response: ApiResponse<Value> = serde_json::from_value(transport_response.body)
             .map_err(|_| anyhow::anyhow!("Telegram sendMessage returned an invalid response"))?;
         if !response.ok {
-            bail!("Telegram sendMessage was rejected by the Bot API");
+            bail!(
+                "Telegram sendMessage returned HTTP {}",
+                transport_response.status
+            );
         }
         Ok(())
     }
 
     pub async fn send_typing(&self, target: &str) -> Result<()> {
-        let value = self
+        let transport_response = self
             .transport
             .post(
                 &self.token,
@@ -170,10 +215,13 @@ impl Telegram {
                 json!({"chat_id": target, "action": "typing"}),
             )
             .await?;
-        let response: ApiResponse<Value> = serde_json::from_value(value)
+        let response: ApiResponse<Value> = serde_json::from_value(transport_response.body)
             .map_err(|_| anyhow::anyhow!("Telegram sendChatAction returned an invalid response"))?;
         if !response.ok {
-            bail!("Telegram sendChatAction was rejected by the Bot API");
+            bail!(
+                "Telegram sendChatAction returned HTTP {}",
+                transport_response.status
+            );
         }
         Ok(())
     }
@@ -275,14 +323,31 @@ mod tests {
     #[derive(Default)]
     struct FakeTransport {
         calls: Mutex<Vec<(String, Value)>>,
-        responses: Mutex<VecDeque<Value>>,
+        responses: Mutex<VecDeque<TransportResponse>>,
     }
 
     impl FakeTransport {
         fn with_responses(responses: Vec<Value>) -> Self {
             Self {
                 calls: Mutex::new(Vec::new()),
-                responses: Mutex::new(responses.into()),
+                responses: Mutex::new(
+                    responses
+                        .into_iter()
+                        .map(|body| TransportResponse { status: 200, body })
+                        .collect(),
+                ),
+            }
+        }
+
+        fn with_status_responses(responses: Vec<(u16, Value)>) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                responses: Mutex::new(
+                    responses
+                        .into_iter()
+                        .map(|(status, body)| TransportResponse { status, body })
+                        .collect(),
+                ),
             }
         }
     }
@@ -423,7 +488,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_path_posts_chat_and_text_without_token_in_payload() {
+    async fn send_path_posts_rich_markdown_without_token_in_payload() {
         let fake = Arc::new(FakeTransport::with_responses(vec![json!({
             "ok": true,
             "result": {}
@@ -431,17 +496,59 @@ mod tests {
         let telegram =
             Telegram::with_transport("do-not-log".to_string(), vec![7], vec![], fake.clone());
 
-        telegram.send("7", "reply").await.unwrap();
+        telegram.send_rich("7", "reply").await.unwrap();
 
         let calls = fake.calls.lock().unwrap();
         assert_eq!(
             calls.as_slice(),
             [(
-                "sendMessage".to_string(),
-                json!({"chat_id": "7", "text": "reply"})
+                "sendRichMessage".to_string(),
+                json!({
+                    "chat_id": "7",
+                    "rich_message": {"markdown": "reply"}
+                })
             )]
         );
         assert!(!calls[0].1.to_string().contains("do-not-log"));
+    }
+
+    #[tokio::test]
+    async fn rejected_rich_markdown_falls_back_to_plain_chunks() {
+        let fake = Arc::new(FakeTransport::with_status_responses(vec![
+            (400, json!({"ok": false, "error_code": 400})),
+            (200, json!({"ok": true, "result": {}})),
+            (200, json!({"ok": true, "result": {}})),
+        ]));
+        let telegram =
+            Telegram::with_transport("secret".to_string(), vec![7], vec![], fake.clone());
+        let text = format!("{}é", "x".repeat(TEXT_LIMIT));
+
+        telegram.send_rich("7", &text).await.unwrap();
+
+        let calls = fake.calls.lock().unwrap();
+        assert_eq!(calls[0].0, "sendRichMessage");
+        assert_eq!(calls[1].0, "sendMessage");
+        assert_eq!(calls[2].0, "sendMessage");
+        assert_eq!(
+            calls[1..]
+                .iter()
+                .map(|(_, body)| body["text"].as_str().unwrap())
+                .collect::<String>(),
+            text
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_preserves_http_conflict_status() {
+        let fake = Arc::new(FakeTransport::with_status_responses(vec![(
+            409,
+            json!({"ok": false, "error_code": 409}),
+        )]));
+        let telegram = Telegram::with_transport("secret".to_string(), vec![7], vec![], fake);
+
+        let error = telegram.poll(0).await.unwrap_err();
+
+        assert!(error.to_string().contains("HTTP 409"));
     }
 
     #[tokio::test]
@@ -477,7 +584,7 @@ mod tests {
         let text = format!("{}é", "a".repeat(TEXT_LIMIT));
 
         for chunk in split_text(&text) {
-            telegram.send("7", &chunk).await.unwrap();
+            telegram.send_plain("7", &chunk).await.unwrap();
         }
 
         let calls = fake.calls.lock().unwrap();

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -160,6 +160,23 @@ impl Telegram {
         }
         Ok(())
     }
+
+    pub async fn send_typing(&self, target: &str) -> Result<()> {
+        let value = self
+            .transport
+            .post(
+                &self.token,
+                "sendChatAction",
+                json!({"chat_id": target, "action": "typing"}),
+            )
+            .await?;
+        let response: ApiResponse<Value> = serde_json::from_value(value)
+            .map_err(|_| anyhow::anyhow!("Telegram sendChatAction returned an invalid response"))?;
+        if !response.ok {
+            bail!("Telegram sendChatAction was rejected by the Bot API");
+        }
+        Ok(())
+    }
 }
 
 #[derive(Deserialize)]
@@ -422,6 +439,28 @@ mod tests {
             [(
                 "sendMessage".to_string(),
                 json!({"chat_id": "7", "text": "reply"})
+            )]
+        );
+        assert!(!calls[0].1.to_string().contains("do-not-log"));
+    }
+
+    #[tokio::test]
+    async fn typing_path_posts_chat_action_without_token_in_payload() {
+        let fake = Arc::new(FakeTransport::with_responses(vec![json!({
+            "ok": true,
+            "result": true
+        })]));
+        let telegram =
+            Telegram::with_transport("do-not-log".to_string(), vec![7], vec![], fake.clone());
+
+        telegram.send_typing("7").await.unwrap();
+
+        let calls = fake.calls.lock().unwrap();
+        assert_eq!(
+            calls.as_slice(),
+            [(
+                "sendChatAction".to_string(),
+                json!({"chat_id": "7", "action": "typing"})
             )]
         );
         assert!(!calls[0].1.to_string().contains("do-not-log"));


### PR DESCRIPTION
## Summary

- send Telegram typing chat actions immediately and every four seconds while an agent runs
- log accepted messages, backend execution, completion, reply length, and successful delivery without content or credentials
- omit the iMessage-only sent-by-push footer from Telegram replies
- send replies up to 32,768 characters as native Telegram Rich Markdown
- use ordered 4,096-character plain chunks for larger replies and as a safe HTTP 400 formatting fallback

## Why

Telegram users had no visible indication that a request was being processed, successful gateway work was silent in local logs, and replies displayed raw Markdown plus an unnecessary transport footer.

## Test plan

- cargo fmt --check
- git diff --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --locked (95 passed)
- focused typing request, refresh, stop, and stalled-request cancellation tests
- focused Rich Markdown payload, Markdown boundary, rejection fallback, Unicode reconstruction, and HTTP 409 diagnostic tests
- independent review with all findings resolved

## Risks

Typing updates are best effort and cannot delay the agent response. Rich formatting retries as plain chunks only after an explicit HTTP 400 rejection; network, auth, rate-limit, conflict, and server failures are not retried. Replies larger than the rich-message limit intentionally lose formatting to preserve exact content and safe delivery. iMessage formatting and its loop-prevention footer remain unchanged.

## Related issue

None.