### PR TITLE
feat(telegram): support private-chat topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,10 @@ agent = "claude"
 
 iMessage thread keys are `imessage:self:<handle>` and
 `imessage:dm:<handle>`. Telegram private-chat keys are
-`telegram:dm:<chat_id>`. Legacy unqualified iMessage route keys remain accepted.
+`telegram:dm:<chat_id>`. Private-chat topic keys append
+`:topic:<topic_id>`; topic routes inherit the parent private-chat route unless
+an exact topic route is configured. Legacy unqualified iMessage route keys
+remain accepted.
 
 push reads TOML only. Convert any earlier `config.json` file to `config.toml`
 before upgrading. The old JSON filename remains gitignored to reduce the risk

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -65,15 +65,18 @@ An incoming Telegram update reaches the agent only when all of these are true:
   is in `telegram.allow_chat_ids`
 - the text is not empty
 
-Group chats, channels, forum topics, edited messages, and other update types are
-out of scope and ignored. The private-chat thread key is
-`telegram:dm:<chat_id>`. Replies are sent to that same chat id.
+Group chats, channels, group forum topics, edited messages, and other update
+types are out of scope and ignored. The private-chat thread key is
+`telegram:dm:<chat_id>`. A private-chat topic uses
+`telegram:dm:<chat_id>:topic:<topic_id>` and replies target that topic.
 
 A route with `"channel": "telegram"` selects a backend for all accepted
 Telegram messages. An exact `"thread": "telegram:dm:<chat_id>"` route takes
-priority over a channel route. The default `agent` applies when no route
-matches. iMessage keys include the `imessage:` prefix, so identical numeric or
-text identifiers cannot share Telegram session state.
+priority over a channel route and is inherited by its private-chat topics. An
+exact topic route takes priority over the parent chat route. The default
+`agent` applies when no route matches. iMessage keys include the `imessage:`
+prefix, so identical numeric or text identifiers cannot share Telegram session
+state.
 
 ## Cursor and Restart Behavior
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -265,6 +265,7 @@ mod tests {
             text: "secret request".to_string(),
             is_from_me: false,
             is_supported: true,
+            thread_id: None,
         }
     }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -18,6 +18,8 @@ pub struct RawMessage {
     pub text: String,
     pub is_from_me: bool,
     pub is_supported: bool,
+    /// Channel-specific thread/topic id (Telegram `message_thread_id`).
+    pub thread_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -89,6 +91,7 @@ impl Channel {
                         text: message.text,
                         is_from_me: message.is_from_me,
                         is_supported: true,
+                        thread_id: None,
                     })
                     .collect())
             }
@@ -136,12 +139,20 @@ impl Channel {
                 }
                 None
             }
-            Self::Telegram(telegram) => telegram.is_allowed(message).then(|| {
-                (
-                    format!("telegram:dm:{}", message.chat_identifier),
-                    message.chat_identifier.clone(),
-                )
-            }),
+            Self::Telegram(telegram) => {
+                telegram
+                    .is_allowed(message)
+                    .then(|| match message.thread_id {
+                        Some(topic) => (
+                            format!("telegram:dm:{}:topic:{topic}", message.chat_identifier),
+                            format!("{}:{topic}", message.chat_identifier),
+                        ),
+                        None => (
+                            format!("telegram:dm:{}", message.chat_identifier),
+                            message.chat_identifier.clone(),
+                        ),
+                    })
+            }
         }
     }
 
@@ -261,6 +272,7 @@ mod tests {
             text: "hello".to_string(),
             is_from_me: false,
             is_supported: true,
+            thread_id: None,
         }
     }
 
@@ -274,6 +286,16 @@ mod tests {
         assert_eq!(
             telegram().accept(&telegram_message(8, 9, false)),
             Some(("telegram:dm:9".to_string(), "9".to_string()))
+        );
+    }
+
+    #[test]
+    fn telegram_topic_message_gets_its_own_thread_key_and_target() {
+        let mut message = telegram_message(7, 7, false);
+        message.thread_id = Some(99);
+        assert_eq!(
+            telegram().accept(&message),
+            Some(("telegram:dm:7:topic:99".to_string(), "7:99".to_string()))
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,11 +137,18 @@ impl Config {
 
     pub fn agent_for_message(&self, channel: &str, thread: &str) -> Result<AgentBackend> {
         for route in self.routes.iter().filter(|route| route.thread.is_some()) {
-            if route.matches(channel, thread) {
+            if route.matches_thread(channel, thread) {
                 return AgentBackend::parse(&route.agent);
             }
         }
-        for route in &self.routes {
+        if let Some(parent) = telegram_parent_thread(channel, thread) {
+            for route in self.routes.iter().filter(|route| route.thread.is_some()) {
+                if route.matches_thread(channel, parent) {
+                    return AgentBackend::parse(&route.agent);
+                }
+            }
+        }
+        for route in self.routes.iter().filter(|route| route.thread.is_none()) {
             if route.matches(channel, thread) {
                 return AgentBackend::parse(&route.agent);
             }
@@ -299,11 +306,11 @@ impl RouteRule {
         self.channel.as_deref().is_none_or(|value| value == channel)
     }
 
-    fn matches(&self, channel: &str, thread: &str) -> bool {
+    fn matches_thread(&self, channel: &str, thread: &str) -> bool {
         if !self.can_match_channel(channel) {
             return false;
         }
-        self.thread.as_deref().is_none_or(|value| {
+        self.thread.as_deref().is_some_and(|value| {
             value == thread
                 || (channel == "imessage"
                     && thread
@@ -311,6 +318,21 @@ impl RouteRule {
                         .is_some_and(|legacy| legacy == value))
         })
     }
+
+    fn matches(&self, channel: &str, thread: &str) -> bool {
+        if !self.can_match_channel(channel) {
+            return false;
+        }
+        self.thread
+            .as_deref()
+            .is_none_or(|_| self.matches_thread(channel, thread))
+    }
+}
+
+fn telegram_parent_thread<'a>(channel: &str, thread: &'a str) -> Option<&'a str> {
+    (channel == "telegram")
+        .then(|| thread.rsplit_once(":topic:").map(|(parent, _)| parent))
+        .flatten()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1004,6 +1004,7 @@ mod tests {
             is_from_me: from_me,
             is_group: false,
             is_supported: true,
+            thread_id: None,
         }
     }
 
@@ -1503,6 +1504,59 @@ mod tests {
         let _ = std::fs::remove_dir_all(assistant_dir);
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn telegram_topic_gets_own_thread_and_reply_targets_the_topic() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("telegram-topic-sessions");
+        let assistant_dir = temp_path("telegram-topic-assistant");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut cfg = test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        );
+        cfg.channel = "telegram".to_string();
+        cfg.self_handles.clear();
+        cfg.allow_from.clear();
+        cfg.telegram_bot_token = Some("secret".to_string());
+        cfg.telegram_allow_user_ids = vec![7];
+        let mut gateway = Gateway::new(cfg).unwrap();
+        gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+
+        let mut topic_message = telegram_message(20, 7, 7, false, "in topic");
+        topic_message.thread_id = Some(99);
+        let mut handles = Vec::new();
+        gateway
+            .tick_fake(
+                vec![topic_message, telegram_message(21, 7, 7, false, "in main")],
+                &mut handles,
+            )
+            .await;
+        gateway.queues.clear();
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert_eq!(calls.lock().unwrap().len(), 2);
+        assert!(calls.lock().unwrap().iter().all(|call| call.is_new));
+        let replies = gateway.ctx.sent_replies.lock().unwrap().clone();
+        assert!(replies.contains(&("7:99".to_string(), "fake reply: in topic".to_string())));
+        assert!(replies.contains(&("7".to_string(), "fake reply: in main".to_string())));
+        let events = audit_events(&format!("{state_path}.audit.jsonl"));
+        assert!(events.iter().any(|e| {
+            e.event == "message_accepted" && e.thread.as_deref() == Some("telegram:dm:7:topic:99")
+        }));
+        assert!(events.iter().any(|e| {
+            e.event == "message_accepted" && e.thread.as_deref() == Some("telegram:dm:7")
+        }));
+
+        let _ = std::fs::remove_file(&state_path);
+        let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+        let _ = std::fs::remove_dir_all(sessions_dir);
+        let _ = std::fs::remove_dir_all(assistant_dir);
+    }
+
     fn test_config(state_path: &str, sessions_dir: &str, assistant_dir: &str) -> Config {
         Config {
             channel: "imessage".to_string(),
@@ -1567,6 +1621,7 @@ mod tests {
             is_from_me,
             is_group: false,
             is_supported: true,
+            thread_id: None,
         }
     }
 
@@ -1586,6 +1641,7 @@ mod tests {
             is_from_me: false,
             is_group,
             is_supported: true,
+            thread_id: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -692,6 +692,11 @@ tools = ["Read", "Grep"]
                 agent: "claude".to_string(),
             },
             config::RouteRule {
+                thread: Some("telegram:dm:7:topic:99".to_string()),
+                channel: None,
+                agent: "codex".to_string(),
+            },
+            config::RouteRule {
                 thread: Some("self:me@icloud.com".to_string()),
                 channel: None,
                 agent: "codex".to_string(),
@@ -705,6 +710,16 @@ tools = ["Read", "Grep"]
         assert_eq!(
             cfg.agent_for_message("telegram", "telegram:dm:8").unwrap(),
             config::AgentBackend::Codex
+        );
+        assert_eq!(
+            cfg.agent_for_message("telegram", "telegram:dm:7:topic:99")
+                .unwrap(),
+            config::AgentBackend::Codex
+        );
+        assert_eq!(
+            cfg.agent_for_message("telegram", "telegram:dm:7:topic:100")
+                .unwrap(),
+            config::AgentBackend::Claude
         );
         assert_eq!(
             cfg.agent_for_message("imessage", "imessage:self:me@icloud.com")

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -152,16 +152,10 @@ impl Telegram {
     }
 
     pub async fn send_rich(&self, target: &str, text: &str) -> Result<()> {
+        let mut payload = target_payload(target);
+        payload["rich_message"] = json!({"markdown": text});
         let transport_response = self
-            .transport
-            .post(
-                &self.token,
-                "sendRichMessage",
-                json!({
-                    "chat_id": target,
-                    "rich_message": {"markdown": text}
-                }),
-            )
+            .post_with_topic_fallback("sendRichMessage", payload)
             .await?;
         let response: ApiResponse<Value> = serde_json::from_value(transport_response.body)
             .map_err(|_| {
@@ -187,13 +181,10 @@ impl Telegram {
     }
 
     pub async fn send_plain(&self, target: &str, text: &str) -> Result<()> {
+        let mut payload = target_payload(target);
+        payload["text"] = json!(text);
         let transport_response = self
-            .transport
-            .post(
-                &self.token,
-                "sendMessage",
-                json!({"chat_id": target, "text": text}),
-            )
+            .post_with_topic_fallback("sendMessage", payload)
             .await?;
         let response: ApiResponse<Value> = serde_json::from_value(transport_response.body)
             .map_err(|_| anyhow::anyhow!("Telegram sendMessage returned an invalid response"))?;
@@ -207,13 +198,10 @@ impl Telegram {
     }
 
     pub async fn send_typing(&self, target: &str) -> Result<()> {
+        let mut payload = target_payload(target);
+        payload["action"] = json!("typing");
         let transport_response = self
-            .transport
-            .post(
-                &self.token,
-                "sendChatAction",
-                json!({"chat_id": target, "action": "typing"}),
-            )
+            .post_with_topic_fallback("sendChatAction", payload)
             .await?;
         let response: ApiResponse<Value> = serde_json::from_value(transport_response.body)
             .map_err(|_| anyhow::anyhow!("Telegram sendChatAction returned an invalid response"))?;
@@ -224,6 +212,63 @@ impl Telegram {
             );
         }
         Ok(())
+    }
+
+    /// Posts the payload, retrying once without `message_thread_id` when
+    /// Telegram rejects a private-chat topic send with "message thread not
+    /// found", for example when a topic is stale or unavailable. The retry
+    /// lands the reply in the main chat view instead of losing it.
+    async fn post_with_topic_fallback(
+        &self,
+        method: &'static str,
+        mut payload: Value,
+    ) -> Result<TransportResponse> {
+        let response = self
+            .transport
+            .post(&self.token, method, payload.clone())
+            .await?;
+        let ok = response
+            .body
+            .get("ok")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let thread_missing = response
+            .body
+            .get("description")
+            .and_then(Value::as_str)
+            .is_some_and(|d| d.contains("message thread not found"));
+        if ok
+            || response.status != 400
+            || !thread_missing
+            || payload.get("message_thread_id").is_none()
+        {
+            return Ok(response);
+        }
+        if let Some(obj) = payload.as_object_mut() {
+            obj.remove("message_thread_id");
+        }
+        self.transport.post(&self.token, method, payload).await
+    }
+}
+
+/// Builds the send payload for a reply target. `Channel::accept` encodes
+/// topic targets as `"{chat_id}:{topic_id}"`; plain targets are the chat id.
+fn target_payload(target: &str) -> Value {
+    let (chat, topic) = split_target(target);
+    let mut payload = json!({"chat_id": chat});
+    if let Some(topic) = topic {
+        payload["message_thread_id"] = json!(topic);
+    }
+    payload
+}
+
+fn split_target(target: &str) -> (&str, Option<i64>) {
+    match target.split_once(':') {
+        Some((chat, topic)) => match topic.parse::<i64>() {
+            Ok(topic) => (chat, Some(topic)),
+            Err(_) => (target, None),
+        },
+        None => (target, None),
     }
 }
 
@@ -253,6 +298,7 @@ impl Update {
                 text: String::new(),
                 is_from_me: false,
                 is_supported: false,
+                thread_id: None,
             };
         };
         RawMessage {
@@ -267,6 +313,7 @@ impl Update {
             text: message.text.unwrap_or_default(),
             is_from_me: false,
             is_supported: true,
+            thread_id: message.message_thread_id,
         }
     }
 }
@@ -278,6 +325,8 @@ struct TelegramMessage {
     chat: Chat,
     #[serde(default)]
     text: Option<String>,
+    #[serde(default)]
+    message_thread_id: Option<i64>,
 }
 
 #[derive(Deserialize)]
@@ -390,7 +439,17 @@ mod tests {
                         "text": "group"
                     }
                 },
-                {"update_id": 103, "edited_message": {}}
+                {"update_id": 103, "edited_message": {}},
+                {
+                    "update_id": 104,
+                    "message": {
+                        "from": {"id": 7},
+                        "chat": {"id": 7, "type": "private"},
+                        "text": "in a topic",
+                        "message_thread_id": 99,
+                        "is_topic_message": true
+                    }
+                }
             ]
         })
     }
@@ -402,13 +461,16 @@ mod tests {
 
         let messages = telegram.poll(100).await.unwrap();
 
-        assert_eq!(messages.len(), 3);
+        assert_eq!(messages.len(), 4);
         assert_eq!(messages[0].row_id, 101);
         assert_eq!(messages[0].handle, "7");
         assert_eq!(messages[0].chat_identifier, "7");
         assert!(!messages[0].is_group);
+        assert_eq!(messages[0].thread_id, None);
         assert!(messages[1].is_group);
         assert!(!messages[2].is_supported);
+        assert_eq!(messages[3].thread_id, Some(99));
+        assert!(!messages[3].is_group);
     }
 
     #[tokio::test]
@@ -436,7 +498,7 @@ mod tests {
 
         let cursor = telegram.latest_cursor().await.unwrap();
 
-        assert_eq!(cursor, 103);
+        assert_eq!(cursor, 104);
         let calls = fake.calls.lock().unwrap();
         assert_eq!(calls[0].1["offset"], -1);
         assert_eq!(calls[0].1["timeout"], 0);
@@ -454,6 +516,7 @@ mod tests {
                     kind: "private".to_string(),
                 },
                 text: Some("hi".to_string()),
+                message_thread_id: None,
             }),
         }
         .into_raw();
@@ -535,6 +598,104 @@ mod tests {
                 .map(|(_, body)| body["text"].as_str().unwrap())
                 .collect::<String>(),
             text
+        );
+    }
+
+    #[tokio::test]
+    async fn topic_target_sends_message_thread_id() {
+        let fake = Arc::new(FakeTransport::with_responses(vec![
+            json!({"ok": true, "result": {}}),
+            json!({"ok": true, "result": {}}),
+            json!({"ok": true, "result": true}),
+        ]));
+        let telegram =
+            Telegram::with_transport("secret".to_string(), vec![7], vec![], fake.clone());
+
+        telegram.send_plain("7:99", "reply").await.unwrap();
+        telegram.send_rich("7:99", "reply").await.unwrap();
+        telegram.send_typing("7:99").await.unwrap();
+
+        let calls = fake.calls.lock().unwrap();
+        assert_eq!(
+            calls[0].1,
+            json!({"chat_id": "7", "message_thread_id": 99, "text": "reply"})
+        );
+        assert_eq!(
+            calls[1].1,
+            json!({
+                "chat_id": "7",
+                "message_thread_id": 99,
+                "rich_message": {"markdown": "reply"}
+            })
+        );
+        assert_eq!(
+            calls[2].1,
+            json!({"chat_id": "7", "message_thread_id": 99, "action": "typing"})
+        );
+    }
+
+    #[tokio::test]
+    async fn topic_send_retries_without_thread_id_on_thread_not_found() {
+        let fake = Arc::new(FakeTransport::with_status_responses(vec![
+            (
+                400,
+                json!({
+                    "ok": false,
+                    "error_code": 400,
+                    "description": "Bad Request: message thread not found"
+                }),
+            ),
+            (200, json!({"ok": true, "result": {}})),
+        ]));
+        let telegram =
+            Telegram::with_transport("secret".to_string(), vec![7], vec![], fake.clone());
+
+        telegram.send_plain("7:99", "reply").await.unwrap();
+
+        let calls = fake.calls.lock().unwrap();
+        assert_eq!(
+            calls.as_slice(),
+            [
+                (
+                    "sendMessage".to_string(),
+                    json!({"chat_id": "7", "message_thread_id": 99, "text": "reply"})
+                ),
+                (
+                    "sendMessage".to_string(),
+                    json!({"chat_id": "7", "text": "reply"})
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn topic_send_does_not_retry_other_400s_and_rich_still_falls_back() {
+        let fake = Arc::new(FakeTransport::with_status_responses(vec![(
+            400,
+            json!({"ok": false, "error_code": 400, "description": "Bad Request: chat not found"}),
+        )]));
+        let telegram =
+            Telegram::with_transport("secret".to_string(), vec![7], vec![], fake.clone());
+
+        let error = telegram.send_plain("7:99", "reply").await.unwrap_err();
+
+        assert!(error.to_string().contains("HTTP 400"));
+        assert_eq!(fake.calls.lock().unwrap().len(), 1);
+
+        let fake = Arc::new(FakeTransport::with_status_responses(vec![
+            (400, json!({"ok": false, "error_code": 400})),
+            (200, json!({"ok": true, "result": {}})),
+        ]));
+        let telegram =
+            Telegram::with_transport("secret".to_string(), vec![7], vec![], fake.clone());
+
+        telegram.send_rich("7:99", "reply").await.unwrap();
+
+        let calls = fake.calls.lock().unwrap();
+        assert_eq!(calls[0].0, "sendRichMessage");
+        assert_eq!(
+            calls[1].1,
+            json!({"chat_id": "7", "message_thread_id": 99, "text": "reply"})
         );
     }
 


### PR DESCRIPTION
## Summary

- preserve Telegram private-chat topic ids from updates
- isolate backend sessions per topic and reply into the originating topic
- fall back to the main private chat when Telegram reports a stale or unavailable topic
- preserve existing per-chat routes, with exact topic routes taking precedence
- document topic routing and scope

## Why

Telegram private chats can carry `message_thread_id`. Treating every message as the main chat mixed topic sessions and sent feedback or replies to the wrong place.

## Test plan

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (101 passed)
- `git diff --check`
- independent review completed; exact-route compatibility finding fixed and re-tested

## Risks

Private-chat topics are supported. Group chats and group forum topics remain out of scope. If Telegram rejects a stale topic id, the reply deliberately falls back to the main private chat rather than being lost.

## Related issue

None.