### PR TITLE
feat: persist canonical conversation history

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ iMessage or Telegram -> push gateway -> Claude Code or Codex -> same-channel rep
 
 1. Poll `~/Library/Messages/chat.db` or the Telegram Bot API for new messages.
 2. Keep only messages from yourself or configured allowed senders.
-3. Map each conversation to the active backend session.
-4. Load your assistant identity from `~/.push/SOUL.md`.
-5. Run the configured backend headlessly.
-6. Send the final answer back to the originating channel and conversation.
+3. Store the accepted message in `~/.push/push.db`.
+4. Map each conversation to the active backend session.
+5. Load your assistant identity from `~/.push/SOUL.md`.
+6. Run the configured backend headlessly.
+7. Store the generated reply, then deliver it to the originating conversation.
 
 Identity is plain Markdown you own. The gateway injects it into each run, so
 you can read it, edit it, and version it without learning a custom format.
@@ -132,6 +133,15 @@ formatting, and email handles are matched case-insensitively.
 restart, push resumes after the last completed row and keeps existing backend
 sessions when the selected backend has not changed.
 
+`push.db` is the canonical conversation journal. It stores accepted inbound
+messages before command or backend work, and stores generated outbound messages
+before delivery. Channel event IDs make inbound retries idempotent, while one
+outbound row per inbound turn prevents a restart from generating a second
+assistant response. Cursors and backend session IDs remain in `state.json`.
+If the process stops after a channel accepts a reply but before SQLite records
+delivery, restart may resend the same stored reply; it still does not generate
+a different second response.
+
 ## Telegram Support
 
 Telegram uses Bot API long polling, so push opens no public port and needs no
@@ -204,6 +214,7 @@ codex_sandbox = "workspace-write"
 codex_approval_policy = "never"
 audit_log_path = "~/.push/audit.jsonl"
 audit_log_content = false
+database_path = "~/.push/push.db"
 assistant_dir = "~/.push"
 
 [imessage]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,8 @@ own the durable pieces:
 - allowlists
 - routing
 - assistant identity
-- conversation state
+- canonical conversation history
+- cursor and backend-session state
 - delivery
 
 ### 2. Runtime Disposable
@@ -62,6 +63,7 @@ flowchart LR
         poller[Channel poller] --> gateway[Gateway loop]
         gateway --> worker[Per-thread worker]
         store[(state.json)] <--> gateway
+        history[(push.db)] <--> gateway
         soul[/SOUL.md/] --> worker
         worker --> adapter[Agent adapter]
     end
@@ -92,6 +94,7 @@ sequenceDiagram
     DB-->>P: messages
     P->>G: Message values
     G->>G: filter sender and reply marker
+    G->>G: persist accepted inbound message
     alt slash command
         G->>S: handle command locally
     else assistant turn
@@ -100,6 +103,7 @@ sequenceDiagram
         W->>W: resolve routed backend session
         W->>A: run prompt with context
         A-->>W: reply and optional backend session id
+        W->>W: persist generated outbound message
         W->>S: send reply
         W->>G: ack completed row
     end
@@ -176,6 +180,15 @@ now means "backend session id".
 
 If the configured backend changes for a thread, push starts a fresh backend
 session instead of trying to resume the old runtime's session.
+
+`push.db` stores channel-qualified conversations and their inbound and outbound
+messages. Accepted inbound messages are inserted before gateway commands or
+backend dispatch. Generated backend, command, and error replies are inserted
+before delivery, with generation and delivery state tracked separately. A
+unique channel event ID makes inbound retries idempotent, and a unique link from
+each inbound message to its outbound response preserves the generation/delivery
+crash boundary. SQLite history does not replace `state.json` cursors or backend
+session IDs in this phase.
 
 `audit_log_path` stores a local JSONL event stream for production debugging.
 Audit events record message metadata, routing decisions, backend run starts and

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -82,6 +82,7 @@ push takes a narrower bet:
 - `src/imessage/poller.rs`: reads Messages rows.
 - `src/imessage/sender.rs`: sends replies through AppleScript.
 - `src/gateway.rs`: poll loop, filtering, commands, queues, worker dispatch.
+- `src/history.rs`: canonical SQLite conversations and messages.
 - `src/agent.rs`: backend boundary.
 - `src/claude.rs`: Claude Code adapter.
 - `src/codex.rs`: Codex adapter.
@@ -151,6 +152,7 @@ user prompt.
 | `state_path` | JSON state path. |
 | `audit_log_path` | Local JSONL audit log path. |
 | `audit_log_content` | Whether audit events include message and reply text. |
+| `database_path` | Canonical SQLite history path; defaults to `~/.push/push.db`. |
 | `assistant_dir` | Directory with `SOUL.md`; defaults to `~/.push`. |
 | `reply_marker` | Footer used to skip push's own replies. |
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -21,6 +21,7 @@ Use absolute paths in service files. The service user needs:
 - access to the configured `config.toml`
 - write access to `state_path`
 - write access to `audit_log_path`
+- write access to `database_path`
 - write access to `sessions_dir`
 - read access to `assistant_dir/SOUL.md` when custom identity is configured
 - access to `claude` or `codex` on `PATH`
@@ -31,7 +32,8 @@ Use absolute paths in service files. The service user needs:
 
 `state_path` stores independent cursors for each channel. `sessions_dir` stores
 per-thread backend work directories, and `state.json` stores backend session
-ids. Keep both paths on durable storage. Restarting the service resumes after
+ids. `database_path` stores the canonical conversation journal. Keep these
+paths on durable storage. Restarting the service resumes after
 the last completed row and reuses existing backend sessions when the backend for
 that thread has not changed.
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -80,7 +80,9 @@ state.
 
 ## Cursor and Restart Behavior
 
-`state.json` stores independent `imessage` and `telegram` cursors. On the first
+`state.json` stores independent `imessage` and `telegram` cursors. `push.db`
+stores channel-qualified canonical conversations, so Telegram and iMessage
+history cannot collide. On the first
 Telegram start, push asks Telegram for the newest pending update and records its
 id without running it. This explicit backlog skip prevents old bot messages
 from unexpectedly starting agent work. Later accepted and ignored updates
@@ -101,6 +103,7 @@ Protect these files as credentials or private assistant data:
 
 - the bot token and configuration
 - `state.json` and the audit log
+- `push.db`
 - the session workspace directory
 - `assistant_dir/SOUL.md`
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -85,6 +85,7 @@ pub struct FakeRunner {
     pub backend: AgentBackend,
     pub session_id: String,
     pub calls: std::sync::Arc<std::sync::Mutex<Vec<FakeRunCall>>>,
+    pub before_return: Option<std::sync::Arc<dyn Fn() + Send + Sync>>,
 }
 
 #[cfg(test)]
@@ -103,6 +104,9 @@ impl FakeRunner {
             is_new: req.is_new,
             prompt: req.prompt.to_string(),
         });
+        if let Some(before_return) = &self.before_return {
+            before_return();
+        }
         Ok(RunOutput {
             reply: format!("fake reply: {}", req.prompt),
             session_id: req.is_new.then(|| self.session_id.clone()),

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -22,6 +22,12 @@ pub struct RawMessage {
     pub thread_id: Option<i64>,
 }
 
+impl RawMessage {
+    pub fn event_id(&self) -> String {
+        format!("{}:{}", self.channel, self.row_id)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutboundChunk {
     pub text: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,6 +56,8 @@ pub struct Config {
     pub state_path: String,
     #[serde(default = "default_audit_log_path")]
     pub audit_log_path: String,
+    #[serde(default = "default_database_path")]
+    pub database_path: String,
     #[serde(default)]
     pub audit_log_content: bool,
     #[serde(default = "default_assistant_dir")]
@@ -101,6 +103,7 @@ impl Config {
         c.sessions_dir = expand_home(&c.sessions_dir);
         c.state_path = expand_home(&c.state_path);
         c.audit_log_path = expand_home(&c.audit_log_path);
+        c.database_path = expand_home(&c.database_path);
         c.assistant_dir = expand_home(&c.assistant_dir);
         c.validate()?;
         Ok(c)
@@ -413,6 +416,9 @@ fn default_state_path() -> String {
 }
 fn default_audit_log_path() -> String {
     "~/.push/audit.jsonl".to_string()
+}
+fn default_database_path() -> String {
+    "~/.push/push.db".to_string()
 }
 fn default_assistant_dir() -> String {
     "~/.push".to_string()

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -23,6 +23,7 @@ use crate::channel::{Channel, RawMessage};
 use crate::claude;
 use crate::codex;
 use crate::config::{AgentBackend, Config};
+use crate::history::{DeliveryStatus, History, OutboundMessage, OutboundOrigin};
 use crate::soul;
 use crate::store::Store;
 
@@ -31,13 +32,16 @@ const QUEUE_DEPTH: usize = 32;
 const SEND_TIMEOUT: Duration = Duration::from_secs(30);
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(30);
 const TYPING_REFRESH: Duration = Duration::from_secs(4);
+const DELIVERY_ATTEMPTS: usize = 3;
 const SESSION_SETUP_FAILURE: &str =
     "Push could not prepare this conversation. Check the local logs, then resend.";
 const SANDBOX_SETUP_FAILURE: &str =
     "Push could not create its session workspace. Check the local logs, then resend.";
 
+#[derive(Clone)]
 struct Job {
     row_id: i64,
+    inbound_id: i64,
     thread: String,
     target: String,
     backend: AgentBackend,
@@ -48,6 +52,7 @@ struct Job {
 #[derive(Clone)]
 struct Ctx {
     store: Arc<Mutex<Store>>,
+    history: Arc<Mutex<History>>,
     ack: Arc<Mutex<AckState>>,
     runners: Arc<HashMap<AgentBackend, Runner>>,
     channel: Channel,
@@ -60,6 +65,8 @@ struct Ctx {
     setup_failure_replies: Arc<Mutex<Vec<String>>>,
     #[cfg(test)]
     sent_replies: Arc<Mutex<Vec<(String, String)>>>,
+    #[cfg(test)]
+    send_failures_remaining: Arc<Mutex<usize>>,
 }
 
 pub struct Gateway {
@@ -81,6 +88,9 @@ struct AckState {
 impl Gateway {
     pub fn new(cfg: Config) -> Result<Self> {
         let store = Arc::new(Mutex::new(Store::open(&cfg.state_path)?));
+        let history = Arc::new(Mutex::new(History::open(&cfg.database_path).with_context(
+            || format!("open canonical history database {}", cfg.database_path),
+        )?));
         let ack = Arc::new(Mutex::new(AckState::default()));
         let runners = Arc::new(runners(&cfg));
         let channel = Channel::new(&cfg)?;
@@ -91,6 +101,7 @@ impl Gateway {
         ));
         let ctx = Ctx {
             store: store.clone(),
+            history,
             ack: ack.clone(),
             runners,
             channel: channel.clone(),
@@ -103,6 +114,8 @@ impl Gateway {
             setup_failure_replies: Arc::new(Mutex::new(Vec::new())),
             #[cfg(test)]
             sent_replies: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(test)]
+            send_failures_remaining: Arc::new(Mutex::new(0)),
         };
         let poll_interval = cfg.poll_interval_dur()?;
         Ok(Self {
@@ -208,6 +221,29 @@ impl Gateway {
                 continue;
             }
             if let Some((thread, target)) = self.channel.accept(m) {
+                let inbound_id = match self.ctx.history.lock().unwrap().record_inbound(
+                    m.channel,
+                    &thread,
+                    &m.event_id(),
+                    m.text.trim(),
+                ) {
+                    Ok(id) => id,
+                    Err(error) => {
+                        error!(
+                            "[{}] canonical history write failed for event {}: {error}; message will be retried",
+                            thread,
+                            m.event_id()
+                        );
+                        self.audit(self.ctx.audit.failed(
+                            "message_history_failed",
+                            m.row_id,
+                            &thread,
+                            None,
+                            error.to_string(),
+                        ));
+                        return;
+                    }
+                };
                 let backend = match self.cfg.agent_for_message(m.channel, &thread) {
                     Ok(v) => v,
                     Err(e) => {
@@ -228,15 +264,17 @@ impl Gateway {
                     "[{thread}] new message accepted; routing to {}",
                     backend.as_str()
                 );
-                self.route(
-                    m.row_id,
+                let job = Job {
+                    row_id: m.row_id,
+                    inbound_id,
                     thread,
                     target,
                     backend,
-                    m.text.trim().to_string(),
-                    handles,
-                )
-                .await;
+                    text: m.text.trim().to_string(),
+                };
+                if !self.route(job, handles).await {
+                    return;
+                }
             } else {
                 self.audit(self.ctx.audit.ignored(m, self.channel.reject_reason(m)));
                 self.complete_row(m.row_id, "ignored");
@@ -247,15 +285,11 @@ impl Gateway {
         }
     }
 
-    async fn route(
-        &mut self,
-        row_id: i64,
-        thread: String,
-        target: String,
-        backend: AgentBackend,
-        text: String,
-        handles: &mut Vec<JoinHandle<()>>,
-    ) {
+    async fn route(&mut self, job: Job, handles: &mut Vec<JoinHandle<()>>) -> bool {
+        let row_id = job.row_id;
+        let thread = job.thread.clone();
+        let target = job.target.clone();
+        let backend = job.backend;
         if !self.queues.contains_key(&thread) {
             let (tx, rx) = mpsc::channel::<Job>(QUEUE_DEPTH);
             let ctx = self.ctx.clone();
@@ -263,18 +297,12 @@ impl Gateway {
             self.queues.insert(thread.clone(), tx);
         }
 
-        let job = Job {
-            row_id,
-            thread: thread.clone(),
-            target: target.clone(),
-            backend,
-            text,
-        };
         let full = matches!(
-            self.queues.get(&thread).unwrap().try_send(job),
+            self.queues.get(&thread).unwrap().try_send(job.clone()),
             Err(mpsc::error::TrySendError::Full(_))
         );
         if full {
+            self.ack.lock().unwrap().in_flight.insert(row_id);
             warn!("[{thread}] queue full, asking sender to resend");
             self.audit(self.ctx.audit.failed(
                 "message_queue_failed",
@@ -283,34 +311,35 @@ impl Gateway {
                 Some(backend),
                 "queue full",
             ));
-            if reply_to(
-                &self.ctx,
-                &target,
-                "I'm a bit behind on this thread - resend that in a moment.",
-            )
-            .await
-            {
-                self.audit(self.ctx.audit.reply_sent(
-                    row_id,
-                    &thread,
-                    &target,
-                    Some(backend),
-                    "I'm a bit behind on this thread - resend that in a moment.",
-                ));
-                self.complete_row(row_id, "queue_full");
-            } else {
-                self.audit(self.ctx.audit.reply_failed(
-                    row_id,
-                    &thread,
-                    &target,
-                    Some(backend),
-                    "queue full reply failed",
-                ));
-                self.complete_row(row_id, "queue_full_reply_failed");
+            let reply = "I'm a bit behind on this thread - resend that in a moment.";
+            match record_and_deliver(&self.ctx, &job, OutboundOrigin::Gateway, reply).await {
+                Ok(DeliveryOutcome::Delivered | DeliveryOutcome::AlreadyDelivered) => {
+                    self.audit(self.ctx.audit.reply_sent(
+                        row_id,
+                        &thread,
+                        &target,
+                        Some(backend),
+                        reply,
+                    ));
+                    self.complete_row(row_id, "queue_full");
+                }
+                Err(error) => {
+                    error!("[{thread}] canonical history write failed: {error}");
+                    self.audit(self.ctx.audit.failed(
+                        "message_history_failed",
+                        row_id,
+                        &thread,
+                        Some(backend),
+                        error.to_string(),
+                    ));
+                    self.ack.lock().unwrap().in_flight.remove(&row_id);
+                    return false;
+                }
             }
         } else {
             self.ack.lock().unwrap().in_flight.insert(row_id);
         }
+        true
     }
 
     fn complete_row(&self, row_id: i64, reason: &str) {
@@ -331,35 +360,55 @@ async fn worker(ctx: Ctx, mut rx: mpsc::Receiver<Job>) {
 }
 
 async fn handle(ctx: &Ctx, job: Job) {
+    let existing_outbound = { ctx.history.lock().unwrap().outbound_for(job.inbound_id) };
+    match existing_outbound {
+        Ok(Some(outbound)) => {
+            match deliver_stored(ctx, &job, &outbound).await {
+                Ok(DeliveryOutcome::Delivered | DeliveryOutcome::AlreadyDelivered) => {
+                    audit(
+                        ctx,
+                        ctx.audit.reply_sent(
+                            job.row_id,
+                            &job.thread,
+                            &job.target,
+                            Some(job.backend),
+                            &outbound.content,
+                        ),
+                    );
+                    complete_job(ctx, &job, "recovered_outbound");
+                }
+                Err(error) => history_error(ctx, &job, "recover outbound", error),
+            }
+            return;
+        }
+        Ok(None) => {}
+        Err(error) => {
+            history_error(ctx, &job, "read outbound", error);
+            return;
+        }
+    }
+
     if let Some(reply) = command(ctx, &job) {
-        if reply_to(ctx, &job.target, &reply).await {
-            info!(
-                "[{}] command reply sent via {}",
-                job.thread,
-                ctx.channel.id()
-            );
-            audit(
-                ctx,
-                ctx.audit.reply_sent(
-                    job.row_id,
-                    &job.thread,
-                    &job.target,
-                    Some(job.backend),
-                    &reply,
-                ),
-            );
-            complete_job(ctx, &job, "command");
-        } else {
-            audit(
-                ctx,
-                ctx.audit.reply_failed(
-                    job.row_id,
-                    &job.thread,
-                    &job.target,
-                    Some(job.backend),
-                    "command reply failed",
-                ),
-            );
+        match record_and_deliver(ctx, &job, OutboundOrigin::Gateway, &reply).await {
+            Ok(DeliveryOutcome::Delivered | DeliveryOutcome::AlreadyDelivered) => {
+                info!(
+                    "[{}] command reply sent via {}",
+                    job.thread,
+                    ctx.channel.id()
+                );
+                audit(
+                    ctx,
+                    ctx.audit.reply_sent(
+                        job.row_id,
+                        &job.thread,
+                        &job.target,
+                        Some(job.backend),
+                        &reply,
+                    ),
+                );
+                complete_job(ctx, &job, "command");
+            }
+            Err(error) => history_error(ctx, &job, "record command reply", error),
         }
         return;
     }
@@ -517,6 +566,18 @@ async fn handle(ctx: &Ctx, job: Job) {
                 ctx.audit
                     .backend_completed(job.row_id, &job.thread, job.backend, &out.reply),
             );
+            let outbound = match ctx.history.lock().unwrap().record_outbound(
+                job.inbound_id,
+                OutboundOrigin::Backend,
+                Some(job.backend.as_str()),
+                &out.reply,
+            ) {
+                Ok(outbound) => outbound,
+                Err(error) => {
+                    history_error(ctx, &job, "record backend reply", error);
+                    return;
+                }
+            };
             if let Err(e) = ctx
                 .store
                 .lock()
@@ -536,30 +597,22 @@ async fn handle(ctx: &Ctx, job: Job) {
                 );
                 return;
             }
-            if reply_to(ctx, &job.target, &out.reply).await {
-                info!("[{}] reply sent via {}", job.thread, ctx.channel.id());
-                audit(
-                    ctx,
-                    ctx.audit.reply_sent(
-                        job.row_id,
-                        &job.thread,
-                        &job.target,
-                        Some(job.backend),
-                        &out.reply,
-                    ),
-                );
-                complete_job(ctx, &job, "completed");
-            } else {
-                audit(
-                    ctx,
-                    ctx.audit.reply_failed(
-                        job.row_id,
-                        &job.thread,
-                        &job.target,
-                        Some(job.backend),
-                        "backend reply failed",
-                    ),
-                );
+            match deliver_stored(ctx, &job, &outbound).await {
+                Ok(DeliveryOutcome::Delivered | DeliveryOutcome::AlreadyDelivered) => {
+                    info!("[{}] reply sent via {}", job.thread, ctx.channel.id());
+                    audit(
+                        ctx,
+                        ctx.audit.reply_sent(
+                            job.row_id,
+                            &job.thread,
+                            &job.target,
+                            Some(job.backend),
+                            &out.reply,
+                        ),
+                    );
+                    complete_job(ctx, &job, "completed");
+                }
+                Err(error) => history_error(ctx, &job, "deliver backend reply", error),
             }
         }
         Err(RunError::Timeout) => {
@@ -574,35 +627,22 @@ async fn handle(ctx: &Ctx, job: Job) {
                     format!("{} run timed out", runner.label()),
                 ),
             );
-            if reply_to(
-                ctx,
-                &job.target,
-                "That took too long and was stopped. Try again or simplify the request.",
-            )
-            .await
-            {
-                audit(
-                    ctx,
-                    ctx.audit.reply_sent(
-                        job.row_id,
-                        &job.thread,
-                        &job.target,
-                        Some(job.backend),
-                        "That took too long and was stopped. Try again or simplify the request.",
-                    ),
-                );
-                complete_job(ctx, &job, "timeout");
-            } else {
-                audit(
-                    ctx,
-                    ctx.audit.reply_failed(
-                        job.row_id,
-                        &job.thread,
-                        &job.target,
-                        Some(job.backend),
-                        "timeout reply failed",
-                    ),
-                );
+            let reply = "That took too long and was stopped. Try again or simplify the request.";
+            match record_and_deliver(ctx, &job, OutboundOrigin::Gateway, reply).await {
+                Ok(DeliveryOutcome::Delivered | DeliveryOutcome::AlreadyDelivered) => {
+                    audit(
+                        ctx,
+                        ctx.audit.reply_sent(
+                            job.row_id,
+                            &job.thread,
+                            &job.target,
+                            Some(job.backend),
+                            reply,
+                        ),
+                    );
+                    complete_job(ctx, &job, "timeout");
+                }
+                Err(error) => history_error(ctx, &job, "record timeout reply", error),
             }
         }
         Err(RunError::Failed(msg)) => {
@@ -617,29 +657,22 @@ async fn handle(ctx: &Ctx, job: Job) {
                     msg.clone(),
                 ),
             );
-            if reply_to(ctx, &job.target, &format!("⚠️ {}", short(&msg))).await {
-                audit(
-                    ctx,
-                    ctx.audit.reply_sent(
-                        job.row_id,
-                        &job.thread,
-                        &job.target,
-                        Some(job.backend),
-                        &format!("⚠️ {}", short(&msg)),
-                    ),
-                );
-                complete_job(ctx, &job, "backend_failed");
-            } else {
-                audit(
-                    ctx,
-                    ctx.audit.reply_failed(
-                        job.row_id,
-                        &job.thread,
-                        &job.target,
-                        Some(job.backend),
-                        "failure reply failed",
-                    ),
-                );
+            let reply = format!("⚠️ {}", short(&msg));
+            match record_and_deliver(ctx, &job, OutboundOrigin::Gateway, &reply).await {
+                Ok(DeliveryOutcome::Delivered | DeliveryOutcome::AlreadyDelivered) => {
+                    audit(
+                        ctx,
+                        ctx.audit.reply_sent(
+                            job.row_id,
+                            &job.thread,
+                            &job.target,
+                            Some(job.backend),
+                            &reply,
+                        ),
+                    );
+                    complete_job(ctx, &job, "backend_failed");
+                }
+                Err(error) => history_error(ctx, &job, "record failure reply", error),
             }
         }
     }
@@ -675,8 +708,8 @@ where
 
 /// Setup failures are terminal for the current row. Try to tell the user what
 /// happened, then complete the row so one bad setup step cannot wedge ack state.
-/// If notification delivery also fails, the row is still completed and the
-/// failed notification is logged.
+/// The persisted notification is retried in bounded batches until delivery or
+/// shutdown.
 async fn complete_setup_failure(ctx: &Ctx, job: &Job, reply: &str) {
     #[cfg(test)]
     ctx.setup_failure_replies
@@ -684,9 +717,8 @@ async fn complete_setup_failure(ctx: &Ctx, job: &Job, reply: &str) {
         .unwrap()
         .push(reply.to_string());
 
-    #[cfg(not(test))]
-    {
-        if reply_to(ctx, &job.target, reply).await {
+    match record_and_deliver(ctx, job, OutboundOrigin::Gateway, reply).await {
+        Ok(DeliveryOutcome::Delivered | DeliveryOutcome::AlreadyDelivered) => {
             audit(
                 ctx,
                 ctx.audit.reply_sent(
@@ -697,21 +729,10 @@ async fn complete_setup_failure(ctx: &Ctx, job: &Job, reply: &str) {
                     reply,
                 ),
             );
-        } else {
-            audit(
-                ctx,
-                ctx.audit.reply_failed(
-                    job.row_id,
-                    &job.thread,
-                    &job.target,
-                    Some(job.backend),
-                    "setup failure reply failed",
-                ),
-            );
-            warn!(
-                "[{}] setup failure reply was not sent; completing row {}",
-                job.thread, job.row_id
-            );
+        }
+        Err(error) => {
+            history_error(ctx, job, "record setup failure reply", error);
+            return;
         }
     }
     audit(ctx, ctx.audit.completed(job.row_id, "setup_failed"));
@@ -759,10 +780,105 @@ fn command(ctx: &Ctx, job: &Job) -> Option<String> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeliveryOutcome {
+    Delivered,
+    AlreadyDelivered,
+}
+
+async fn record_and_deliver(
+    ctx: &Ctx,
+    job: &Job,
+    origin: OutboundOrigin,
+    text: &str,
+) -> Result<DeliveryOutcome> {
+    let outbound = ctx.history.lock().unwrap().record_outbound(
+        job.inbound_id,
+        origin,
+        Some(job.backend.as_str()),
+        text,
+    )?;
+    deliver_stored(ctx, job, &outbound).await
+}
+
+async fn deliver_stored(
+    ctx: &Ctx,
+    job: &Job,
+    outbound: &OutboundMessage,
+) -> Result<DeliveryOutcome> {
+    if outbound.status == DeliveryStatus::Delivered {
+        return Ok(DeliveryOutcome::AlreadyDelivered);
+    }
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        let delivered = reply_to(ctx, &job.target, &outbound.content).await;
+        let status = if delivered {
+            DeliveryStatus::Delivered
+        } else {
+            DeliveryStatus::Failed
+        };
+        ctx.history
+            .lock()
+            .unwrap()
+            .mark_delivery(outbound.id, status)?;
+        if delivered {
+            return Ok(DeliveryOutcome::Delivered);
+        }
+        audit(
+            ctx,
+            ctx.audit.reply_failed(
+                job.row_id,
+                &job.thread,
+                &job.target,
+                Some(job.backend),
+                "stored outbound delivery attempt failed",
+            ),
+        );
+        if attempt < DELIVERY_ATTEMPTS {
+            warn!(
+                "delivery attempt {attempt}/{DELIVERY_ATTEMPTS} failed; retrying stored outbound"
+            );
+            #[cfg(not(test))]
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        } else {
+            warn!("delivery attempts exhausted; stored outbound remains failed and will retry");
+            attempt = 0;
+            #[cfg(not(test))]
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+        #[cfg(test)]
+        tokio::task::yield_now().await;
+    }
+}
+
+fn history_error(ctx: &Ctx, job: &Job, action: &str, error: anyhow::Error) {
+    error!(
+        "[{}] canonical history {action} failed: {error}; refusing unrecorded delivery",
+        job.thread
+    );
+    audit(
+        ctx,
+        ctx.audit.failed(
+            "message_history_failed",
+            job.row_id,
+            &job.thread,
+            Some(job.backend),
+            format!("{action}: {error}"),
+        ),
+    );
+}
+
 async fn reply_to(ctx: &Ctx, target: &str, text: &str) -> bool {
     let chunks = ctx.channel.outbound_chunks(text, &ctx.reply_marker);
     #[cfg(test)]
     {
+        let mut failures = ctx.send_failures_remaining.lock().unwrap();
+        if *failures > 0 {
+            *failures -= 1;
+            return false;
+        }
+        drop(failures);
         ctx.sent_replies.lock().unwrap().extend(
             chunks
                 .into_iter()
@@ -1057,8 +1173,15 @@ mod tests {
                 disallowed_tools: Vec::new(),
             }),
         );
+        let history_path = temp_path("setup-failure-history");
+        let mut history = History::open(history_path.to_str().unwrap()).unwrap();
+        let inbound_id = history
+            .record_inbound("imessage", "imessage:self:me", "imessage:10", "hello")
+            .unwrap();
+        assert_eq!(inbound_id, 1);
         Ctx {
             store,
+            history: Arc::new(Mutex::new(history)),
             ack,
             runners: Arc::new(runners),
             channel: filter(),
@@ -1075,12 +1198,14 @@ mod tests {
             )),
             setup_failure_replies: Arc::new(Mutex::new(Vec::new())),
             sent_replies: Arc::new(Mutex::new(Vec::new())),
+            send_failures_remaining: Arc::new(Mutex::new(0)),
         }
     }
 
     fn setup_failure_job(row_id: i64) -> Job {
         Job {
             row_id,
+            inbound_id: 1,
             thread: "imessage:self:me".to_string(),
             target: "me@icloud.com".to_string(),
             backend: AgentBackend::Claude,
@@ -1500,6 +1625,289 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn canonical_history_failure_prevents_backend_dispatch_and_cursor_advance() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("history-failure-sessions");
+        let assistant_dir = temp_path("history-failure-assistant");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut gateway = Gateway::new(test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        ))
+        .unwrap();
+        gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+        gateway
+            .ctx
+            .history
+            .lock()
+            .unwrap()
+            .execute_batch_for_test("DROP TABLE messages");
+        let mut handles = Vec::new();
+
+        gateway
+            .tick_fake(
+                vec![message(1, "me@icloud.com", "", true, "hello")],
+                &mut handles,
+            )
+            .await;
+
+        assert!(handles.is_empty());
+        assert!(calls.lock().unwrap().is_empty());
+        assert!(gateway.ctx.sent_replies.lock().unwrap().is_empty());
+        assert_eq!(gateway.store.lock().unwrap().cursor("imessage"), 0);
+
+        let _ = std::fs::remove_file(&state_path);
+        let _ = std::fs::remove_file(format!("{state_path}.db"));
+        let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+        let _ = std::fs::remove_dir_all(sessions_dir);
+        let _ = std::fs::remove_dir_all(assistant_dir);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pending_outbound_is_delivered_after_restart_without_backend_rerun() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("history-recovery-sessions");
+        let assistant_dir = temp_path("history-recovery-assistant");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let config = test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        );
+        let mut history = History::open(&config.database_path).unwrap();
+        let inbound_id = history
+            .record_inbound(
+                "imessage",
+                "imessage:self:me@icloud.com",
+                "imessage:1",
+                "hello",
+            )
+            .unwrap();
+        history
+            .record_outbound(
+                inbound_id,
+                OutboundOrigin::Backend,
+                Some("codex"),
+                "stored reply",
+            )
+            .unwrap();
+        drop(history);
+        let mut gateway = Gateway::new(config).unwrap();
+        gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+        let mut handles = Vec::new();
+
+        gateway
+            .tick_fake(
+                vec![message(1, "me@icloud.com", "", true, "hello")],
+                &mut handles,
+            )
+            .await;
+        gateway.queues.clear();
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert!(calls.lock().unwrap().is_empty());
+        assert_eq!(
+            gateway.ctx.sent_replies.lock().unwrap().as_slice(),
+            [(
+                "me@icloud.com".to_string(),
+                "stored reply\n\n-- sent by push".to_string()
+            )]
+        );
+        assert_eq!(
+            gateway
+                .ctx
+                .history
+                .lock()
+                .unwrap()
+                .outbound_for(inbound_id)
+                .unwrap()
+                .unwrap()
+                .status,
+            DeliveryStatus::Delivered
+        );
+        assert_eq!(gateway.store.lock().unwrap().cursor("imessage"), 1);
+
+        let _ = std::fs::remove_file(&state_path);
+        let _ = std::fs::remove_file(format!("{state_path}.db"));
+        let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+        let _ = std::fs::remove_dir_all(sessions_dir);
+        let _ = std::fs::remove_dir_all(assistant_dir);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_state_save_failure_keeps_reply_for_restart_without_backend_rerun() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("session-save-failure-sessions");
+        let assistant_dir = temp_path("session-save-failure-assistant");
+        let state_blocker = temp_path("session-save-failure-blocker");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        std::fs::write(&state_blocker, "not a directory").unwrap();
+        let first_calls = Arc::new(Mutex::new(Vec::new()));
+        let mut gateway = Gateway::new(test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        ))
+        .unwrap();
+        let store = gateway.store.clone();
+        let broken_state_path = state_blocker.join("state.json");
+        gateway.ctx.runners = Arc::new(fake_runners_with_hook(
+            first_calls.clone(),
+            Some(Arc::new(move || {
+                store
+                    .lock()
+                    .unwrap()
+                    .set_path_for_test(broken_state_path.clone());
+            })),
+        ));
+        let mut handles = Vec::new();
+
+        gateway
+            .tick_fake(
+                vec![message(1, "me@icloud.com", "", true, "hello")],
+                &mut handles,
+            )
+            .await;
+        gateway.queues.clear();
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert_eq!(first_calls.lock().unwrap().len(), 1);
+        assert!(gateway.ctx.sent_replies.lock().unwrap().is_empty());
+        let inbound_id = gateway
+            .ctx
+            .history
+            .lock()
+            .unwrap()
+            .record_inbound(
+                "imessage",
+                "imessage:self:me@icloud.com",
+                "imessage:1",
+                "hello",
+            )
+            .unwrap();
+        assert_eq!(
+            gateway
+                .ctx
+                .history
+                .lock()
+                .unwrap()
+                .outbound_for(inbound_id)
+                .unwrap()
+                .unwrap()
+                .status,
+            DeliveryStatus::Pending
+        );
+        drop(gateway);
+
+        let second_calls = Arc::new(Mutex::new(Vec::new()));
+        let mut restarted = Gateway::new(test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        ))
+        .unwrap();
+        restarted.ctx.runners = Arc::new(fake_runners(second_calls.clone()));
+        let mut handles = Vec::new();
+        restarted
+            .tick_fake(
+                vec![message(1, "me@icloud.com", "", true, "hello")],
+                &mut handles,
+            )
+            .await;
+        restarted.queues.clear();
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert!(second_calls.lock().unwrap().is_empty());
+        assert_eq!(
+            restarted.ctx.sent_replies.lock().unwrap().as_slice(),
+            [(
+                "me@icloud.com".to_string(),
+                "fake reply: hello\n\n-- sent by push".to_string()
+            )]
+        );
+        assert_eq!(restarted.store.lock().unwrap().cursor("imessage"), 1);
+
+        let _ = std::fs::remove_file(&state_path);
+        let _ = std::fs::remove_file(format!("{state_path}.db"));
+        let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+        let _ = std::fs::remove_file(state_blocker);
+        let _ = std::fs::remove_dir_all(sessions_dir);
+        let _ = std::fs::remove_dir_all(assistant_dir);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn exhausted_delivery_batch_retries_without_blocking_cursor() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("delivery-retry-sessions");
+        let assistant_dir = temp_path("delivery-retry-assistant");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut gateway = Gateway::new(test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        ))
+        .unwrap();
+        gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+        *gateway.ctx.send_failures_remaining.lock().unwrap() = DELIVERY_ATTEMPTS;
+        let mut handles = Vec::new();
+
+        gateway
+            .tick_fake(
+                vec![message(1, "me@icloud.com", "", true, "hello")],
+                &mut handles,
+            )
+            .await;
+        gateway.queues.clear();
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert_eq!(calls.lock().unwrap().len(), 1);
+        assert_eq!(gateway.ctx.sent_replies.lock().unwrap().len(), 1);
+        assert_eq!(gateway.store.lock().unwrap().cursor("imessage"), 1);
+        let inbound_id = gateway
+            .ctx
+            .history
+            .lock()
+            .unwrap()
+            .record_inbound(
+                "imessage",
+                "imessage:self:me@icloud.com",
+                "imessage:1",
+                "hello",
+            )
+            .unwrap();
+        assert_eq!(
+            gateway
+                .ctx
+                .history
+                .lock()
+                .unwrap()
+                .outbound_for(inbound_id)
+                .unwrap()
+                .unwrap()
+                .status,
+            DeliveryStatus::Delivered
+        );
+
+        let _ = std::fs::remove_file(&state_path);
+        let _ = std::fs::remove_file(format!("{state_path}.db"));
+        let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+        let _ = std::fs::remove_dir_all(sessions_dir);
+        let _ = std::fs::remove_dir_all(assistant_dir);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn telegram_filters_before_agent_and_replies_to_originating_chat() {
         let state_path = temp_state_path();
         let sessions_dir = temp_path("telegram-sessions");
@@ -1628,6 +2036,7 @@ mod tests {
             sessions_dir: sessions_dir.to_string(),
             state_path: state_path.to_string(),
             audit_log_path: format!("{state_path}.audit.jsonl"),
+            database_path: format!("{state_path}.db"),
             audit_log_content: false,
             assistant_dir: assistant_dir.to_string(),
             reply_marker: "\n\n-- sent by push".to_string(),
@@ -1643,6 +2052,13 @@ mod tests {
     }
 
     fn fake_runners(calls: Arc<Mutex<Vec<FakeRunCall>>>) -> HashMap<AgentBackend, Runner> {
+        fake_runners_with_hook(calls, None)
+    }
+
+    fn fake_runners_with_hook(
+        calls: Arc<Mutex<Vec<FakeRunCall>>>,
+        before_return: Option<Arc<dyn Fn() + Send + Sync>>,
+    ) -> HashMap<AgentBackend, Runner> {
         let mut runners = HashMap::new();
         runners.insert(
             AgentBackend::Codex,
@@ -1650,6 +2066,7 @@ mod tests {
                 backend: AgentBackend::Codex,
                 session_id: "fake-session".to_string(),
                 calls,
+                before_return,
             }),
         );
         runners

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,457 @@
+//! Canonical SQLite conversation history owned by the gateway.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+
+const SCHEMA_VERSION: i64 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutboundOrigin {
+    Backend,
+    Gateway,
+}
+
+impl OutboundOrigin {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Backend => "backend",
+            Self::Gateway => "gateway",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryStatus {
+    Pending,
+    Delivered,
+    Failed,
+}
+
+impl DeliveryStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Delivered => "delivered",
+            Self::Failed => "failed",
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "delivered" => Ok(Self::Delivered),
+            "failed" => Ok(Self::Failed),
+            other => bail!("invalid delivery status {other:?}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutboundMessage {
+    pub id: i64,
+    pub content: String,
+    pub status: DeliveryStatus,
+}
+
+pub struct History {
+    path: PathBuf,
+    conn: Connection,
+}
+
+impl History {
+    pub fn open(path: &str) -> Result<Self> {
+        let path = PathBuf::from(path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create database directory {}", parent.display()))?;
+        }
+        let conn = Connection::open(&path)
+            .with_context(|| format!("open conversation database {}", path.display()))?;
+        restrict_permissions(&path)?;
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .context("enable conversation database foreign keys")?;
+        migrate(&conn).context("migrate conversation database")?;
+        Ok(Self { path, conn })
+    }
+
+    pub fn record_inbound(
+        &mut self,
+        channel: &str,
+        thread_key: &str,
+        channel_event_id: &str,
+        content: &str,
+    ) -> Result<i64> {
+        let database_path = self.path.display().to_string();
+        let tx = self
+            .conn
+            .transaction()
+            .with_context(|| format!("begin inbound transaction in {database_path}"))?;
+        let conversation_id = conversation(&tx, channel, thread_key)?;
+        tx.execute(
+            "INSERT INTO messages (
+                conversation_id, direction, origin, content, channel_event_id,
+                generation_status, delivery_status
+             ) VALUES (?1, 'inbound', 'channel', ?2, ?3, 'received', 'not_applicable')
+             ON CONFLICT(channel_event_id) DO NOTHING",
+            params![conversation_id, content, channel_event_id],
+        )
+        .with_context(|| format!("insert inbound message into {database_path}"))?;
+        let id = tx
+            .query_row(
+                "SELECT id FROM messages WHERE channel_event_id = ?1",
+                [channel_event_id],
+                |row| row.get(0),
+            )
+            .with_context(|| format!("read canonical inbound message from {database_path}"))?;
+        tx.commit()
+            .with_context(|| format!("commit inbound message to {database_path}"))?;
+        Ok(id)
+    }
+
+    pub fn record_outbound(
+        &mut self,
+        inbound_id: i64,
+        origin: OutboundOrigin,
+        backend: Option<&str>,
+        content: &str,
+    ) -> Result<OutboundMessage> {
+        let database_path = self.path.display().to_string();
+        let tx = self
+            .conn
+            .transaction()
+            .with_context(|| format!("begin outbound transaction in {database_path}"))?;
+        tx.execute(
+            "INSERT INTO messages (
+                conversation_id, direction, origin, content, backend,
+                in_reply_to_id, generation_status, delivery_status
+             )
+             SELECT conversation_id, 'outbound', ?2, ?3, ?4, id, 'completed', 'pending'
+             FROM messages WHERE id = ?1 AND direction = 'inbound'
+             ON CONFLICT(in_reply_to_id) DO NOTHING",
+            params![inbound_id, origin.as_str(), content, backend],
+        )
+        .with_context(|| format!("insert outbound message into {database_path}"))?;
+        let message = outbound_for_tx(&tx, inbound_id)?
+            .with_context(|| format!("inbound message {inbound_id} does not exist"))?;
+        tx.commit()
+            .with_context(|| format!("commit outbound message to {database_path}"))?;
+        Ok(message)
+    }
+
+    pub fn outbound_for(&self, inbound_id: i64) -> Result<Option<OutboundMessage>> {
+        outbound_for_conn(&self.conn, inbound_id).with_context(|| {
+            format!(
+                "read outbound for inbound {inbound_id} from {}",
+                self.path.display()
+            )
+        })
+    }
+
+    pub fn mark_delivery(&mut self, message_id: i64, status: DeliveryStatus) -> Result<()> {
+        if status == DeliveryStatus::Pending {
+            bail!("cannot reset outbound delivery to pending");
+        }
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE messages
+                 SET delivery_status = ?2, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                 WHERE id = ?1 AND direction = 'outbound'",
+                params![message_id, status.as_str()],
+            )
+            .with_context(|| {
+                format!("update outbound delivery status in {}", self.path.display())
+            })?;
+        if changed != 1 {
+            bail!("outbound message {message_id} does not exist");
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn execute_batch_for_test(&self, sql: &str) {
+        self.conn.execute_batch(sql).unwrap();
+    }
+}
+
+fn migrate(conn: &Connection) -> Result<()> {
+    let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if version > SCHEMA_VERSION {
+        bail!(
+            "conversation database schema {version} is newer than supported version {SCHEMA_VERSION}"
+        );
+    }
+    if version == 0 {
+        conn.execute_batch(
+            "BEGIN IMMEDIATE;
+             CREATE TABLE conversations (
+                 id INTEGER PRIMARY KEY,
+                 channel TEXT NOT NULL,
+                 thread_key TEXT NOT NULL,
+                 created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 UNIQUE(channel, thread_key)
+             );
+             CREATE TABLE messages (
+                 id INTEGER PRIMARY KEY,
+                 conversation_id INTEGER NOT NULL REFERENCES conversations(id),
+                 direction TEXT NOT NULL CHECK(direction IN ('inbound', 'outbound')),
+                 origin TEXT NOT NULL CHECK(origin IN ('channel', 'backend', 'gateway')),
+                 content TEXT NOT NULL,
+                 backend TEXT,
+                 channel_event_id TEXT UNIQUE,
+                 in_reply_to_id INTEGER UNIQUE REFERENCES messages(id),
+                 generation_status TEXT NOT NULL,
+                 delivery_status TEXT NOT NULL,
+                 created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 CHECK (
+                     (direction = 'inbound'
+                      AND origin = 'channel'
+                      AND channel_event_id IS NOT NULL
+                      AND in_reply_to_id IS NULL
+                      AND generation_status = 'received'
+                      AND delivery_status = 'not_applicable')
+                     OR
+                     (direction = 'outbound'
+                      AND origin IN ('backend', 'gateway')
+                      AND channel_event_id IS NULL
+                      AND in_reply_to_id IS NOT NULL
+                      AND generation_status = 'completed'
+                      AND delivery_status IN ('pending', 'delivered', 'failed'))
+                 )
+             );
+             CREATE INDEX messages_conversation_id_idx
+                 ON messages(conversation_id, id);
+             PRAGMA user_version = 1;
+             COMMIT;",
+        )?;
+    }
+    Ok(())
+}
+
+fn conversation(tx: &Transaction<'_>, channel: &str, thread_key: &str) -> Result<i64> {
+    tx.execute(
+        "INSERT INTO conversations (channel, thread_key) VALUES (?1, ?2)
+         ON CONFLICT(channel, thread_key) DO UPDATE SET
+             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+        params![channel, thread_key],
+    )?;
+    tx.query_row(
+        "SELECT id FROM conversations WHERE channel = ?1 AND thread_key = ?2",
+        params![channel, thread_key],
+        |row| row.get(0),
+    )
+    .context("read conversation")
+}
+
+fn outbound_for_tx(tx: &Transaction<'_>, inbound_id: i64) -> Result<Option<OutboundMessage>> {
+    outbound_for_query(tx, inbound_id)
+}
+
+fn outbound_for_conn(conn: &Connection, inbound_id: i64) -> Result<Option<OutboundMessage>> {
+    outbound_for_query(conn, inbound_id)
+}
+
+fn outbound_for_query(conn: &Connection, inbound_id: i64) -> Result<Option<OutboundMessage>> {
+    conn.query_row(
+        "SELECT id, content, delivery_status
+             FROM messages WHERE in_reply_to_id = ?1",
+        [inbound_id],
+        |row| {
+            let status: String = row.get(2)?;
+            Ok((row.get(0)?, row.get(1)?, status))
+        },
+    )
+    .optional()?
+    .map(|(id, content, status)| {
+        Ok(OutboundMessage {
+            id,
+            content,
+            status: DeliveryStatus::parse(&status)?,
+        })
+    })
+    .transpose()
+}
+
+#[cfg(unix)]
+fn restrict_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("restrict database permissions {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn restrict_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::temp_path;
+
+    #[test]
+    fn migrates_new_database_and_reopens_it() {
+        let path = temp_path("history-migration");
+
+        drop(History::open(path.to_str().unwrap()).unwrap());
+        let reopened = History::open(path.to_str().unwrap()).unwrap();
+
+        let version: i64 = reopened
+            .conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn retries_one_channel_event_without_duplicate_user_turn() {
+        let path = temp_path("history-retry");
+        let mut history = History::open(path.to_str().unwrap()).unwrap();
+
+        let first = history
+            .record_inbound("telegram", "telegram:dm:7", "telegram:101", "hello")
+            .unwrap();
+        let retry = history
+            .record_inbound("telegram", "telegram:dm:7", "telegram:101", "hello")
+            .unwrap();
+
+        assert_eq!(first, retry);
+        let count: i64 = history
+            .conn
+            .query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn generated_reply_is_unique_and_delivery_survives_restart() {
+        let path = temp_path("history-crash-boundary");
+        let mut history = History::open(path.to_str().unwrap()).unwrap();
+        let inbound = history
+            .record_inbound("imessage", "imessage:self:me", "imessage:4", "hello")
+            .unwrap();
+
+        let first = history
+            .record_outbound(inbound, OutboundOrigin::Backend, Some("claude"), "first")
+            .unwrap();
+        let duplicate = history
+            .record_outbound(inbound, OutboundOrigin::Backend, Some("claude"), "second")
+            .unwrap();
+        assert_eq!(first, duplicate);
+        assert_eq!(duplicate.content, "first");
+        history
+            .mark_delivery(first.id, DeliveryStatus::Delivered)
+            .unwrap();
+        drop(history);
+
+        let reopened = History::open(path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            reopened.outbound_for(inbound).unwrap().unwrap().status,
+            DeliveryStatus::Delivered
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn same_thread_text_isolated_by_channel() {
+        let path = temp_path("history-channel-isolation");
+        let mut history = History::open(path.to_str().unwrap()).unwrap();
+
+        history
+            .record_inbound("imessage", "dm:7", "imessage:1", "one")
+            .unwrap();
+        history
+            .record_inbound("telegram", "dm:7", "telegram:1", "two")
+            .unwrap();
+
+        let count: i64 = history
+            .conn
+            .query_row("SELECT COUNT(*) FROM conversations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn gateway_and_backend_outbound_origins_are_distinct() {
+        let path = temp_path("history-origins");
+        let mut history = History::open(path.to_str().unwrap()).unwrap();
+        let backend_inbound = history
+            .record_inbound("telegram", "telegram:dm:7", "telegram:1", "one")
+            .unwrap();
+        let gateway_inbound = history
+            .record_inbound("telegram", "telegram:dm:7", "telegram:2", "/help")
+            .unwrap();
+
+        history
+            .record_outbound(
+                backend_inbound,
+                OutboundOrigin::Backend,
+                Some("codex"),
+                "backend reply",
+            )
+            .unwrap();
+        history
+            .record_outbound(
+                gateway_inbound,
+                OutboundOrigin::Gateway,
+                Some("codex"),
+                "command reply",
+            )
+            .unwrap();
+
+        let rows: Vec<(String, Option<String>, String, String)> = history
+            .conn
+            .prepare(
+                "SELECT origin, backend, generation_status, delivery_status
+                 FROM messages WHERE direction = 'outbound' ORDER BY id",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert_eq!(
+            rows,
+            [
+                (
+                    "backend".to_string(),
+                    Some("codex".to_string()),
+                    "completed".to_string(),
+                    "pending".to_string(),
+                ),
+                (
+                    "gateway".to_string(),
+                    Some("codex".to_string()),
+                    "completed".to_string(),
+                    "pending".to_string(),
+                ),
+            ]
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn database_permissions_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_path("history-permissions");
+        let _history = History::open(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod claude;
 mod codex;
 mod config;
 mod gateway;
+mod history;
 mod imessage;
 mod soul;
 mod store;
@@ -119,6 +120,7 @@ fn run_checks(cfg: &config::Config) -> CheckReport {
     check_state_dir(cfg, &mut checks);
     check_sessions_dir(cfg, &mut checks);
     check_audit_log_dir(cfg, &mut checks);
+    check_history_database(cfg, &mut checks);
     match cfg.channel_kind() {
         Ok(config::ChannelKind::IMessage) => check_imessage_db(cfg, &mut checks),
         Ok(config::ChannelKind::Telegram) => check_telegram_config(cfg, &mut checks),
@@ -177,6 +179,22 @@ fn check_sessions_dir(cfg: &config::Config, checks: &mut Vec<Check>) {
             format!(
                 "cannot create {}: {e}. Create it or choose a writable sessions_dir.",
                 cfg.sessions_dir
+            ),
+        )),
+    }
+}
+
+fn check_history_database(cfg: &config::Config, checks: &mut Vec<Check>) {
+    match history::History::open(&cfg.database_path) {
+        Ok(_) => checks.push(Check::pass(
+            "conversation database",
+            format!("{} is ready", cfg.database_path),
+        )),
+        Err(error) => checks.push(Check::fail(
+            "conversation database",
+            format!(
+                "cannot open {}: {error}. Choose a writable database_path and repair or remove an invalid database.",
+                cfg.database_path
             ),
         )),
     }
@@ -423,6 +441,12 @@ mod tests {
         assert_eq!(cfg.telegram_bot_token_env, "TELEGRAM_BOT_TOKEN");
         assert_eq!(cfg.telegram_allow_user_ids, [123456789]);
         assert!(cfg.telegram_allow_chat_ids.is_empty());
+        assert_eq!(
+            cfg.database_path,
+            Path::new(&std::env::var("HOME").unwrap())
+                .join(".push/push.db")
+                .to_string_lossy()
+        );
         assert_eq!(
             cfg.assistant_dir,
             Path::new(&std::env::var("HOME").unwrap())
@@ -783,6 +807,10 @@ tools = ["Read", "Grep"]
             .with_extension("audit.jsonl")
             .to_string_lossy()
             .to_string();
+        cfg.database_path = state_path
+            .with_extension("push.db")
+            .to_string_lossy()
+            .to_string();
         cfg.sessions_dir = sessions_dir.to_string_lossy().to_string();
 
         let report = run_checks(&cfg);
@@ -801,12 +829,16 @@ tools = ["Read", "Grep"]
             check.name == "audit log directory" && matches!(check.status, CheckStatus::Pass)
         }));
         assert!(report.checks.iter().any(|check| {
+            check.name == "conversation database" && matches!(check.status, CheckStatus::Pass)
+        }));
+        assert!(report.checks.iter().any(|check| {
             check.name == "iMessage database" && matches!(check.status, CheckStatus::Pass)
         }));
 
         let _ = std::fs::remove_file(db_path);
         let _ = std::fs::remove_file(state_path);
         let _ = std::fs::remove_file(cfg.audit_log_path);
+        let _ = std::fs::remove_file(cfg.database_path);
         let _ = std::fs::remove_dir_all(sessions_dir);
     }
 
@@ -846,6 +878,7 @@ tools = ["Read", "Grep"]
             sessions_dir: "/fake/sessions".to_string(),
             state_path: "/fake/state.json".to_string(),
             audit_log_path: "/fake/audit.jsonl".to_string(),
+            database_path: "/fake/push.db".to_string(),
             audit_log_content: false,
             assistant_dir: "/fake/assistant".to_string(),
             reply_marker: "\n\n-- sent by push".to_string(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -169,6 +169,11 @@ impl Store {
         std::fs::rename(&tmp, &self.path).context("rename state")?;
         Ok(())
     }
+
+    #[cfg(test)]
+    pub fn set_path_for_test(&mut self, path: PathBuf) {
+        self.path = path;
+    }
 }
 
 fn default_backend() -> String {


### PR DESCRIPTION
## Summary

- add a migrated SQLite journal at `~/.push/push.db` with channel-qualified conversations and canonical inbound/outbound messages
- persist accepted inbound events before route, command, or backend work with stable idempotency keys
- persist one generated outbound per inbound before delivery, with distinct backend/gateway origins and separate generation/delivery state
- recover pending responses after restart without rerunning the backend, and retry delivery in bounded batches
- keep cursors and backend sessions in the existing `state.json` store

## Why

Push must own durable conversation history independently of Claude or Codex sessions and preserve the generation-to-delivery crash boundary.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (118 passed)
- `git diff --check`
- focused tests cover schema migration/reopen, idempotent retry, channel isolation, origin separation, 0600 permissions, database fail-closed behavior, pending-response restart recovery, session-state save failure, and delivery recovery after an exhausted retry batch
- independent subagent review completed; both ordering/retry findings were fixed and re-reviewed with no serious findings remaining

## Risks

- Conversation content is now retained locally in `push.db`; the database file is restricted to mode 0600 on Unix.
- A crash after a channel accepts a reply but before delivery status commits can resend the same stored reply, but cannot generate a different second response.
- A sustained delivery outage keeps the affected thread ordered and retries until delivery or bounded shutdown.

## Related issue

Closes #56