### PR TITLE
feat: add named permission profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,18 +204,18 @@ settings, pushes to `main` deploy the site automatically.
 channel = "imessage"
 agent = "codex"
 
-# Advanced shared and backend settings use their existing top-level names.
+# Advanced shared settings.
 claude_bin = "claude"
-claude_permission_mode = "bypassPermissions"
-claude_allowed_tools = []
-claude_disallowed_tools = []
 codex_bin = "codex"
-codex_sandbox = "workspace-write"
-codex_approval_policy = "never"
 audit_log_path = "~/.push/audit.jsonl"
 audit_log_content = false
 database_path = "~/.push/push.db"
 assistant_dir = "~/.push"
+permission_profile = "restricted"
+job_permission_profiles = ["restricted", "research"]
+
+[permission_profiles.research]
+capability = "read-only"
 
 [imessage]
 self_handles = ["you@icloud.com"]
@@ -229,6 +229,7 @@ allow_chat_ids = []
 [[routes]]
 thread = "imessage:self:you@icloud.com"
 agent = "codex"
+permission_profile = "workspace"
 ```
 
 `channel` can be `imessage` or `telegram`. `agent` can be `claude` or `codex`.
@@ -241,10 +242,12 @@ Routes can override the backend by channel or exact channel-qualified thread:
 [[routes]]
 channel = "telegram"
 agent = "codex"
+permission_profile = "restricted"
 
 [[routes]]
 thread = "telegram:dm:123456789"
 agent = "claude"
+permission_profile = "workspace"
 ```
 
 iMessage thread keys are `imessage:self:<handle>` and
@@ -253,6 +256,34 @@ iMessage thread keys are `imessage:self:<handle>` and
 `:topic:<topic_id>`; topic routes inherit the parent private-chat route unless
 an exact topic route is configured. Legacy unqualified iMessage route keys
 remain accepted.
+
+## Permission Profiles
+
+Every route selects a named Push permission profile. The default is the built-in
+`restricted` profile. Built-ins are `restricted` (`read-only` capability),
+`workspace`, and the deliberately explicit `full-access`. Custom profiles can
+only select one of those capabilities; they cannot inject raw backend flags.
+
+Backend translation is intentionally conservative:
+
+- `restricted`: Claude gets only Read, Grep, and Glob with Bash and write tools
+  denied; Codex uses the read-only sandbox with approvals disabled.
+- `workspace`: Claude gets read and file-edit tools but no Bash because Claude
+  Code has no equivalent to Codex filesystem sandboxing; Codex uses
+  `workspace-write` with approvals disabled.
+- `full-access`: Claude uses `bypassPermissions`; Codex uses
+  `danger-full-access`. Select it by name only in environments you control.
+
+Future jobs request only a profile name explicitly listed in
+`job_permission_profiles`. The allow-list defaults to only `restricted`; adding
+`workspace`, `full-access`, or a custom profile is an explicit operator choice.
+Unknown route profiles fail startup. Unknown or unapproved job references return
+a job-scoped validation error without invalidating messaging routes.
+
+Legacy raw settings such as `claude_permission_mode`, `claude_tools`,
+`claude_allowed_tools`, `claude_disallowed_tools`, `codex_sandbox`, and
+`codex_approval_policy` now produce a migration error; replace them with a named
+profile.
 
 push reads TOML only. Convert any earlier `config.json` file to `config.toml`
 before upgrading. The old JSON filename remains gitignored to reduce the risk
@@ -283,19 +314,9 @@ MCP servers, or use any other backend tool. Keep `imessage.allow_from` tight, an
 lost or shared phone, forwarded iMessage account, or compromised allowed sender
 as able to instruct the agent.
 
-Claude Code defaults to `bypassPermissions` for headless use. Codex defaults to
-`workspace-write` plus `never` approval for non-interactive use. Both settings
-should be treated as powerful automation. Use the least access that still makes
-the assistant useful, and run broad-access modes only in an environment you
-control.
-
-For Claude Code, `claude_tools` maps to `--tools`, which controls which tools
-are available to the model. Set entries such as `"Read"` and `"Grep"` for a
-read-only assistant, or `[""]` to disable tools for pure text replies.
-`claude_allowed_tools` maps to `--allowed-tools`, which lets matching tools run
-without a prompt, and `claude_disallowed_tools` maps to `--disallowed-tools`,
-which denies matching tools. The shorter `tools`, `allowed_tools`, and
-`disallowed_tools` names are also accepted.
+The default `restricted` profile does not grant write or shell tools. Broader
+profiles should still be treated as powerful automation because backend
+enforcement differs and an allowed sender controls the request.
 
 ## Audit Log
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -218,16 +218,14 @@ the trust boundary. iMessage uses `imessage.self_handles` and
 `imessage.allow_from`; Telegram uses stable numeric `telegram.allow_user_ids`
 and `telegram.allow_chat_ids`.
 
-Backend permissions are adapter-specific:
-
-- Claude Code currently defaults to `bypassPermissions` for headless use.
-  `claude_tools` controls the available Claude Code tool set.
-  `claude_allowed_tools` and `claude_disallowed_tools` pass permission allow
-  and deny rules through to Claude Code.
-- Codex currently defaults to `workspace-write` with approval policy `never`.
-
-Both should be treated as powerful local automation. Use broader modes only in
-environments you control.
+Routes select a named Push permission profile. `restricted` is the default,
+future jobs may use only explicitly allow-listed profile names, and
+`full-access` is explicit. Push translates the common capability into backend
+controls for every request. Claude receives a fixed tool allowlist and denies
+Bash outside full access; Codex receives `read-only`, `workspace-write`, or
+`danger-full-access`. Claude does not provide a Codex-equivalent filesystem
+sandbox, so its `workspace` mapping permits file tools but deliberately omits
+shell access. Custom profiles select a capability, not raw backend flags.
 
 ## Extension Points
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -131,6 +131,9 @@ user prompt.
 |---|---|
 | `agent` | `claude` or `codex`. |
 | `routes` | Exact thread to backend overrides. |
+| `permission_profile` | Default named profile; defaults to `restricted`. |
+| `permission_profiles` | Custom names mapped to a common capability. |
+| `job_permission_profiles` | Explicit profile names future jobs may request; defaults to `restricted`. |
 | `imessage.db_path` | Path to Messages `chat.db`. |
 | `poll_interval` | How often to poll. |
 | `run_timeout` | Max backend run time. |
@@ -140,13 +143,7 @@ user prompt.
 | `telegram.allow_user_ids` | Allowed private-chat sender IDs. |
 | `telegram.allow_chat_ids` | Allowed private chat IDs. |
 | `claude_bin` | Claude Code binary. |
-| `claude_permission_mode` | Claude Code permission mode. |
-| `claude_tools` | Optional Claude Code available tool list. |
-| `claude_allowed_tools` | Optional Claude Code permission allow rules. |
-| `claude_disallowed_tools` | Optional Claude Code permission deny rules. |
 | `codex_bin` | Codex binary. |
-| `codex_sandbox` | Codex sandbox mode. |
-| `codex_approval_policy` | Codex approval policy. |
 | `codex_model` | Optional Codex model override. |
 | `sessions_dir` | Per-thread working dirs. |
 | `state_path` | JSON state path. |
@@ -179,8 +176,7 @@ user prompt.
 - A crash during an in-flight run retries that message on restart, which can
   duplicate backend work but avoids silently losing the message.
 - Codex resume behavior depends on the Codex CLI session store.
-- Claude `bypassPermissions` and Codex non-interactive automation are powerful
-  local execution modes.
+- Full-access profiles are powerful local execution modes.
 - iMessage database shape can change across macOS versions.
 
 ## Next Scope

--- a/docs/services.md
+++ b/docs/services.md
@@ -173,9 +173,9 @@ is completed.
 
 Managed services run without a person watching the terminal. An allowed sender
 can instruct the configured backend to use its tools, subject to your backend
-settings. Keep `imessage.allow_from` narrow, use the least-powerful backend permissions
-that still work, and consider Claude Code `claude_tools`,
-`claude_allowed_tools`, and `claude_disallowed_tools` when running headlessly.
+settings. Keep `imessage.allow_from` narrow and use the least-powerful named
+permission profile that works. The default `restricted` profile omits shell and
+write tools; select `full-access` only in an environment you control.
 
 Store config files, state files, audit logs, backend credentials, and service
 logs with permissions appropriate for the service user. Logs may contain

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use uuid::Uuid;
 
-use crate::config::AgentBackend;
+use crate::config::{AgentBackend, PermissionCapability};
 use crate::{claude, codex};
 
 /// One headless agent turn.
@@ -14,6 +14,7 @@ pub struct Request<'a> {
     pub is_new: bool,
     pub work_dir: &'a str,
     pub instructions: &'a str,
+    pub permission: PermissionCapability,
     pub prompt: &'a str,
 }
 
@@ -94,6 +95,7 @@ pub struct FakeRunCall {
     pub session_id: String,
     pub is_new: bool,
     pub prompt: String,
+    pub permission: PermissionCapability,
 }
 
 #[cfg(test)]
@@ -103,6 +105,7 @@ impl FakeRunner {
             session_id: req.session_id.to_string(),
             is_new: req.is_new,
             prompt: req.prompt.to_string(),
+            permission: req.permission,
         });
         if let Some(before_return) = &self.before_return {
             before_return();

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -6,14 +6,11 @@ use serde::Deserialize;
 use tokio::process::Command;
 
 use crate::agent::{Request, RunError, RunOutput};
+use crate::config::PermissionCapability;
 
 /// Runner invokes the `claude` binary in print mode.
 pub struct Runner {
     pub bin: String,
-    pub permission_mode: String,
-    pub tools: Option<Vec<String>>,
-    pub allowed_tools: Vec<String>,
-    pub disallowed_tools: Vec<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -55,12 +52,13 @@ impl Runner {
 
     fn command(&self, req: &Request<'_>) -> Command {
         let mut cmd = Command::new(&self.bin);
+        let controls = controls(req.permission);
         cmd.arg("-p")
             .arg(req.prompt)
             .arg("--output-format")
             .arg("json")
             .arg("--permission-mode")
-            .arg(&self.permission_mode)
+            .arg(controls.permission_mode)
             .arg("--add-dir")
             .arg(req.work_dir);
         if req.is_new {
@@ -71,14 +69,14 @@ impl Runner {
         if !req.instructions.trim().is_empty() {
             cmd.arg("--append-system-prompt").arg(req.instructions);
         }
-        if let Some(tools) = &self.tools {
+        if let Some(tools) = controls.tools {
             cmd.arg("--tools");
             cmd.args(tools);
         }
-        for tool in &self.allowed_tools {
+        for tool in controls.allowed_tools {
             cmd.arg("--allowed-tools").arg(tool);
         }
-        for tool in &self.disallowed_tools {
+        for tool in controls.disallowed_tools {
             cmd.arg("--disallowed-tools").arg(tool);
         }
         cmd.current_dir(req.work_dir);
@@ -115,6 +113,42 @@ impl Runner {
                 }
             }
         }
+    }
+}
+
+struct Controls {
+    permission_mode: &'static str,
+    tools: Option<&'static [&'static str]>,
+    allowed_tools: &'static [&'static str],
+    disallowed_tools: &'static [&'static str],
+}
+
+const READ_ONLY_TOOLS: &[&str] = &["Read", "Grep", "Glob"];
+const WORKSPACE_TOOLS: &[&str] = &["Read", "Grep", "Glob", "Edit", "Write", "NotebookEdit"];
+const NO_TOOLS: &[&str] = &[];
+const DENY_SHELL_AND_WRITES: &[&str] = &["Bash", "Edit", "Write", "NotebookEdit"];
+const DENY_SHELL: &[&str] = &["Bash"];
+
+fn controls(capability: PermissionCapability) -> Controls {
+    match capability {
+        PermissionCapability::ReadOnly => Controls {
+            permission_mode: "dontAsk",
+            tools: Some(READ_ONLY_TOOLS),
+            allowed_tools: READ_ONLY_TOOLS,
+            disallowed_tools: DENY_SHELL_AND_WRITES,
+        },
+        PermissionCapability::Workspace => Controls {
+            permission_mode: "dontAsk",
+            tools: Some(WORKSPACE_TOOLS),
+            allowed_tools: WORKSPACE_TOOLS,
+            disallowed_tools: DENY_SHELL,
+        },
+        PermissionCapability::FullAccess => Controls {
+            permission_mode: "bypassPermissions",
+            tools: None,
+            allowed_tools: NO_TOOLS,
+            disallowed_tools: NO_TOOLS,
+        },
     }
 }
 
@@ -159,6 +193,26 @@ mod tests {
         );
     }
 
+    #[test]
+    fn translates_all_permission_capabilities() {
+        let read_only = controls(PermissionCapability::ReadOnly);
+        assert_eq!(read_only.permission_mode, "dontAsk");
+        assert_eq!(read_only.tools, Some(READ_ONLY_TOOLS));
+        assert!(read_only.disallowed_tools.contains(&"Bash"));
+        assert!(read_only.disallowed_tools.contains(&"Edit"));
+
+        let workspace = controls(PermissionCapability::Workspace);
+        assert_eq!(workspace.permission_mode, "dontAsk");
+        assert_eq!(workspace.tools, Some(WORKSPACE_TOOLS));
+        assert!(workspace.allowed_tools.contains(&"Edit"));
+        assert!(workspace.disallowed_tools.contains(&"Bash"));
+
+        let full = controls(PermissionCapability::FullAccess);
+        assert_eq!(full.permission_mode, "bypassPermissions");
+        assert_eq!(full.tools, None);
+        assert!(full.disallowed_tools.is_empty());
+    }
+
     #[tokio::test]
     async fn satisfies_runner_contract() {
         assert_runner_contract(RunnerContract {
@@ -180,13 +234,7 @@ mod tests {
             sh_arg(&args_path)
         );
         let cli = FakeCli::new("claude", &script);
-        let runner = Runner {
-            bin: cli.bin(),
-            permission_mode: "bypassPermissions".to_string(),
-            tools: Some(vec!["Read".to_string(), "Grep".to_string()]),
-            allowed_tools: vec!["Read".to_string(), "Bash(git status:*)".to_string()],
-            disallowed_tools: vec!["Edit".to_string()],
-        };
+        let runner = Runner { bin: cli.bin() };
 
         let out = runner
             .run(
@@ -195,6 +243,7 @@ mod tests {
                     is_new: true,
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: "assistant identity",
+                    permission: PermissionCapability::ReadOnly,
                     prompt: "hello",
                 },
                 Duration::from_secs(5),
@@ -206,14 +255,15 @@ mod tests {
         assert_eq!(out.session_id, Some("claude-returned".to_string()));
         let args = read_args(&args_path);
         assert_arg_pair(&args, "--session-id", "push-session");
-        assert_arg_pair(&args, "--permission-mode", "bypassPermissions");
+        assert_arg_pair(&args, "--permission-mode", "dontAsk");
         assert_arg_pair(&args, "--append-system-prompt", "assistant identity");
         assert_arg_pair(&args, "-p", "hello");
         assert_arg_pair(&args, "--tools", "Read");
         assert_arg_pair(&args, "--allowed-tools", "Read");
-        assert_arg_pair(&args, "--disallowed-tools", "Edit");
+        assert_arg_pair(&args, "--disallowed-tools", "Bash");
         assert!(args.contains(&"Grep".to_string()));
-        assert!(args.contains(&"Bash(git status:*)".to_string()));
+        assert!(args.contains(&"Glob".to_string()));
+        assert!(args.contains(&"Edit".to_string()));
         assert!(!args.contains(&"--resume".to_string()));
     }
 
@@ -226,13 +276,7 @@ mod tests {
             sh_arg(&args_path)
         );
         let cli = FakeCli::new("claude", &script);
-        let runner = Runner {
-            bin: cli.bin(),
-            permission_mode: "default".to_string(),
-            tools: None,
-            allowed_tools: Vec::new(),
-            disallowed_tools: Vec::new(),
-        };
+        let runner = Runner { bin: cli.bin() };
 
         let out = runner
             .run(
@@ -241,6 +285,7 @@ mod tests {
                     is_new: false,
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: "assistant identity",
+                    permission: PermissionCapability::Workspace,
                     prompt: "continue",
                 },
                 Duration::from_secs(5),
@@ -254,6 +299,10 @@ mod tests {
         assert!(!args.contains(&"--session-id".to_string()));
         assert_arg_pair(&args, "--append-system-prompt", "assistant identity");
         assert_arg_pair(&args, "-p", "continue");
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["--allowed-tools", "Edit"]));
+        assert_arg_pair(&args, "--disallowed-tools", "Bash");
     }
 
     #[tokio::test]
@@ -263,13 +312,7 @@ mod tests {
             "claude",
             "#!/bin/sh\nprintf '%s\\n' '{\"is_error\":true,\"result\":\"api down\"}'\nexit 1\n",
         );
-        let runner = Runner {
-            bin: cli.bin(),
-            permission_mode: "default".to_string(),
-            tools: None,
-            allowed_tools: Vec::new(),
-            disallowed_tools: Vec::new(),
-        };
+        let runner = Runner { bin: cli.bin() };
 
         let err = match runner
             .run(request(work_dir.to_str().unwrap()), Duration::from_secs(5))
@@ -286,13 +329,7 @@ mod tests {
     async fn reports_timeout() {
         let work_dir = temp_dir("claude-timeout-work");
         let cli = FakeCli::new("claude", "#!/bin/sh\nsleep 2\n");
-        let runner = Runner {
-            bin: cli.bin(),
-            permission_mode: "default".to_string(),
-            tools: None,
-            allowed_tools: Vec::new(),
-            disallowed_tools: Vec::new(),
-        };
+        let runner = Runner { bin: cli.bin() };
 
         let err = match runner
             .run(
@@ -314,6 +351,7 @@ mod tests {
             is_new: true,
             work_dir,
             instructions: "",
+            permission: PermissionCapability::ReadOnly,
             prompt: "hello",
         }
     }
@@ -357,13 +395,7 @@ mod tests {
         let bin = cli.bin();
         ContractCase {
             fake_cli: cli,
-            runner: Box::new(Runner {
-                bin,
-                permission_mode: "default".to_string(),
-                tools: None,
-                allowed_tools: Vec::new(),
-                disallowed_tools: Vec::new(),
-            }),
+            runner: Box::new(Runner { bin }),
             request: contract_request(work_dir, true),
             timeout: Duration::from_secs(5),
         }
@@ -378,13 +410,7 @@ mod tests {
         let bin = cli.bin();
         ContractCase {
             fake_cli: cli,
-            runner: Box::new(Runner {
-                bin,
-                permission_mode: "default".to_string(),
-                tools: None,
-                allowed_tools: Vec::new(),
-                disallowed_tools: Vec::new(),
-            }),
+            runner: Box::new(Runner { bin }),
             request: contract_request(work_dir, false),
             timeout: Duration::from_secs(5),
         }
@@ -399,13 +425,7 @@ mod tests {
         let bin = cli.bin();
         ContractCase {
             fake_cli: cli,
-            runner: Box::new(Runner {
-                bin,
-                permission_mode: "default".to_string(),
-                tools: None,
-                allowed_tools: Vec::new(),
-                disallowed_tools: Vec::new(),
-            }),
+            runner: Box::new(Runner { bin }),
             request: contract_request(work_dir, true),
             timeout: Duration::from_secs(5),
         }
@@ -417,13 +437,7 @@ mod tests {
         let bin = cli.bin();
         ContractCase {
             fake_cli: cli,
-            runner: Box::new(Runner {
-                bin,
-                permission_mode: "default".to_string(),
-                tools: None,
-                allowed_tools: Vec::new(),
-                disallowed_tools: Vec::new(),
-            }),
+            runner: Box::new(Runner { bin }),
             request: contract_request(work_dir, true),
             timeout: Duration::from_millis(10),
         }
@@ -435,6 +449,7 @@ mod tests {
             is_new,
             work_dir,
             instructions: String::new(),
+            permission: PermissionCapability::ReadOnly,
             prompt: "hello".to_string(),
         }
     }

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -10,12 +10,11 @@ use tokio::process::Command;
 use uuid::Uuid;
 
 use crate::agent::{Request, RunError, RunOutput};
+use crate::config::PermissionCapability;
 
 /// Runner invokes `codex exec` in non-interactive mode.
 pub struct Runner {
     pub bin: String,
-    pub sandbox: String,
-    pub approval_policy: String,
     pub model: Option<String>,
 }
 
@@ -35,10 +34,11 @@ impl Runner {
         let out_path = Path::new(req.work_dir)
             .join(format!(".push-codex-last-message-{}.txt", Uuid::new_v4()));
         let mut cmd = Command::new(&self.bin);
+        let sandbox = sandbox(req.permission);
         cmd.arg("--ask-for-approval")
-            .arg(&self.approval_policy)
+            .arg("never")
             .arg("--sandbox")
-            .arg(&self.sandbox);
+            .arg(sandbox);
         if !req.instructions.trim().is_empty() {
             cmd.arg("-c")
                 .arg(developer_instructions(req.instructions.trim()));
@@ -110,6 +110,14 @@ impl Runner {
             reply: reply.trim().to_string(),
             session_id,
         })
+    }
+}
+
+fn sandbox(capability: PermissionCapability) -> &'static str {
+    match capability {
+        PermissionCapability::ReadOnly => "read-only",
+        PermissionCapability::Workspace => "workspace-write",
+        PermissionCapability::FullAccess => "danger-full-access",
     }
 }
 
@@ -325,6 +333,7 @@ mod tests {
                     is_new: true,
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: "assistant identity",
+                    permission: PermissionCapability::Workspace,
                     prompt: "hello",
                 },
                 Duration::from_secs(5),
@@ -360,6 +369,7 @@ mod tests {
                     is_new: false,
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: "assistant identity",
+                    permission: PermissionCapability::ReadOnly,
                     prompt: "continue",
                 },
                 Duration::from_secs(5),
@@ -372,6 +382,7 @@ mod tests {
         let args = read_args(&args_path);
         assert_arg_sequence(&args, &["exec", "resume"]);
         assert_arg_present(&args, "existing-thread");
+        assert_arg_pair(&args, "--sandbox", "read-only");
         assert_arg_pair(&args, "-c", &developer_instructions("assistant identity"));
         assert_eq!(args.last().unwrap(), "continue");
         assert!(!args.contains(&"-C".to_string()));
@@ -418,12 +429,7 @@ mod tests {
     }
 
     fn runner(bin: String) -> Runner {
-        Runner {
-            bin,
-            sandbox: "workspace-write".to_string(),
-            approval_policy: "never".to_string(),
-            model: None,
-        }
+        Runner { bin, model: None }
     }
 
     fn request(work_dir: &str) -> Request<'_> {
@@ -432,6 +438,7 @@ mod tests {
             is_new: true,
             work_dir,
             instructions: "",
+            permission: PermissionCapability::ReadOnly,
             prompt: "hello",
         }
     }
@@ -575,7 +582,18 @@ mod tests {
             is_new,
             work_dir,
             instructions: String::new(),
+            permission: PermissionCapability::ReadOnly,
             prompt: "hello".to_string(),
         }
+    }
+
+    #[test]
+    fn translates_all_permission_capabilities() {
+        assert_eq!(sandbox(PermissionCapability::ReadOnly), "read-only");
+        assert_eq!(sandbox(PermissionCapability::Workspace), "workspace-write");
+        assert_eq!(
+            sandbox(PermissionCapability::FullAccess),
+            "danger-full-access"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 //! Gateway configuration loaded from a TOML file.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
@@ -32,22 +32,16 @@ pub struct Config {
     pub agent: String,
     #[serde(default)]
     pub routes: Vec<RouteRule>,
+    #[serde(default = "default_permission_profile")]
+    pub permission_profile: String,
+    #[serde(default = "default_job_permission_profiles")]
+    pub job_permission_profiles: Vec<String>,
+    #[serde(default)]
+    pub permission_profiles: HashMap<String, PermissionProfileConfig>,
     #[serde(default = "default_claude_bin")]
     pub claude_bin: String,
-    #[serde(default = "default_claude_permission_mode", alias = "permission_mode")]
-    pub claude_permission_mode: String,
-    #[serde(default, alias = "tools")]
-    pub claude_tools: Option<Vec<String>>,
-    #[serde(default, alias = "allowed_tools")]
-    pub claude_allowed_tools: Vec<String>,
-    #[serde(default, alias = "disallowed_tools")]
-    pub claude_disallowed_tools: Vec<String>,
     #[serde(default = "default_codex_bin")]
     pub codex_bin: String,
-    #[serde(default = "default_codex_sandbox")]
-    pub codex_sandbox: String,
-    #[serde(default = "default_codex_approval_policy")]
-    pub codex_approval_policy: String,
     #[serde(default)]
     pub codex_model: Option<String>,
     #[serde(default = "default_sessions_dir")]
@@ -78,6 +72,24 @@ impl Config {
             bail!(
                 "structured [assistant] settings are no longer supported; move assistant identity into assistant_dir/SOUL.md"
             );
+        }
+        for legacy in [
+            "permission_mode",
+            "tools",
+            "allowed_tools",
+            "disallowed_tools",
+            "claude_permission_mode",
+            "claude_tools",
+            "claude_allowed_tools",
+            "claude_disallowed_tools",
+            "codex_sandbox",
+            "codex_approval_policy",
+        ] {
+            if root.contains_key(legacy) {
+                bail!(
+                    "legacy permission setting {legacy:?} is no longer supported; select a named permission_profile instead"
+                );
+            }
         }
         flatten_provider_section(
             root,
@@ -141,25 +153,73 @@ impl Config {
             })
     }
 
-    pub fn agent_for_message(&self, channel: &str, thread: &str) -> Result<AgentBackend> {
+    pub fn route_for_message(&self, channel: &str, thread: &str) -> Result<RouteSelection> {
         for route in self.routes.iter().filter(|route| route.thread.is_some()) {
             if route.matches_thread(channel, thread) {
-                return AgentBackend::parse(&route.agent);
+                return self.resolve_route(route);
             }
         }
         if let Some(parent) = telegram_parent_thread(channel, thread) {
             for route in self.routes.iter().filter(|route| route.thread.is_some()) {
                 if route.matches_thread(channel, parent) {
-                    return AgentBackend::parse(&route.agent);
+                    return self.resolve_route(route);
                 }
             }
         }
         for route in self.routes.iter().filter(|route| route.thread.is_none()) {
             if route.matches(channel, thread) {
-                return AgentBackend::parse(&route.agent);
+                return self.resolve_route(route);
             }
         }
-        self.agent_backend()
+        Ok(RouteSelection {
+            backend: self.agent_backend()?,
+            permission: self.resolve_permission_profile(&self.permission_profile)?,
+        })
+    }
+
+    pub fn permission_for_job(&self, name: &str) -> Result<PermissionProfile> {
+        let profile = self
+            .resolve_permission_profile(name)
+            .with_context(|| format!("invalid job permission profile {name:?}"))?;
+        if !self
+            .job_permission_profiles
+            .iter()
+            .any(|allowed| allowed == name)
+        {
+            bail!(
+                "job permission profile {:?} is not included in job_permission_profiles",
+                profile.name
+            );
+        }
+        Ok(profile)
+    }
+
+    fn resolve_route(&self, route: &RouteRule) -> Result<RouteSelection> {
+        let profile = route
+            .permission_profile
+            .as_deref()
+            .unwrap_or(&self.permission_profile);
+        Ok(RouteSelection {
+            backend: AgentBackend::parse(&route.agent)?,
+            permission: self.resolve_permission_profile(profile)?,
+        })
+    }
+
+    fn resolve_permission_profile(&self, name: &str) -> Result<PermissionProfile> {
+        let capability = match name {
+            "restricted" => PermissionCapability::ReadOnly,
+            "workspace" => PermissionCapability::Workspace,
+            "full-access" => PermissionCapability::FullAccess,
+            custom => self
+                .permission_profiles
+                .get(custom)
+                .with_context(|| format!("unknown permission profile {custom:?}"))?
+                .capability()?,
+        };
+        Ok(PermissionProfile {
+            name: name.to_string(),
+            capability,
+        })
     }
 
     pub fn required_agent_bins(&self) -> Result<Vec<&str>> {
@@ -209,6 +269,23 @@ impl Config {
             }
         }
         self.agent_backend()?;
+        self.resolve_permission_profile(&self.permission_profile)
+            .context("invalid default permission profile")?;
+        for (name, profile) in &self.permission_profiles {
+            if name.trim().is_empty() {
+                bail!("permission profile names cannot be empty");
+            }
+            if matches!(name.as_str(), "restricted" | "workspace" | "full-access") {
+                bail!("built-in permission profile {name:?} cannot be redefined");
+            }
+            profile
+                .capability()
+                .with_context(|| format!("invalid permission profile {name:?}"))?;
+        }
+        for name in &self.job_permission_profiles {
+            self.permission_for_job(name)
+                .with_context(|| format!("invalid job permission profile {name:?}"))?;
+        }
         for route in &self.routes {
             AgentBackend::parse(&route.agent)
                 .with_context(|| format!("invalid route agent for {route:?}"))?;
@@ -221,33 +298,12 @@ impl Config {
             if let Some(channel) = &route.channel {
                 ChannelKind::parse(channel).context("invalid route channel")?;
             }
-        }
-        for tool in self
-            .claude_allowed_tools
-            .iter()
-            .chain(self.claude_disallowed_tools.iter())
-        {
-            if tool.trim().is_empty() {
-                bail!("claude tool filters cannot contain empty entries");
-            }
-        }
-        if self.claude_tools.as_ref().is_some_and(Vec::is_empty) {
-            bail!("claude_tools must be null or contain at least one entry");
-        }
-        if !matches!(
-            self.codex_sandbox.as_str(),
-            "read-only" | "workspace-write" | "danger-full-access"
-        ) {
-            bail!("invalid codex_sandbox {}; expected read-only, workspace-write, or danger-full-access", self.codex_sandbox);
-        }
-        if !matches!(
-            self.codex_approval_policy.as_str(),
-            "untrusted" | "on-request" | "never"
-        ) {
-            bail!(
-                "invalid codex_approval_policy {}; expected untrusted, on-request, or never",
-                self.codex_approval_policy
-            );
+            let profile = route
+                .permission_profile
+                .as_deref()
+                .unwrap_or(&self.permission_profile);
+            self.resolve_permission_profile(profile)
+                .with_context(|| format!("invalid permission profile for route {route:?}"))?;
         }
         self.poll_interval_dur()?;
         self.run_timeout_dur()?;
@@ -291,6 +347,51 @@ pub struct RouteRule {
     #[serde(default)]
     pub channel: Option<String>,
     pub agent: String,
+    #[serde(default)]
+    pub permission_profile: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteSelection {
+    pub backend: AgentBackend,
+    pub permission: PermissionProfile,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct PermissionProfileConfig {
+    pub capability: String,
+}
+
+impl PermissionProfileConfig {
+    fn capability(&self) -> Result<PermissionCapability> {
+        PermissionCapability::parse(&self.capability)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PermissionProfile {
+    pub name: String,
+    pub capability: PermissionCapability,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PermissionCapability {
+    ReadOnly,
+    Workspace,
+    FullAccess,
+}
+
+impl PermissionCapability {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "read-only" => Ok(Self::ReadOnly),
+            "workspace" => Ok(Self::Workspace),
+            "full-access" => Ok(Self::FullAccess),
+            other => bail!(
+                "invalid permission capability {other:?}; expected read-only, workspace, or full-access"
+            ),
+        }
+    }
 }
 
 impl RouteRule {
@@ -396,17 +497,14 @@ fn default_agent() -> String {
 fn default_claude_bin() -> String {
     "claude".to_string()
 }
-fn default_claude_permission_mode() -> String {
-    "bypassPermissions".to_string()
-}
 fn default_codex_bin() -> String {
     "codex".to_string()
 }
-fn default_codex_sandbox() -> String {
-    "workspace-write".to_string()
+fn default_permission_profile() -> String {
+    "restricted".to_string()
 }
-fn default_codex_approval_policy() -> String {
-    "never".to_string()
+fn default_job_permission_profiles() -> Vec<String> {
+    vec!["restricted".to_string()]
 }
 fn default_sessions_dir() -> String {
     "~/.push/sessions".to_string()

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -22,7 +22,7 @@ use crate::audit::{AuditEvent, AuditLog};
 use crate::channel::{Channel, RawMessage};
 use crate::claude;
 use crate::codex;
-use crate::config::{AgentBackend, Config};
+use crate::config::{AgentBackend, Config, PermissionProfile};
 use crate::history::{DeliveryStatus, History, OutboundMessage, OutboundOrigin};
 use crate::soul;
 use crate::store::Store;
@@ -45,6 +45,7 @@ struct Job {
     thread: String,
     target: String,
     backend: AgentBackend,
+    permission: PermissionProfile,
     text: String,
 }
 
@@ -244,7 +245,7 @@ impl Gateway {
                         return;
                     }
                 };
-                let backend = match self.cfg.agent_for_message(m.channel, &thread) {
+                let route = match self.cfg.route_for_message(m.channel, &thread) {
                     Ok(v) => v,
                     Err(e) => {
                         error!("[{thread}] route error: {e}");
@@ -259,6 +260,7 @@ impl Gateway {
                         continue;
                     }
                 };
+                let backend = route.backend;
                 self.audit(self.ctx.audit.accepted(m, &thread, backend));
                 info!(
                     "[{thread}] new message accepted; routing to {}",
@@ -270,6 +272,7 @@ impl Gateway {
                     thread,
                     target,
                     backend,
+                    permission: route.permission,
                     text: m.text.trim().to_string(),
                 };
                 if !self.route(job, handles).await {
@@ -507,6 +510,7 @@ async fn handle(ctx: &Ctx, job: Job) {
         is_new,
         work_dir: &work_dir,
         instructions: &instructions,
+        permission: job.permission.capability,
         prompt: &job.text,
     };
 
@@ -925,18 +929,12 @@ fn runners(cfg: &Config) -> HashMap<AgentBackend, Runner> {
         AgentBackend::Claude,
         Runner::Claude(claude::Runner {
             bin: cfg.claude_bin.clone(),
-            permission_mode: cfg.claude_permission_mode.clone(),
-            tools: cfg.claude_tools.clone(),
-            allowed_tools: cfg.claude_allowed_tools.clone(),
-            disallowed_tools: cfg.claude_disallowed_tools.clone(),
         }),
     );
     runners.insert(
         AgentBackend::Codex,
         Runner::Codex(codex::Runner {
             bin: cfg.codex_bin.clone(),
-            sandbox: cfg.codex_sandbox.clone(),
-            approval_policy: cfg.codex_approval_policy.clone(),
             model: cfg.codex_model.clone(),
         }),
     );
@@ -1167,10 +1165,6 @@ mod tests {
             AgentBackend::Claude,
             Runner::Claude(claude::Runner {
                 bin: "claude".to_string(),
-                permission_mode: "bypassPermissions".to_string(),
-                tools: None,
-                allowed_tools: Vec::new(),
-                disallowed_tools: Vec::new(),
             }),
         );
         let history_path = temp_path("setup-failure-history");
@@ -1209,6 +1203,10 @@ mod tests {
             thread: "imessage:self:me".to_string(),
             target: "me@icloud.com".to_string(),
             backend: AgentBackend::Claude,
+            permission: PermissionProfile {
+                name: "restricted".to_string(),
+                capability: crate::config::PermissionCapability::ReadOnly,
+            },
             text: "hello".to_string(),
         }
     }
@@ -1518,12 +1516,18 @@ mod tests {
         let assistant_dir = temp_path("e2e-assistant");
         std::fs::create_dir_all(&assistant_dir).unwrap();
         let calls = Arc::new(Mutex::new(Vec::new()));
-        let mut gateway = Gateway::new(test_config(
+        let mut cfg = test_config(
             &state_path,
             sessions_dir.to_str().unwrap(),
             assistant_dir.to_str().unwrap(),
-        ))
-        .unwrap();
+        );
+        cfg.routes = vec![crate::config::RouteRule {
+            thread: Some("imessage:dm:+15551234567".to_string()),
+            channel: None,
+            agent: "codex".to_string(),
+            permission_profile: Some("workspace".to_string()),
+        }];
+        let mut gateway = Gateway::new(cfg).unwrap();
         gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
 
         let mut handles = Vec::new();
@@ -1563,11 +1567,13 @@ mod tests {
                     session_id: String::new(),
                     is_new: true,
                     prompt: "first".to_string(),
+                    permission: crate::config::PermissionCapability::Workspace,
                 },
                 FakeRunCall {
                     session_id: "fake-session".to_string(),
                     is_new: false,
                     prompt: "second".to_string(),
+                    permission: crate::config::PermissionCapability::Workspace,
                 }
             ]
         );
@@ -2024,14 +2030,11 @@ mod tests {
             telegram_allow_chat_ids: Vec::new(),
             agent: "codex".to_string(),
             routes: Vec::new(),
+            permission_profile: "restricted".to_string(),
+            job_permission_profiles: vec!["restricted".to_string()],
+            permission_profiles: HashMap::new(),
             claude_bin: "claude".to_string(),
-            claude_permission_mode: "bypassPermissions".to_string(),
-            claude_tools: None,
-            claude_allowed_tools: Vec::new(),
-            claude_disallowed_tools: Vec::new(),
             codex_bin: "codex".to_string(),
-            codex_sandbox: "workspace-write".to_string(),
-            codex_approval_policy: "never".to_string(),
             codex_model: None,
             sessions_dir: sessions_dir.to_string(),
             state_path: state_path.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,9 +134,10 @@ fn check_config(cfg: &config::Config, checks: &mut Vec<Check>) {
     checks.push(Check::pass(
         "config",
         format!(
-            "channel={}, agent={}, imessage.self_handles={}, imessage.allow_from={}, telegram.allow_user_ids={}, telegram.allow_chat_ids={}",
+            "channel={}, agent={}, permission_profile={}, imessage.self_handles={}, imessage.allow_from={}, telegram.allow_user_ids={}, telegram.allow_chat_ids={}",
             cfg.channel,
             cfg.agent,
+            cfg.permission_profile,
             cfg.self_handles.len(),
             cfg.allow_from.len(),
             cfg.telegram_allow_user_ids.len(),
@@ -441,6 +442,8 @@ mod tests {
         assert_eq!(cfg.telegram_bot_token_env, "TELEGRAM_BOT_TOKEN");
         assert_eq!(cfg.telegram_allow_user_ids, [123456789]);
         assert!(cfg.telegram_allow_chat_ids.is_empty());
+        assert_eq!(cfg.permission_profile, "restricted");
+        assert!(cfg.permission_profiles.is_empty());
         assert_eq!(
             cfg.database_path,
             Path::new(&std::env::var("HOME").unwrap())
@@ -642,7 +645,7 @@ claude_tools = []
     }
 
     #[test]
-    fn doctor_accepts_unprefixed_claude_tool_filter_aliases() {
+    fn config_rejects_legacy_claude_tool_filter_aliases() {
         let path = temp_path("claude-tool-alias-config");
         std::fs::write(
             &path,
@@ -653,15 +656,14 @@ disallowed_tools = ["Edit"]
         )
         .unwrap();
 
-        let cfg = Config::load(path.to_str().unwrap()).unwrap();
+        let error = Config::load(path.to_str().unwrap()).unwrap_err();
 
-        assert_eq!(cfg.claude_allowed_tools, vec!["Read"]);
-        assert_eq!(cfg.claude_disallowed_tools, vec!["Edit"]);
+        assert!(error.to_string().contains("named permission_profile"));
         let _ = std::fs::remove_file(path);
     }
 
     #[test]
-    fn doctor_accepts_unprefixed_claude_tools_alias() {
+    fn config_rejects_legacy_claude_tools_alias() {
         let path = temp_path("claude-tools-alias-config");
         std::fs::write(
             &path,
@@ -671,12 +673,9 @@ tools = ["Read", "Grep"]
         )
         .unwrap();
 
-        let cfg = Config::load(path.to_str().unwrap()).unwrap();
+        let error = Config::load(path.to_str().unwrap()).unwrap_err();
 
-        assert_eq!(
-            cfg.claude_tools,
-            Some(vec!["Read".to_string(), "Grep".to_string()])
-        );
+        assert!(error.to_string().contains("named permission_profile"));
         let _ = std::fs::remove_file(path);
     }
 
@@ -708,6 +707,7 @@ tools = ["Read", "Grep"]
             thread: None,
             channel: Some("imessage".to_string()),
             agent: "claude".to_string(),
+            permission_profile: None,
         }];
         let mut checks = Vec::new();
 
@@ -751,47 +751,127 @@ tools = ["Read", "Grep"]
                 thread: None,
                 channel: Some("telegram".to_string()),
                 agent: "codex".to_string(),
+                permission_profile: Some("workspace".to_string()),
             },
             config::RouteRule {
                 thread: Some("telegram:dm:7".to_string()),
                 channel: None,
                 agent: "claude".to_string(),
+                permission_profile: None,
             },
             config::RouteRule {
                 thread: Some("telegram:dm:7:topic:99".to_string()),
                 channel: None,
                 agent: "codex".to_string(),
+                permission_profile: None,
             },
             config::RouteRule {
                 thread: Some("self:me@icloud.com".to_string()),
                 channel: None,
                 agent: "codex".to_string(),
+                permission_profile: None,
             },
         ];
 
         assert_eq!(
-            cfg.agent_for_message("telegram", "telegram:dm:7").unwrap(),
+            cfg.route_for_message("telegram", "telegram:dm:7")
+                .unwrap()
+                .backend,
             config::AgentBackend::Claude
         );
         assert_eq!(
-            cfg.agent_for_message("telegram", "telegram:dm:8").unwrap(),
+            cfg.route_for_message("telegram", "telegram:dm:8")
+                .unwrap()
+                .backend,
             config::AgentBackend::Codex
         );
         assert_eq!(
-            cfg.agent_for_message("telegram", "telegram:dm:7:topic:99")
-                .unwrap(),
+            cfg.route_for_message("telegram", "telegram:dm:8")
+                .unwrap()
+                .permission
+                .capability,
+            config::PermissionCapability::Workspace
+        );
+        assert_eq!(
+            cfg.route_for_message("telegram", "telegram:dm:7:topic:99")
+                .unwrap()
+                .backend,
             config::AgentBackend::Codex
         );
         assert_eq!(
-            cfg.agent_for_message("telegram", "telegram:dm:7:topic:100")
-                .unwrap(),
+            cfg.route_for_message("telegram", "telegram:dm:7:topic:100")
+                .unwrap()
+                .backend,
             config::AgentBackend::Claude
         );
         assert_eq!(
-            cfg.agent_for_message("imessage", "imessage:self:me@icloud.com")
-                .unwrap(),
+            cfg.route_for_message("imessage", "imessage:self:me@icloud.com")
+                .unwrap()
+                .backend,
             config::AgentBackend::Codex
         );
+    }
+
+    #[test]
+    fn unknown_route_permission_profile_fails_config_load() {
+        let path = temp_path("unknown-route-permission");
+        std::fs::write(
+            &path,
+            r#"self_handles = ["me@icloud.com"]
+
+[[routes]]
+channel = "imessage"
+agent = "claude"
+permission_profile = "missing"
+"#,
+        )
+        .unwrap();
+
+        let error = Config::load(path.to_str().unwrap()).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("invalid permission profile for route"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn job_profile_errors_are_scoped_and_enforce_named_allow_list() {
+        let path = temp_path("job-permission-profile");
+        std::fs::write(
+            &path,
+            r#"self_handles = ["me@icloud.com"]
+job_permission_profiles = ["job-writer"]
+
+[permission_profiles.job-writer]
+capability = "workspace"
+"#,
+        )
+        .unwrap();
+        let cfg = Config::load(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            cfg.permission_for_job("job-writer").unwrap().capability,
+            config::PermissionCapability::Workspace
+        );
+        assert!(cfg
+            .permission_for_job("missing")
+            .unwrap_err()
+            .to_string()
+            .contains("invalid job permission profile"));
+        assert!(cfg
+            .permission_for_job("workspace")
+            .unwrap_err()
+            .to_string()
+            .contains("is not included in job_permission_profiles"));
+        assert_eq!(
+            cfg.route_for_message("imessage", "imessage:self:me@icloud.com")
+                .unwrap()
+                .permission
+                .capability,
+            config::PermissionCapability::ReadOnly
+        );
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]
@@ -866,14 +946,11 @@ tools = ["Read", "Grep"]
             telegram_allow_chat_ids: Vec::new(),
             agent: "codex".to_string(),
             routes: Vec::new(),
+            permission_profile: "restricted".to_string(),
+            job_permission_profiles: vec!["restricted".to_string()],
+            permission_profiles: std::collections::HashMap::new(),
             claude_bin: "/fake/claude".to_string(),
-            claude_permission_mode: "bypassPermissions".to_string(),
-            claude_tools: None,
-            claude_allowed_tools: Vec::new(),
-            claude_disallowed_tools: Vec::new(),
             codex_bin: "/fake/codex".to_string(),
-            codex_sandbox: "workspace-write".to_string(),
-            codex_approval_policy: "never".to_string(),
             codex_model: None,
             sessions_dir: "/fake/sessions".to_string(),
             state_path: "/fake/state.json".to_string(),

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use crate::agent::{Request, RunError, RunOutput};
+use crate::config::PermissionCapability;
 
 pub struct FakeCli {
     root: PathBuf,
@@ -74,6 +75,7 @@ pub struct ContractRequest {
     pub is_new: bool,
     pub work_dir: PathBuf,
     pub instructions: String,
+    pub permission: PermissionCapability,
     pub prompt: String,
 }
 
@@ -84,6 +86,7 @@ impl ContractRequest {
             is_new: self.is_new,
             work_dir: self.work_dir.to_str().unwrap(),
             instructions: &self.instructions,
+            permission: self.permission,
             prompt: &self.prompt,
         }
     }


### PR DESCRIPTION
## Summary

- add restrictive built-in and custom named permission profiles
- resolve route profiles before polling and carry the selected capability to each backend request
- translate read-only, workspace, and explicit full-access capabilities to conservative Claude Code and Codex controls
- add an explicit job profile allow-list that defaults to `restricted`
- reject legacy raw backend permission flags with a migration error and document backend differences

## Why

Unattended routes and future jobs need inspectable Push-owned permissions instead of broad backend defaults. The job allow-list ensures a job can select only an operator-approved profile name and cannot construct arbitrary backend flags.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (122 passed)
- `git diff --check`
- independent subagent review completed; one job authorization finding fixed and re-reviewed with no remaining findings

## Risks

- Existing raw Claude or Codex permission settings now fail with an actionable migration error.
- Claude Code has no Codex-equivalent filesystem sandbox, so its workspace profile permits file tools but deliberately denies Bash.

## Related issue

Closes #58
