### PR TITLE
feat: add durable ask-user approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,18 @@ message is capped at 4 KiB, and the complete history block is capped at 16 KiB.
 `SOUL.md` remains separate backend instruction context. Audit events record
 whether a run was new and how many messages were used for rehydration.
 
+`ask_user` is the durable approval boundary for later workflows. It stores a
+bounded question in `push.db` before sending the same plain numbered list on
+iMessage or Telegram. A reply may be a number when exactly one question is
+pending for that origin, or `<correlation-id> <number>`. Answers are bound to
+the allowlisted sender, chat, channel, and exact thread or Telegram topic. The
+workflow can consume the normalized selected value once. Pending questions
+survive restart; expired, cancelled, duplicate, ambiguous, and mismatched
+replies never reach an agent and are recorded in the audit log. Failed delivery
+leaves the question persisted with failed delivery status for diagnosis or
+cancellation. Approval replies are control inputs, so they update approval and
+audit state without entering the conversation transcript used for rehydration.
+
 ## Telegram Support
 
 Telegram uses Bot API long polling, so push opens no public port and needs no

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,10 +201,22 @@ each inbound message to its outbound response preserves the generation/delivery
 crash boundary. SQLite history does not replace `state.json` cursors or backend
 session IDs in this phase.
 
+The same database stores `ask_user` questions before delivery. Each question
+has a UUID correlation id, two to nine bounded choices, an expiry, delivery
+state, and an exact channel, sender, chat, and thread/topic binding. Inbound
+numbered replies pass the normal allowlist first, then resolve transactionally
+to one normalized value. The workflow consumes an answer at most once. Pending
+questions survive restart; cancellation and expiry are terminal, and rejected
+or duplicate answer attempts are audited without reaching a backend session or
+the rehydrated conversation transcript. Workflows can poll the durable question
+state and consume an answered value once; crossing the expiry first records an
+expired terminal state, so later cancellation cannot overwrite the timeout.
+
 `audit_log_path` stores a local JSONL event stream for production debugging.
-Audit events record message metadata, routing decisions, backend run starts and
-failures, reply delivery metadata, and row completion. Message and reply text
-are redacted by default; `audit_log_content` opts into content logging.
+Audit events record message metadata, routing decisions, approval outcomes,
+backend run starts and failures, reply delivery metadata, and row completion.
+Message and reply text are redacted by default; `audit_log_content` opts into
+content logging.
 
 ## Assistant Identity
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -83,6 +83,7 @@ push takes a narrower bet:
 - `src/imessage/sender.rs`: sends replies through AppleScript.
 - `src/gateway.rs`: poll loop, filtering, commands, queues, worker dispatch.
 - `src/history.rs`: canonical SQLite conversations and messages.
+- `src/approval.rs`: durable bounded questions and normalized answers.
 - `src/agent.rs`: backend boundary.
 - `src/claude.rs`: Claude Code adapter.
 - `src/codex.rs`: Codex adapter.

--- a/src/approval.rs
+++ b/src/approval.rs
@@ -1,0 +1,264 @@
+//! Channel-neutral, durable user questions and normalized answers.
+//!
+//! Creation and answer-consumption entry points are intentionally ready for
+//! the drafted-jobs workflow; inbound answer resolution is active now.
+
+#![allow(dead_code)]
+
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+pub const MAX_CHOICES: usize = 9;
+const MAX_PROMPT_CHARS: usize = 2_000;
+const MAX_LABEL_CHARS: usize = 256;
+const MAX_VALUE_CHARS: usize = 256;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Choice {
+    pub label: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Question {
+    pub id: String,
+    pub channel: String,
+    pub thread_key: String,
+    pub sender_key: String,
+    pub chat_key: String,
+    pub target: String,
+    pub prompt: String,
+    pub choices: Vec<Choice>,
+    pub expires_at_ms: i64,
+}
+
+impl Question {
+    pub fn new(
+        origin: AnswerOrigin,
+        target: impl Into<String>,
+        prompt: impl Into<String>,
+        choices: Vec<Choice>,
+        expires_at_ms: i64,
+    ) -> Result<Self> {
+        let question = Self {
+            id: Uuid::new_v4().to_string(),
+            channel: origin.channel,
+            thread_key: origin.thread_key,
+            sender_key: origin.sender_key,
+            chat_key: origin.chat_key,
+            target: target.into(),
+            prompt: prompt.into(),
+            choices,
+            expires_at_ms,
+        };
+        question.validate()?;
+        Ok(question)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if Uuid::parse_str(&self.id)
+            .map(|id| id.to_string() != self.id)
+            .unwrap_or(true)
+        {
+            bail!("approval correlation id must be a UUID");
+        }
+        if self.channel.trim().is_empty()
+            || self.thread_key.trim().is_empty()
+            || self.sender_key.trim().is_empty()
+            || self.chat_key.trim().is_empty()
+            || self.target.trim().is_empty()
+            || self.prompt.trim().is_empty()
+        {
+            bail!("approval question fields cannot be empty");
+        }
+        if !(2..=MAX_CHOICES).contains(&self.choices.len()) {
+            bail!("approval question must contain 2 to {MAX_CHOICES} choices");
+        }
+        if self.prompt.chars().count() > MAX_PROMPT_CHARS {
+            bail!("approval prompt exceeds {MAX_PROMPT_CHARS} characters");
+        }
+        if self.choices.iter().any(|choice| {
+            choice.label.trim().is_empty()
+                || choice.value.trim().is_empty()
+                || choice.label.chars().count() > MAX_LABEL_CHARS
+                || choice.value.chars().count() > MAX_VALUE_CHARS
+        }) {
+            bail!("approval choice labels and values must be non-empty and bounded");
+        }
+        Ok(())
+    }
+
+    pub fn render_text(&self) -> String {
+        let mut text = format!("{}\n", self.prompt.trim());
+        for (index, choice) in self.choices.iter().enumerate() {
+            text.push_str(&format!("\n{}. {}", index + 1, choice.label.trim()));
+        }
+        text.push_str(&format!(
+            "\n\nReply with a number, or `{} <number>`. Expires automatically.",
+            self.id
+        ));
+        text
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedAnswer {
+    pub correlation_id: String,
+    pub selected_number: usize,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnswerAttempt {
+    pub correlation_id: Option<String>,
+    pub selected_number: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnswerOrigin {
+    pub channel: String,
+    pub thread_key: String,
+    pub sender_key: String,
+    pub chat_key: String,
+}
+
+pub fn parse_answer(text: &str) -> Option<AnswerAttempt> {
+    let parts = text.split_whitespace().collect::<Vec<_>>();
+    if let Some(correlation_id) = parts.first().and_then(|value| Uuid::parse_str(value).ok()) {
+        let selected_number = match parts.as_slice() {
+            [_, number] => number.parse().unwrap_or_default(),
+            _ => 0,
+        };
+        return Some(AnswerAttempt {
+            correlation_id: Some(correlation_id.to_string()),
+            selected_number,
+        });
+    }
+    match parts.as_slice() {
+        [number] => number.parse().ok().map(|selected_number| AnswerAttempt {
+            correlation_id: None,
+            selected_number,
+        }),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnswerOutcome {
+    NotAnAnswer,
+    Selected(NormalizedAnswer),
+    Expired(String),
+    Duplicate(String),
+    Cancelled(String),
+    Mismatched(String),
+    InvalidChoice(String),
+    Ambiguous,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryStatus {
+    Delivered,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuestionState {
+    Pending,
+    Answered,
+    Consumed,
+    Expired,
+    Cancelled,
+}
+
+impl QuestionState {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "answered" => Ok(Self::Answered),
+            "consumed" => Ok(Self::Consumed),
+            "expired" => Ok(Self::Expired),
+            "cancelled" => Ok(Self::Cancelled),
+            other => bail!("invalid approval question state {other:?}"),
+        }
+    }
+}
+
+impl DeliveryStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Delivered => "delivered",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_and_correlated_numbered_answers() {
+        let id = Uuid::new_v4().to_string();
+        assert_eq!(
+            parse_answer(" 2 "),
+            Some(AnswerAttempt {
+                correlation_id: None,
+                selected_number: 2,
+            })
+        );
+        assert_eq!(
+            parse_answer(&format!("{id} 1")),
+            Some(AnswerAttempt {
+                correlation_id: Some(id.clone()),
+                selected_number: 1,
+            })
+        );
+        assert_eq!(parse_answer("yes"), None);
+        assert_eq!(
+            parse_answer(&format!("{id} junk")),
+            Some(AnswerAttempt {
+                correlation_id: Some(id.clone()),
+                selected_number: 0,
+            })
+        );
+        assert_eq!(
+            parse_answer(&format!("{} 2", id.to_uppercase())),
+            Some(AnswerAttempt {
+                correlation_id: Some(id),
+                selected_number: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn question_validation_bounds_prompt_choices_and_correlation() {
+        let origin = AnswerOrigin {
+            channel: "imessage".to_string(),
+            thread_key: "imessage:self:me".to_string(),
+            sender_key: "me".to_string(),
+            chat_key: "me".to_string(),
+        };
+        let choices = vec![
+            Choice {
+                label: "Yes".to_string(),
+                value: "yes".to_string(),
+            },
+            Choice {
+                label: "No".to_string(),
+                value: "no".to_string(),
+            },
+        ];
+        assert!(Question::new(
+            origin.clone(),
+            "me",
+            "x".repeat(MAX_PROMPT_CHARS + 1),
+            choices.clone(),
+            1,
+        )
+        .is_err());
+        let mut question = Question::new(origin, "me", "Continue?", choices, 1).unwrap();
+        question.id = "not-a-uuid".to_string();
+        assert!(question.validate().is_err());
+    }
+}

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -206,6 +206,18 @@ impl AuditLog {
         event.reason = Some(reason.into());
         event
     }
+
+    pub fn approval(
+        &self,
+        event_name: &'static str,
+        row_id: i64,
+        thread: &str,
+        reason: impl Into<String>,
+    ) -> AuditEvent {
+        let mut event = self.base(event_name, Some(row_id), Some(thread), None);
+        event.reason = Some(reason.into());
+        event
+    }
     fn base(
         &self,
         event: &'static str,

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -18,6 +18,9 @@ use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
 use crate::agent::{Request, RunError, Runner};
+use crate::approval::{
+    AnswerOrigin, AnswerOutcome, DeliveryStatus as ApprovalDeliveryStatus, Question,
+};
 use crate::audit::{AuditEvent, AuditLog};
 use crate::channel::{Channel, RawMessage};
 use crate::claude;
@@ -131,6 +134,36 @@ impl Gateway {
         })
     }
 
+    #[allow(dead_code)]
+    pub async fn ask_user(&self, question: Question) -> Result<String> {
+        if question.channel != self.channel.id() {
+            anyhow::bail!(
+                "question channel {:?} does not match running channel {:?}",
+                question.channel,
+                self.channel.id()
+            );
+        }
+        let id = question.id.clone();
+        self.ctx
+            .history
+            .lock()
+            .unwrap()
+            .create_question(&question, now_ms())?;
+        let delivered = reply_to(&self.ctx, &question.target, &question.render_text()).await;
+        self.ctx.history.lock().unwrap().mark_question_delivery(
+            &id,
+            if delivered {
+                ApprovalDeliveryStatus::Delivered
+            } else {
+                ApprovalDeliveryStatus::Failed
+            },
+        )?;
+        if !delivered {
+            anyhow::bail!("approval question {id} could not be delivered");
+        }
+        Ok(id)
+    }
+
     /// Runs until SIGINT/SIGTERM, then drains in-flight runs and returns.
     pub async fn run(mut self) -> Result<()> {
         self.skip_backlog().await?;
@@ -223,6 +256,30 @@ impl Gateway {
                 continue;
             }
             if let Some((thread, target)) = self.channel.accept(m) {
+                let approval = self.ctx.history.lock().unwrap().answer_question(
+                    &approval_origin(m, &thread),
+                    m.text.trim(),
+                    now_ms(),
+                );
+                match approval {
+                    Ok(AnswerOutcome::NotAnAnswer) => {}
+                    Ok(outcome) => {
+                        self.audit_approval(m.row_id, &thread, &outcome);
+                        self.complete_row(m.row_id, "approval_answer");
+                        continue;
+                    }
+                    Err(error) => {
+                        error!("[{thread}] approval lookup failed: {error}");
+                        self.audit(self.ctx.audit.failed(
+                            "approval_answer_failed",
+                            m.row_id,
+                            &thread,
+                            None,
+                            error.to_string(),
+                        ));
+                        return;
+                    }
+                }
                 let inbound_id = match self.ctx.history.lock().unwrap().record_inbound(
                     m.channel,
                     &thread,
@@ -353,6 +410,33 @@ impl Gateway {
 
     fn audit(&self, event: AuditEvent) {
         audit(&self.ctx, event);
+    }
+
+    fn audit_approval(&self, row_id: i64, thread: &str, outcome: &AnswerOutcome) {
+        let (event, reason) = match outcome {
+            AnswerOutcome::Selected(answer) => (
+                "approval_answer_selected",
+                format!(
+                    "correlation_id={}, selected_number={}",
+                    answer.correlation_id, answer.selected_number
+                ),
+            ),
+            AnswerOutcome::Expired(id) => ("approval_answer_rejected", format!("expired:{id}")),
+            AnswerOutcome::Duplicate(id) => ("approval_answer_rejected", format!("duplicate:{id}")),
+            AnswerOutcome::Cancelled(id) => ("approval_answer_rejected", format!("cancelled:{id}")),
+            AnswerOutcome::Mismatched(id) => {
+                ("approval_answer_rejected", format!("mismatched:{id}"))
+            }
+            AnswerOutcome::InvalidChoice(id) => {
+                ("approval_answer_rejected", format!("invalid_choice:{id}"))
+            }
+            AnswerOutcome::Ambiguous => (
+                "approval_answer_rejected",
+                "ambiguous_plain_number".to_string(),
+            ),
+            AnswerOutcome::NotAnAnswer => return,
+        };
+        self.audit(self.ctx.audit.approval(event, row_id, thread, reason));
     }
 }
 
@@ -1106,6 +1190,37 @@ fn backend_request<'a>(
     }
 }
 
+fn approval_origin(message: &RawMessage, thread: &str) -> AnswerOrigin {
+    if message.channel == "imessage" {
+        let chat_key = crate::channel::normalize_handle(&message.chat_identifier);
+        let sender_key = if thread.starts_with("imessage:self:") {
+            chat_key.clone()
+        } else {
+            crate::channel::normalize_handle(&message.handle)
+        };
+        AnswerOrigin {
+            channel: message.channel.to_string(),
+            thread_key: thread.to_string(),
+            sender_key,
+            chat_key,
+        }
+    } else {
+        AnswerOrigin {
+            channel: message.channel.to_string(),
+            thread_key: thread.to_string(),
+            sender_key: message.handle.clone(),
+            chat_key: message.chat_identifier.clone(),
+        }
+    }
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or_default()
+}
+
 /// Turns a thread key into a filesystem-safe directory name.
 fn sanitize(s: &str) -> String {
     s.chars()
@@ -1763,6 +1878,260 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn imessage_question_delivers_and_plain_number_resolves_once() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("imessage-approval-sessions");
+        let assistant_dir = temp_path("imessage-approval-assistant");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut gateway = Gateway::new(test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        ))
+        .unwrap();
+        gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+        let question = approval_question(
+            "imessage",
+            "imessage:self:me@icloud.com",
+            "me@icloud.com",
+            "me@icloud.com",
+            "me@icloud.com",
+        );
+        let id = gateway.ask_user(question).await.unwrap();
+
+        run_messages(
+            &mut gateway,
+            vec![
+                message(1, "me@icloud.com", "", true, "2"),
+                message(2, "me@icloud.com", "", true, "2"),
+            ],
+        )
+        .await;
+
+        assert!(calls.lock().unwrap().is_empty());
+        assert!(gateway.ctx.sent_replies.lock().unwrap()[0]
+            .1
+            .contains("1. Approve"));
+        assert_eq!(
+            gateway
+                .ctx
+                .history
+                .lock()
+                .unwrap()
+                .take_answer(&id, now_ms())
+                .unwrap()
+                .unwrap()
+                .value,
+            "reject"
+        );
+        run_messages(
+            &mut gateway,
+            vec![message(3, "me@icloud.com", "", true, "hello")],
+        )
+        .await;
+        assert_eq!(calls.lock().unwrap().len(), 1);
+        assert_eq!(calls.lock().unwrap()[0].prompt, "hello");
+        let events = audit_events(&format!("{state_path}.audit.jsonl"));
+        assert!(events
+            .iter()
+            .any(|event| event.event == "approval_answer_selected"));
+        assert!(events.iter().any(|event| {
+            event.event == "approval_answer_rejected"
+                && event.reason.as_deref() == Some(&format!("duplicate:{id}"))
+        }));
+
+        let _ = std::fs::remove_file(&state_path);
+        let _ = std::fs::remove_file(format!("{state_path}.db"));
+        let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+        let _ = std::fs::remove_dir_all(sessions_dir);
+        let _ = std::fs::remove_dir_all(assistant_dir);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn telegram_question_rejects_wrong_topic_sender_and_duplicate() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("telegram-approval-sessions");
+        let assistant_dir = temp_path("telegram-approval-assistant");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut cfg = test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        );
+        cfg.channel = "telegram".to_string();
+        cfg.self_handles.clear();
+        cfg.allow_from.clear();
+        cfg.telegram_bot_token = Some("secret".to_string());
+        cfg.telegram_allow_user_ids = vec![7, 8];
+        let mut gateway = Gateway::new(cfg).unwrap();
+        gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+        let question = approval_question("telegram", "telegram:dm:7:topic:9", "7", "7", "7:9");
+        let id = gateway.ask_user(question).await.unwrap();
+        let correlated = format!("{id} 1");
+        let mut wrong_topic = telegram_message(10, 7, 7, false, &correlated);
+        wrong_topic.thread_id = None;
+        let mut unallowlisted = telegram_message(11, 9, 7, false, &correlated);
+        unallowlisted.thread_id = Some(9);
+        let mut wrong_sender = telegram_message(12, 8, 7, false, &correlated);
+        wrong_sender.thread_id = Some(9);
+        let mut malformed = telegram_message(13, 7, 7, false, &format!("{id} junk"));
+        malformed.thread_id = Some(9);
+        let mut valid = telegram_message(14, 7, 7, false, "1");
+        valid.thread_id = Some(9);
+        let mut duplicate = telegram_message(15, 7, 7, false, &correlated);
+        duplicate.thread_id = Some(9);
+
+        run_messages(
+            &mut gateway,
+            vec![
+                wrong_topic,
+                unallowlisted,
+                wrong_sender,
+                malformed,
+                valid,
+                duplicate,
+            ],
+        )
+        .await;
+
+        assert!(calls.lock().unwrap().is_empty());
+        let events = audit_events(&format!("{state_path}.audit.jsonl"));
+        assert!(events.iter().any(|event| {
+            event.event == "approval_answer_rejected"
+                && event.reason.as_deref() == Some(&format!("mismatched:{id}"))
+        }));
+        assert!(events
+            .iter()
+            .any(|event| { event.event == "message_ignored" && event.row_id == Some(11) }));
+        assert!(events.iter().any(|event| {
+            event.event == "approval_answer_rejected"
+                && event.reason.as_deref() == Some(&format!("duplicate:{id}"))
+        }));
+        assert!(events.iter().any(|event| {
+            event.event == "approval_answer_rejected"
+                && event.reason.as_deref() == Some(&format!("invalid_choice:{id}"))
+        }));
+        assert_eq!(
+            gateway
+                .ctx
+                .history
+                .lock()
+                .unwrap()
+                .take_answer(&id, now_ms())
+                .unwrap()
+                .unwrap()
+                .value,
+            "approve"
+        );
+
+        let _ = std::fs::remove_file(&state_path);
+        let _ = std::fs::remove_file(format!("{state_path}.db"));
+        let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+        let _ = std::fs::remove_dir_all(sessions_dir);
+        let _ = std::fs::remove_dir_all(assistant_dir);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn failed_question_delivery_keeps_the_durable_pending_question() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("approval-delivery-sessions");
+        let assistant_dir = temp_path("approval-delivery-assistant");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        let gateway = Gateway::new(test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        ))
+        .unwrap();
+        *gateway.ctx.send_failures_remaining.lock().unwrap() = 1;
+        let question = approval_question(
+            "imessage",
+            "imessage:self:me@icloud.com",
+            "me@icloud.com",
+            "me@icloud.com",
+            "me@icloud.com",
+        );
+        let id = question.id.clone();
+
+        assert!(gateway.ask_user(question).await.is_err());
+        assert!(matches!(
+            gateway.ctx.history.lock().unwrap().answer_question(
+                &AnswerOrigin {
+                    channel: "imessage".to_string(),
+                    thread_key: "imessage:self:me@icloud.com".to_string(),
+                    sender_key: "me@icloud.com".to_string(),
+                    chat_key: "me@icloud.com".to_string(),
+                },
+                &format!("{id} 1"),
+                now_ms(),
+            ),
+            Ok(AnswerOutcome::Selected(_))
+        ));
+
+        let _ = std::fs::remove_file(&state_path);
+        let _ = std::fs::remove_file(format!("{state_path}.db"));
+        let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+        let _ = std::fs::remove_dir_all(sessions_dir);
+        let _ = std::fs::remove_dir_all(assistant_dir);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn expired_answer_is_audited_without_reaching_the_backend() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("approval-expiry-sessions");
+        let assistant_dir = temp_path("approval-expiry-assistant");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut gateway = Gateway::new(test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        ))
+        .unwrap();
+        gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+        let mut question = approval_question(
+            "imessage",
+            "imessage:self:me@icloud.com",
+            "me@icloud.com",
+            "me@icloud.com",
+            "me@icloud.com",
+        );
+        let created_at = now_ms();
+        question.expires_at_ms = created_at + 10;
+        let id = question.id.clone();
+        gateway
+            .ctx
+            .history
+            .lock()
+            .unwrap()
+            .create_question(&question, created_at)
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        run_messages(
+            &mut gateway,
+            vec![message(1, "me@icloud.com", "", true, &format!("{id} 1"))],
+        )
+        .await;
+
+        assert!(calls.lock().unwrap().is_empty());
+        assert!(audit_events(&format!("{state_path}.audit.jsonl"))
+            .iter()
+            .any(|event| {
+                event.event == "approval_answer_rejected"
+                    && event.reason.as_deref() == Some(&format!("expired:{id}"))
+            }));
+
+        let _ = std::fs::remove_file(&state_path);
+        let _ = std::fs::remove_file(format!("{state_path}.db"));
+        let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+        let _ = std::fs::remove_dir_all(sessions_dir);
+        let _ = std::fs::remove_dir_all(assistant_dir);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn missing_backend_session_rotates_and_rehydrates_once() {
         let state_path = temp_state_path();
         let sessions_dir = temp_path("missing-session-rehydration");
@@ -2378,6 +2747,37 @@ mod tests {
         for handle in handles {
             handle.await.unwrap();
         }
+    }
+
+    fn approval_question(
+        channel: &str,
+        thread: &str,
+        sender: &str,
+        chat: &str,
+        target: &str,
+    ) -> Question {
+        Question::new(
+            AnswerOrigin {
+                channel: channel.to_string(),
+                thread_key: thread.to_string(),
+                sender_key: sender.to_string(),
+                chat_key: chat.to_string(),
+            },
+            target,
+            "Apply the draft?",
+            vec![
+                crate::approval::Choice {
+                    label: "Approve".to_string(),
+                    value: "approve".to_string(),
+                },
+                crate::approval::Choice {
+                    label: "Reject".to_string(),
+                    value: "reject".to_string(),
+                },
+            ],
+            now_ms() + 60_000,
+        )
+        .unwrap()
     }
 
     fn message(row_id: i64, chat: &str, handle: &str, is_from_me: bool, text: &str) -> RawMessage {

--- a/src/history.rs
+++ b/src/history.rs
@@ -5,7 +5,12 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
-const SCHEMA_VERSION: i64 = 1;
+use crate::approval::{
+    parse_answer, AnswerOrigin, AnswerOutcome, DeliveryStatus as ApprovalDeliveryStatus,
+    NormalizedAnswer, Question, QuestionState,
+};
+
+const SCHEMA_VERSION: i64 = 2;
 const MAX_HISTORY_READ_BYTES: usize = 8 * 1024;
 const READ_TRUNCATED: &str = "\n[truncated by push while reading history]";
 
@@ -253,6 +258,263 @@ impl History {
         Ok(messages)
     }
 
+    #[allow(dead_code)]
+    pub fn create_question(&mut self, question: &Question, now_ms: i64) -> Result<()> {
+        question.validate()?;
+        if question.expires_at_ms <= now_ms {
+            bail!("approval question expiry must be in the future");
+        }
+        let choices = serde_json::to_string(&question.choices)?;
+        self.conn.execute(
+            "INSERT INTO approval_questions (
+                id, channel, thread_key, sender_key, chat_key, target,
+                prompt, choices_json, expires_at_ms, status, delivery_status
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'pending', 'pending')",
+            params![
+                question.id,
+                question.channel,
+                question.thread_key,
+                question.sender_key,
+                question.chat_key,
+                question.target,
+                question.prompt,
+                choices,
+                question.expires_at_ms,
+            ],
+        )?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn mark_question_delivery(
+        &mut self,
+        id: &str,
+        status: ApprovalDeliveryStatus,
+    ) -> Result<()> {
+        let changed = self.conn.execute(
+            "UPDATE approval_questions
+             SET delivery_status = ?2, updated_at_ms = unixepoch('subsec') * 1000
+             WHERE id = ?1",
+            params![id, status.as_str()],
+        )?;
+        if changed != 1 {
+            bail!("approval question {id:?} does not exist");
+        }
+        Ok(())
+    }
+
+    pub fn answer_question(
+        &mut self,
+        origin: &AnswerOrigin,
+        text: &str,
+        now_ms: i64,
+    ) -> Result<AnswerOutcome> {
+        let Some(attempt) = parse_answer(text) else {
+            return Ok(AnswerOutcome::NotAnAnswer);
+        };
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "UPDATE approval_questions SET status = 'expired', updated_at_ms = ?1
+             WHERE status = 'pending' AND expires_at_ms <= ?1",
+            [now_ms],
+        )?;
+        let id = if let Some(id) = attempt.correlation_id {
+            id
+        } else {
+            let mut statement = tx.prepare(
+                "SELECT id FROM approval_questions
+                 WHERE channel = ?1 AND thread_key = ?2
+                   AND sender_key = ?3 AND chat_key = ?4
+                   AND status = 'pending'
+                 ORDER BY created_at_ms, id",
+            )?;
+            let ids = statement
+                .query_map(
+                    params![
+                        origin.channel,
+                        origin.thread_key,
+                        origin.sender_key,
+                        origin.chat_key
+                    ],
+                    |row| row.get::<_, String>(0),
+                )?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            drop(statement);
+            match ids.as_slice() {
+                [] => {
+                    let recent = tx
+                        .query_row(
+                            "SELECT id FROM approval_questions
+                             WHERE channel = ?1 AND thread_key = ?2
+                               AND sender_key = ?3 AND chat_key = ?4
+                               AND (
+                                   (status IN ('answered', 'consumed', 'cancelled')
+                                    AND expires_at_ms >= ?5)
+                                   OR
+                                   (status = 'expired' AND expires_at_ms >= ?5 - 86400000)
+                               )
+                             ORDER BY created_at_ms DESC, id DESC LIMIT 1",
+                            params![
+                                origin.channel,
+                                origin.thread_key,
+                                origin.sender_key,
+                                origin.chat_key,
+                                now_ms
+                            ],
+                            |row| row.get::<_, String>(0),
+                        )
+                        .optional()?;
+                    let Some(id) = recent else {
+                        return Ok(AnswerOutcome::NotAnAnswer);
+                    };
+                    id
+                }
+                [id] => id.clone(),
+                _ => return Ok(AnswerOutcome::Ambiguous),
+            }
+        };
+
+        let row = tx
+            .query_row(
+                "SELECT channel, thread_key, sender_key, chat_key, choices_json,
+                        expires_at_ms, status
+                 FROM approval_questions WHERE id = ?1",
+                [&id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, i64>(5)?,
+                        row.get::<_, String>(6)?,
+                    ))
+                },
+            )
+            .optional()?;
+        let Some((channel, thread, sender, chat, choices, expires_at, status)) = row else {
+            return Ok(AnswerOutcome::Mismatched(id));
+        };
+        if channel != origin.channel
+            || thread != origin.thread_key
+            || sender != origin.sender_key
+            || chat != origin.chat_key
+        {
+            return Ok(AnswerOutcome::Mismatched(id));
+        }
+        if status == "answered" || status == "consumed" {
+            return Ok(AnswerOutcome::Duplicate(id));
+        }
+        if status == "cancelled" {
+            return Ok(AnswerOutcome::Cancelled(id));
+        }
+        if status == "expired" || expires_at <= now_ms {
+            tx.execute(
+                "UPDATE approval_questions SET status = 'expired', updated_at_ms = ?2
+                 WHERE id = ?1 AND status = 'pending'",
+                params![id, now_ms],
+            )?;
+            tx.commit()?;
+            return Ok(AnswerOutcome::Expired(id));
+        }
+        let choices: Vec<crate::approval::Choice> = serde_json::from_str(&choices)?;
+        let Some(choice) = attempt
+            .selected_number
+            .checked_sub(1)
+            .and_then(|index| choices.get(index))
+        else {
+            return Ok(AnswerOutcome::InvalidChoice(id));
+        };
+        tx.execute(
+            "UPDATE approval_questions
+             SET status = 'answered', answer_index = ?2, answered_at_ms = ?3,
+                 updated_at_ms = ?3
+             WHERE id = ?1 AND status = 'pending'",
+            params![id, attempt.selected_number as i64, now_ms],
+        )?;
+        tx.commit()?;
+        Ok(AnswerOutcome::Selected(NormalizedAnswer {
+            correlation_id: id,
+            selected_number: attempt.selected_number,
+            value: choice.value.clone(),
+        }))
+    }
+
+    #[allow(dead_code)]
+    pub fn take_answer(&mut self, id: &str, now_ms: i64) -> Result<Option<NormalizedAnswer>> {
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "UPDATE approval_questions SET status = 'expired', updated_at_ms = ?2
+             WHERE id = ?1 AND status = 'pending' AND expires_at_ms <= ?2",
+            params![id, now_ms],
+        )?;
+        let row = tx
+            .query_row(
+                "SELECT choices_json, answer_index FROM approval_questions
+                 WHERE id = ?1 AND status = 'answered'",
+                [id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .optional()?;
+        let Some((choices, selected_number)) = row else {
+            tx.commit()?;
+            return Ok(None);
+        };
+        let choices: Vec<crate::approval::Choice> = serde_json::from_str(&choices)?;
+        let choice = choices
+            .get(selected_number.saturating_sub(1) as usize)
+            .context("stored approval answer index is invalid")?;
+        tx.execute(
+            "UPDATE approval_questions
+             SET status = 'consumed', consumed_at_ms = ?2, updated_at_ms = ?2
+             WHERE id = ?1 AND status = 'answered'",
+            params![id, now_ms],
+        )?;
+        tx.commit()?;
+        Ok(Some(NormalizedAnswer {
+            correlation_id: id.to_string(),
+            selected_number: selected_number as usize,
+            value: choice.value.clone(),
+        }))
+    }
+
+    #[allow(dead_code)]
+    pub fn question_state(&mut self, id: &str, now_ms: i64) -> Result<Option<QuestionState>> {
+        self.conn.execute(
+            "UPDATE approval_questions SET status = 'expired', updated_at_ms = ?2
+             WHERE id = ?1 AND status = 'pending' AND expires_at_ms <= ?2",
+            params![id, now_ms],
+        )?;
+        self.conn
+            .query_row(
+                "SELECT status FROM approval_questions WHERE id = ?1",
+                [id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|status| QuestionState::parse(&status))
+            .transpose()
+    }
+
+    #[allow(dead_code)]
+    pub fn cancel_question(&mut self, id: &str, now_ms: i64) -> Result<bool> {
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "UPDATE approval_questions SET status = 'expired', updated_at_ms = ?2
+             WHERE id = ?1 AND status = 'pending' AND expires_at_ms <= ?2",
+            params![id, now_ms],
+        )?;
+        let cancelled = tx.execute(
+            "UPDATE approval_questions
+             SET status = 'cancelled', updated_at_ms = ?2
+             WHERE id = ?1 AND status = 'pending' AND expires_at_ms > ?2",
+            params![id, now_ms],
+        )? == 1;
+        tx.commit()?;
+        Ok(cancelled)
+    }
+
     #[cfg(test)]
     pub fn execute_batch_for_test(&self, sql: &str) {
         self.conn.execute_batch(sql).unwrap();
@@ -309,6 +571,42 @@ fn migrate(conn: &Connection) -> Result<()> {
              CREATE INDEX messages_conversation_id_idx
                  ON messages(conversation_id, id);
              PRAGMA user_version = 1;
+             COMMIT;",
+        )?;
+    }
+    if version <= 1 {
+        conn.execute_batch(
+            "BEGIN IMMEDIATE;
+             CREATE TABLE approval_questions (
+                 id TEXT PRIMARY KEY,
+                 channel TEXT NOT NULL,
+                 thread_key TEXT NOT NULL,
+                 sender_key TEXT NOT NULL,
+                 chat_key TEXT NOT NULL,
+                 target TEXT NOT NULL,
+                 prompt TEXT NOT NULL,
+                 choices_json TEXT NOT NULL,
+                 expires_at_ms INTEGER NOT NULL,
+                 status TEXT NOT NULL CHECK(status IN (
+                     'pending', 'answered', 'consumed', 'expired', 'cancelled'
+                 )),
+                 delivery_status TEXT NOT NULL CHECK(delivery_status IN (
+                     'pending', 'delivered', 'failed'
+                 )),
+                 answer_index INTEGER,
+                 answered_at_ms INTEGER,
+                 consumed_at_ms INTEGER,
+                 created_at_ms INTEGER NOT NULL DEFAULT (
+                     CAST(strftime('%s', 'now') AS INTEGER) * 1000
+                 ),
+                 updated_at_ms INTEGER NOT NULL DEFAULT (
+                     CAST(strftime('%s', 'now') AS INTEGER) * 1000
+                 )
+             );
+             CREATE INDEX approval_questions_origin_idx ON approval_questions (
+                 channel, thread_key, sender_key, chat_key, status, expires_at_ms
+             );
+             PRAGMA user_version = 2;
              COMMIT;",
         )?;
     }
@@ -375,7 +673,42 @@ fn restrict_permissions(_path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::approval::{Choice, Question};
     use crate::test_support::temp_path;
+
+    fn question(expires_at_ms: i64) -> Question {
+        Question::new(
+            AnswerOrigin {
+                channel: "telegram".to_string(),
+                thread_key: "telegram:dm:7:topic:9".to_string(),
+                sender_key: "7".to_string(),
+                chat_key: "7".to_string(),
+            },
+            "7:9",
+            "Apply the draft?",
+            vec![
+                Choice {
+                    label: "Approve".to_string(),
+                    value: "approve".to_string(),
+                },
+                Choice {
+                    label: "Reject".to_string(),
+                    value: "reject".to_string(),
+                },
+            ],
+            expires_at_ms,
+        )
+        .unwrap()
+    }
+
+    fn origin() -> AnswerOrigin {
+        AnswerOrigin {
+            channel: "telegram".to_string(),
+            thread_key: "telegram:dm:7:topic:9".to_string(),
+            sender_key: "7".to_string(),
+            chat_key: "7".to_string(),
+        }
+    }
 
     #[test]
     fn migrates_new_database_and_reopens_it() {
@@ -389,6 +722,134 @@ mod tests {
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
         assert_eq!(version, SCHEMA_VERSION);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn migrates_v1_history_database_without_losing_messages() {
+        let path = temp_path("approval-v1-migration");
+        let mut history = History::open(path.to_str().unwrap()).unwrap();
+        let inbound = history
+            .record_inbound("imessage", "imessage:self:me", "imessage:1", "hello")
+            .unwrap();
+        history.execute_batch_for_test("DROP TABLE approval_questions; PRAGMA user_version = 1;");
+        drop(history);
+
+        let mut reopened = History::open(path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            reopened
+                .conn
+                .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+        assert!(reopened.outbound_for(inbound).unwrap().is_none());
+        let question = question(2_000);
+        reopened.create_question(&question, 1_000).unwrap();
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn pending_question_survives_restart_and_answer_is_consumed_once() {
+        let path = temp_path("approval-restart");
+        let mut history = History::open(path.to_str().unwrap()).unwrap();
+        let question = question(2_000);
+        history.create_question(&question, 1_000).unwrap();
+        drop(history);
+
+        let mut reopened = History::open(path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            reopened.answer_question(&origin(), "1", 1_100).unwrap(),
+            AnswerOutcome::Selected(NormalizedAnswer {
+                correlation_id: question.id.clone(),
+                selected_number: 1,
+                value: "approve".to_string(),
+            })
+        );
+        assert_eq!(
+            reopened.take_answer(&question.id, 1_200).unwrap(),
+            Some(NormalizedAnswer {
+                correlation_id: question.id.clone(),
+                selected_number: 1,
+                value: "approve".to_string(),
+            })
+        );
+        assert_eq!(reopened.take_answer(&question.id, 1_300).unwrap(), None);
+        assert_eq!(
+            reopened
+                .answer_question(&origin(), &format!("{} 1", question.id), 1_400)
+                .unwrap(),
+            AnswerOutcome::Duplicate(question.id.clone())
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn question_rejects_mismatch_expiry_invalid_choice_and_cancellation() {
+        let path = temp_path("approval-rejections");
+        let mut history = History::open(path.to_str().unwrap()).unwrap();
+        let expired = question(2_000);
+        history.create_question(&expired, 1_000).unwrap();
+        let mut wrong_topic = origin();
+        wrong_topic.thread_key = "telegram:dm:7".to_string();
+        assert_eq!(
+            history
+                .answer_question(&wrong_topic, &format!("{} 1", expired.id), 1_100)
+                .unwrap(),
+            AnswerOutcome::Mismatched(expired.id.clone())
+        );
+        assert_eq!(
+            history
+                .answer_question(&origin(), &format!("{} 3", expired.id), 1_200)
+                .unwrap(),
+            AnswerOutcome::InvalidChoice(expired.id.clone())
+        );
+        assert_eq!(
+            history
+                .answer_question(&origin(), &format!("{} 1", expired.id), 2_000)
+                .unwrap(),
+            AnswerOutcome::Expired(expired.id.clone())
+        );
+        assert_eq!(
+            history.question_state(&expired.id, 2_001).unwrap(),
+            Some(QuestionState::Expired)
+        );
+
+        let cancelled = question(4_000);
+        history.create_question(&cancelled, 2_100).unwrap();
+        assert!(history.cancel_question(&cancelled.id, 2_200).unwrap());
+        assert!(!history.cancel_question(&cancelled.id, 2_300).unwrap());
+        assert_eq!(
+            history
+                .answer_question(&origin(), &format!("{} 1", cancelled.id), 2_400)
+                .unwrap(),
+            AnswerOutcome::Cancelled(cancelled.id.clone())
+        );
+        assert_eq!(
+            history.question_state(&cancelled.id, 2_500).unwrap(),
+            Some(QuestionState::Cancelled)
+        );
+
+        let timed_out = question(3_000);
+        history.create_question(&timed_out, 2_600).unwrap();
+        assert!(!history.cancel_question(&timed_out.id, 3_100).unwrap());
+        assert_eq!(
+            history.question_state(&timed_out.id, 3_100).unwrap(),
+            Some(QuestionState::Expired)
+        );
+
+        let stale = question(4_000);
+        history.create_question(&stale, 3_200).unwrap();
+        let live = question(6_000);
+        history.create_question(&live, 3_300).unwrap();
+        assert_eq!(
+            history.answer_question(&origin(), "1", 5_000).unwrap(),
+            AnswerOutcome::Selected(NormalizedAnswer {
+                correlation_id: live.id,
+                selected_number: 1,
+                value: "approve".to_string(),
+            })
+        );
         let _ = std::fs::remove_file(path);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 //! coding-agent backend, and texts the reply back.
 
 mod agent;
+mod approval;
 mod audit;
 mod channel;
 mod claude;


### PR DESCRIPTION
## Summary

- add a bounded channel-neutral question, choice, correlation, and normalized-answer model
- migrate `push.db` to persist question identity bindings, expiry, lifecycle, answer, and delivery state
- persist questions before plain numbered delivery on iMessage and Telegram
- bind answers to the allowlisted sender, chat, channel, and exact thread or topic
- intercept approval control traffic before conversation persistence or backend routing
- support one-time answer consumption, restart recovery, timeout state, cancellation, ambiguity, duplicate handling, and audit events

## Why

Later drafted jobs and sensitive workflows need a reusable approval boundary that survives gateway restarts and cannot be satisfied by a reply from another user or conversation.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (143 passed)
- `git diff --check`
- focused tests cover v1 migration, restart, one-time consumption, iMessage and Telegram delivery/answers, failed delivery persistence, exact topic/chat/sender/channel binding, allowlist enforcement, malformed and canonicalized correlation ids, plain duplicate and ambiguity behavior, expiry, cancel-after-expiry, bounded inputs, and approval exclusion from rehydration history
- independent subagent review completed; four security/correctness findings fixed and re-reviewed with no remaining findings

## Risks

- Inline Telegram buttons are intentionally deferred; both channels use the same auditable numbered-text format.
- Question delivery failure remains durable and terminally visible to the caller; it does not silently discard the pending record.
- Approval creation and result-consumption APIs are ready for the later drafted-jobs workflow; this PR does not implement jobs.

## Related issue

Closes #59
