### PR TITLE
feat: add manual jobs runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +43,15 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -79,8 +94,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -90,6 +133,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -177,6 +240,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -538,6 +611,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +630,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -584,11 +684,13 @@ name = "push"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono-tz",
  "humantime",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "toml",
  "tracing",
@@ -877,6 +979,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +1013,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1203,6 +1322,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ toml = "1"
 uuid = { version = "1", features = ["v4"] }
 anyhow = "1"
 humantime = "2"
+sha2 = "0.10"
+chrono-tz = "0.10"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ database_path = "~/.push/push.db"
 assistant_dir = "~/.push"
 permission_profile = "restricted"
 job_permission_profiles = ["restricted", "research"]
+jobs_dir = "~/.push/jobs"
+jobs_agent = "codex"
+jobs_max_timeout = "30m"
+jobs_run_dir = "~/.push/run"
 
 [permission_profiles.research]
 capability = "read-only"
@@ -304,6 +308,47 @@ Legacy raw settings such as `claude_permission_mode`, `claude_tools`,
 `claude_allowed_tools`, `claude_disallowed_tools`, `codex_sandbox`, and
 `codex_approval_policy` now produce a migration error; replace them with a named
 profile.
+
+## Manual Jobs
+
+Jobs are user-owned Markdown runbooks in `~/.push/jobs/`. The filename is a
+lowercase slug and the body is sent verbatim to a fresh backend session:
+
+```markdown
++++
+version = 1
+permission_profile = "restricted"
+timeout = "5m"
+workdir = "~/Code"
+backend = "codex"
++++
+
+Review repositories with uncommitted work. Do not change files or remote state.
+```
+
+Use:
+
+```bash
+push job validate --config config.toml
+push job list --config config.toml
+push job show repo-review --config config.toml
+push job run repo-review --config config.toml
+push job runs repo-review --config config.toml
+```
+
+Validation rejects unknown frontmatter, unsafe filenames, symlinks, missing
+work directories, unknown backends, excessive timeouts, and permission profiles
+not explicitly allowed by `job_permission_profiles`. Invalid jobs are disabled
+individually and do not stop messaging or other valid jobs.
+
+Manual runs execute in the invoking CLI process. Push records and claims the
+run in SQLite before execution and holds a non-blocking per-job OS advisory lock
+for its full lifetime. An overlap is recorded as `skipped_overlap`. Once the
+lock is released, the next start safely marks a stale `running` manual claim as
+failed before claiming a new run. Results and diagnostics are bounded and
+remain visible through `push job runs`; manual results are printed to the
+terminal and are never proactively sent to a chat. Scheduling is not enabled in
+this release.
 
 push reads TOML only. Convert any earlier `config.json` file to `config.toml`
 before upgrading. The old JSON filename remains gitignored to reduce the risk

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,7 @@ own the durable pieces:
 - routing
 - assistant identity
 - canonical conversation history
+- validated runbook jobs and their durable run ledger
 - cursor and backend-session state
 - delivery
 
@@ -200,6 +201,15 @@ unique channel event ID makes inbound retries idempotent, and a unique link from
 each inbound message to its outbound response preserves the generation/delivery
 crash boundary. SQLite history does not replace `state.json` cursors or backend
 session IDs in this phase.
+
+The same database stores immutable job-run claims and bounded terminal results.
+Markdown runbooks remain operator-owned files under `jobs_dir`. A manual CLI
+start rereads and validates the exact file, acquires a non-blocking per-job lock,
+then records and claims the run in one immediate SQLite transaction before
+spawning a fresh backend session. The CLI holds the lock through result
+persistence. Only a process that acquired the released lock may fail a stale
+manual claim, so a live local executor is never reclaimed from ledger state
+alone. Manual runs do not reuse chat history or backend session ids.
 
 The same database stores `ask_user` questions before delivery. Each question
 has a UUID correlation id, two to nine bounded choices, an expiry, delivery

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -83,6 +83,7 @@ push takes a narrower bet:
 - `src/imessage/sender.rs`: sends replies through AppleScript.
 - `src/gateway.rs`: poll loop, filtering, commands, queues, worker dispatch.
 - `src/history.rs`: canonical SQLite conversations and messages.
+- `src/jobs.rs`: validated runbooks, advisory locking, manual execution, and run ledger.
 - `src/approval.rs`: durable bounded questions and normalized answers.
 - `src/agent.rs`: backend boundary.
 - `src/claude.rs`: Claude Code adapter.
@@ -135,6 +136,10 @@ user prompt.
 | `permission_profile` | Default named profile; defaults to `restricted`. |
 | `permission_profiles` | Custom names mapped to a common capability. |
 | `job_permission_profiles` | Explicit profile names future jobs may request; defaults to `restricted`. |
+| `jobs_dir` | Installed Markdown runbooks; defaults to `~/.push/jobs`. |
+| `jobs_agent` | Optional default job backend; otherwise uses `agent`. |
+| `jobs_max_timeout` | Maximum validated job timeout; defaults to `30m`. |
+| `jobs_run_dir` | Local advisory-lock state; defaults to `~/.push/run`. |
 | `imessage.db_path` | Path to Messages `chat.db`. |
 | `poll_interval` | How often to poll. |
 | `run_timeout` | Max backend run time. |

--- a/docs/services.md
+++ b/docs/services.md
@@ -157,6 +157,13 @@ For a user service that survives logout, enable lingering:
 loginctl enable-linger "$USER"
 ```
 
+## Manual Jobs
+
+`push job run <name>` executes in the invoking terminal process, not in the
+managed service. Use the same config file so the CLI and service share
+`push.db`, `jobs_dir`, and the local per-job lock directory. Invalid job files
+are reported and disabled individually; they do not stop the messaging service.
+
 ## Restart Behavior
 
 `push` only advances the selected channel cursor after a message is ignored or

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,14 @@ pub struct Config {
     pub job_permission_profiles: Vec<String>,
     #[serde(default)]
     pub permission_profiles: HashMap<String, PermissionProfileConfig>,
+    #[serde(default = "default_jobs_dir")]
+    pub jobs_dir: String,
+    #[serde(default)]
+    pub jobs_agent: Option<String>,
+    #[serde(default = "default_jobs_max_timeout")]
+    pub jobs_max_timeout: String,
+    #[serde(default = "default_jobs_run_dir")]
+    pub jobs_run_dir: String,
     #[serde(default = "default_claude_bin")]
     pub claude_bin: String,
     #[serde(default = "default_codex_bin")]
@@ -117,6 +125,8 @@ impl Config {
         c.audit_log_path = expand_home(&c.audit_log_path);
         c.database_path = expand_home(&c.database_path);
         c.assistant_dir = expand_home(&c.assistant_dir);
+        c.jobs_dir = expand_home(&c.jobs_dir);
+        c.jobs_run_dir = expand_home(&c.jobs_run_dir);
         c.validate()?;
         Ok(c)
     }
@@ -194,6 +204,16 @@ impl Config {
         Ok(profile)
     }
 
+    pub fn jobs_backend(&self) -> Result<AgentBackend> {
+        AgentBackend::parse(self.jobs_agent.as_deref().unwrap_or(&self.agent))
+            .context("invalid jobs_agent")
+    }
+
+    pub fn jobs_max_timeout_dur(&self) -> Result<Duration> {
+        humantime::parse_duration(&self.jobs_max_timeout)
+            .with_context(|| format!("invalid jobs_max_timeout {}", self.jobs_max_timeout))
+    }
+
     fn resolve_route(&self, route: &RouteRule) -> Result<RouteSelection> {
         let profile = route
             .permission_profile
@@ -269,6 +289,13 @@ impl Config {
             }
         }
         self.agent_backend()?;
+        self.jobs_backend()?;
+        if self.jobs_max_timeout_dur()?.is_zero() {
+            bail!("jobs_max_timeout must be positive");
+        }
+        if self.jobs_dir.trim().is_empty() || self.jobs_run_dir.trim().is_empty() {
+            bail!("jobs_dir and jobs_run_dir cannot be empty");
+        }
         self.resolve_permission_profile(&self.permission_profile)
             .context("invalid default permission profile")?;
         for (name, profile) in &self.permission_profiles {
@@ -505,6 +532,15 @@ fn default_permission_profile() -> String {
 }
 fn default_job_permission_profiles() -> Vec<String> {
     vec!["restricted".to_string()]
+}
+fn default_jobs_dir() -> String {
+    "~/.push/jobs".to_string()
+}
+fn default_jobs_max_timeout() -> String {
+    "30m".to_string()
+}
+fn default_jobs_run_dir() -> String {
+    "~/.push/run".to_string()
 }
 fn default_sessions_dir() -> String {
     "~/.push/sessions".to_string()

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1258,7 +1258,7 @@ async fn shutdown_signal() {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::agent::{FakeRunCall, FakeRunner};
     use crate::channel::{normalize_handle, thread_handle};
@@ -2697,6 +2697,10 @@ mod tests {
             permission_profile: "restricted".to_string(),
             job_permission_profiles: vec!["restricted".to_string()],
             permission_profiles: HashMap::new(),
+            jobs_dir: format!("{state_path}.jobs"),
+            jobs_agent: None,
+            jobs_max_timeout: "30m".to_string(),
+            jobs_run_dir: format!("{state_path}.run"),
             claude_bin: "claude".to_string(),
             codex_bin: "codex".to_string(),
             codex_model: None,
@@ -2708,6 +2712,14 @@ mod tests {
             assistant_dir: assistant_dir.to_string(),
             reply_marker: "\n\n-- sent by push".to_string(),
         }
+    }
+
+    pub(crate) fn test_config_for_jobs(
+        state_path: &str,
+        sessions_dir: &str,
+        assistant_dir: &str,
+    ) -> Config {
+        test_config(state_path, sessions_dir, assistant_dir)
     }
 
     fn audit_events(path: &str) -> Vec<crate::audit::AuditEvent> {

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,6 +1,7 @@
 //! Canonical SQLite conversation history owned by the gateway.
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
@@ -10,7 +11,7 @@ use crate::approval::{
     NormalizedAnswer, Question, QuestionState,
 };
 
-const SCHEMA_VERSION: i64 = 2;
+const SCHEMA_VERSION: i64 = 3;
 const MAX_HISTORY_READ_BYTES: usize = 8 * 1024;
 const READ_TRUNCATED: &str = "\n[truncated by push while reading history]";
 
@@ -98,6 +99,8 @@ impl History {
         let conn = Connection::open(&path)
             .with_context(|| format!("open conversation database {}", path.display()))?;
         restrict_permissions(&path)?;
+        conn.busy_timeout(Duration::from_secs(5))
+            .context("configure conversation database busy timeout")?;
         conn.execute_batch("PRAGMA foreign_keys = ON;")
             .context("enable conversation database foreign keys")?;
         migrate(&conn).context("migrate conversation database")?;
@@ -522,6 +525,7 @@ impl History {
 }
 
 fn migrate(conn: &Connection) -> Result<()> {
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
     let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     if version > SCHEMA_VERSION {
         bail!(
@@ -530,8 +534,7 @@ fn migrate(conn: &Connection) -> Result<()> {
     }
     if version == 0 {
         conn.execute_batch(
-            "BEGIN IMMEDIATE;
-             CREATE TABLE conversations (
+            "CREATE TABLE conversations (
                  id INTEGER PRIMARY KEY,
                  channel TEXT NOT NULL,
                  thread_key TEXT NOT NULL,
@@ -570,14 +573,12 @@ fn migrate(conn: &Connection) -> Result<()> {
              );
              CREATE INDEX messages_conversation_id_idx
                  ON messages(conversation_id, id);
-             PRAGMA user_version = 1;
-             COMMIT;",
+             PRAGMA user_version = 1;",
         )?;
     }
     if version <= 1 {
         conn.execute_batch(
-            "BEGIN IMMEDIATE;
-             CREATE TABLE approval_questions (
+            "CREATE TABLE approval_questions (
                  id TEXT PRIMARY KEY,
                  channel TEXT NOT NULL,
                  thread_key TEXT NOT NULL,
@@ -606,10 +607,47 @@ fn migrate(conn: &Connection) -> Result<()> {
              CREATE INDEX approval_questions_origin_idx ON approval_questions (
                  channel, thread_key, sender_key, chat_key, status, expires_at_ms
              );
-             PRAGMA user_version = 2;
-             COMMIT;",
+             PRAGMA user_version = 2;",
         )?;
     }
+    if version <= 2 {
+        conn.execute_batch(
+            "CREATE TABLE job_runs (
+                 id TEXT PRIMARY KEY,
+                 job_name TEXT NOT NULL,
+                 snapshot_hash TEXT NOT NULL,
+                 trigger_kind TEXT NOT NULL,
+                 trigger_id TEXT,
+                 owner_kind TEXT NOT NULL,
+                 scheduled_at_ms INTEGER,
+                 queued_at_ms INTEGER NOT NULL,
+                 started_at_ms INTEGER,
+                 finished_at_ms INTEGER,
+                 backend TEXT NOT NULL,
+                 permission_profile TEXT NOT NULL,
+                 timeout_ms INTEGER NOT NULL,
+                 workdir TEXT NOT NULL,
+                 state TEXT NOT NULL CHECK(state IN (
+                     'queued', 'running', 'succeeded', 'failed', 'timed_out',
+                     'skipped_overlap', 'cancelled'
+                 )),
+                 result TEXT,
+                 error TEXT,
+                 delivery_state TEXT NOT NULL DEFAULT 'not_requested' CHECK(
+                     delivery_state IN ('not_requested', 'pending', 'delivered', 'failed')
+                 ),
+                 delivery_attempts INTEGER NOT NULL DEFAULT 0,
+                 delivery_last_attempt_ms INTEGER,
+                 delivery_error TEXT
+             );
+             CREATE INDEX job_runs_name_time_idx
+                 ON job_runs(job_name, queued_at_ms DESC);
+             CREATE UNIQUE INDEX job_runs_one_active_per_job
+                 ON job_runs(job_name) WHERE state IN ('queued', 'running');
+             PRAGMA user_version = 3;",
+        )?;
+    }
+    conn.execute_batch("COMMIT;")?;
     Ok(())
 }
 
@@ -732,7 +770,9 @@ mod tests {
         let inbound = history
             .record_inbound("imessage", "imessage:self:me", "imessage:1", "hello")
             .unwrap();
-        history.execute_batch_for_test("DROP TABLE approval_questions; PRAGMA user_version = 1;");
+        history.execute_batch_for_test(
+            "DROP TABLE job_runs; DROP TABLE approval_questions; PRAGMA user_version = 1;",
+        );
         drop(history);
 
         let mut reopened = History::open(path.to_str().unwrap()).unwrap();
@@ -741,11 +781,45 @@ mod tests {
                 .conn
                 .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
                 .unwrap(),
-            2
+            SCHEMA_VERSION
         );
         assert!(reopened.outbound_for(inbound).unwrap().is_none());
         let question = question(2_000);
         reopened.create_question(&question, 1_000).unwrap();
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn migrates_v2_approval_database_and_preserves_pending_question() {
+        let path = temp_path("jobs-v2-migration");
+        let mut history = History::open(path.to_str().unwrap()).unwrap();
+        let question = question(2_000);
+        history.create_question(&question, 1_000).unwrap();
+        history.execute_batch_for_test("DROP TABLE job_runs; PRAGMA user_version = 2;");
+        drop(history);
+
+        let mut reopened = History::open(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            reopened.question_state(&question.id, 1_100).unwrap(),
+            Some(QuestionState::Pending)
+        );
+        assert_eq!(
+            reopened
+                .conn
+                .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            3
+        );
+        let run_table: i64 = reopened
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'job_runs'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(run_table, 1);
         let _ = std::fs::remove_file(path);
     }
 

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -1,0 +1,1097 @@
+//! Validated Markdown runbooks and the durable manual-run runtime.
+
+use std::collections::{BTreeMap, HashSet};
+use std::fs::{File, OpenOptions, TryLockError};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{bail, Context, Result};
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::agent::{Request, RunError, Runner};
+use crate::config::{AgentBackend, Config, PermissionProfile};
+use crate::{claude, codex, history::History, soul};
+
+const MAX_STORED_RESULT_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Frontmatter {
+    version: u32,
+    permission_profile: String,
+    timeout: String,
+    workdir: String,
+    #[serde(default)]
+    backend: Option<String>,
+    #[serde(default)]
+    triggers: Vec<Trigger>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Trigger {
+    pub id: String,
+    pub kind: String,
+    pub schedule: String,
+    pub timezone: String,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct Job {
+    pub name: String,
+    pub path: PathBuf,
+    pub body: String,
+    pub permission: PermissionProfile,
+    pub timeout: Duration,
+    pub workdir: PathBuf,
+    pub backend: AgentBackend,
+    pub snapshot_hash: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct JobError {
+    pub name: String,
+    pub path: PathBuf,
+    pub message: String,
+}
+
+pub struct Catalog {
+    pub jobs: BTreeMap<String, Job>,
+    pub errors: Vec<JobError>,
+}
+
+impl Catalog {
+    pub fn load(cfg: &Config) -> Result<Self> {
+        let dir = Path::new(&cfg.jobs_dir);
+        if !dir.exists() {
+            return Ok(Self {
+                jobs: BTreeMap::new(),
+                errors: Vec::new(),
+            });
+        }
+        let mut entries = std::fs::read_dir(dir)
+            .with_context(|| format!("read jobs directory {}", dir.display()))?
+            .collect::<std::io::Result<Vec<_>>>()?;
+        entries.sort_by_key(|entry| entry.file_name());
+        let mut jobs = BTreeMap::new();
+        let mut errors = Vec::new();
+        let mut canonical_paths = HashSet::new();
+        for entry in entries {
+            let path = entry.path();
+            let display_name = entry.file_name().to_string_lossy().to_string();
+            let file_type = match entry.file_type() {
+                Ok(value) => value,
+                Err(error) => {
+                    errors.push(job_error(&display_name, path, error));
+                    continue;
+                }
+            };
+            if file_type.is_symlink() || !file_type.is_file() {
+                errors.push(JobError {
+                    name: display_name,
+                    path,
+                    message: "jobs must be regular Markdown files; symlinks and subdirectories are rejected".to_string(),
+                });
+                continue;
+            }
+            let name = match job_name(&path) {
+                Ok(value) => value,
+                Err(error) => {
+                    errors.push(job_error(&display_name, path, error));
+                    continue;
+                }
+            };
+            let canonical = match std::fs::canonicalize(&path) {
+                Ok(value) => value,
+                Err(error) => {
+                    errors.push(job_error(&name, path, error));
+                    continue;
+                }
+            };
+            if !canonical_paths.insert(canonical) {
+                errors.push(JobError {
+                    name,
+                    path,
+                    message: "duplicate canonical job path".to_string(),
+                });
+                continue;
+            }
+            match load_file(cfg, &name, &path) {
+                Ok(job) => {
+                    jobs.insert(name, job);
+                }
+                Err(error) => errors.push(job_error(&name, path, error)),
+            }
+        }
+        Ok(Self { jobs, errors })
+    }
+
+    pub fn load_named(cfg: &Config, name: &str) -> Result<Job> {
+        validate_slug(name)?;
+        let path = Path::new(&cfg.jobs_dir).join(format!("{name}.md"));
+        let metadata = std::fs::symlink_metadata(&path)
+            .with_context(|| format!("job {name:?} is not installed at {}", path.display()))?;
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            bail!("job {name:?} must be a regular file, not a symlink or directory");
+        }
+        load_file(cfg, name, &path)
+    }
+}
+
+fn load_file(cfg: &Config, name: &str, path: &Path) -> Result<Job> {
+    let expected = std::fs::symlink_metadata(path)
+        .with_context(|| format!("inspect job {}", path.display()))?;
+    if expected.file_type().is_symlink() || !expected.is_file() {
+        bail!("job {name:?} must be a regular file, not a symlink or directory");
+    }
+    let mut file = File::open(path).with_context(|| format!("open job {}", path.display()))?;
+    let opened = file
+        .metadata()
+        .with_context(|| format!("inspect opened job {}", path.display()))?;
+    if !same_file(&expected, &opened) {
+        bail!("job file changed while it was being opened; retry the operation");
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .with_context(|| format!("read job {}", path.display()))?;
+    let text = std::str::from_utf8(&bytes).context("job must be valid UTF-8")?;
+    let (frontmatter, body) = split_runbook(text)?;
+    let metadata: Frontmatter = toml::from_str(frontmatter).context("parse TOML frontmatter")?;
+    if metadata.version != 1 {
+        bail!("unsupported job version {}; expected 1", metadata.version);
+    }
+    if body.trim().is_empty() {
+        bail!("job instruction body cannot be empty");
+    }
+    validate_triggers(&metadata.triggers)?;
+    let permission = cfg.permission_for_job(&metadata.permission_profile)?;
+    let timeout = humantime::parse_duration(&metadata.timeout)
+        .with_context(|| format!("invalid job timeout {:?}", metadata.timeout))?;
+    if timeout.is_zero() || timeout > cfg.jobs_max_timeout_dur()? {
+        bail!(
+            "job timeout must be positive and no greater than {}",
+            cfg.jobs_max_timeout
+        );
+    }
+    let backend = metadata
+        .backend
+        .as_deref()
+        .map(AgentBackend::parse)
+        .transpose()?
+        .unwrap_or(cfg.jobs_backend()?);
+    let workdir = canonical_workdir(&metadata.workdir)?;
+    let snapshot_hash = format!("{:x}", Sha256::digest(&bytes));
+    Ok(Job {
+        name: name.to_string(),
+        path: path.to_path_buf(),
+        body: body.to_string(),
+        permission,
+        timeout,
+        workdir,
+        backend,
+        snapshot_hash,
+    })
+}
+
+#[cfg(unix)]
+fn same_file(expected: &std::fs::Metadata, opened: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    expected.dev() == opened.dev() && expected.ino() == opened.ino()
+}
+
+#[cfg(not(unix))]
+fn same_file(expected: &std::fs::Metadata, opened: &std::fs::Metadata) -> bool {
+    expected.len() == opened.len()
+        && expected.modified().ok() == opened.modified().ok()
+        && opened.is_file()
+}
+
+fn split_runbook(text: &str) -> Result<(&str, &str)> {
+    let rest = text
+        .strip_prefix("+++\n")
+        .or_else(|| text.strip_prefix("+++\r\n"))
+        .context("job must start with a +++ frontmatter delimiter")?;
+    let marker = rest
+        .find("\n+++\n")
+        .map(|index| (index, 5))
+        .or_else(|| rest.find("\r\n+++\r\n").map(|index| (index, 9)))
+        .context("job frontmatter must end with a +++ delimiter on its own line")?;
+    Ok((&rest[..marker.0], &rest[marker.0 + marker.1..]))
+}
+
+fn job_name(path: &Path) -> Result<String> {
+    if path.extension().and_then(|value| value.to_str()) != Some("md") {
+        bail!("installed job filename must end in .md");
+    }
+    let name = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .context("job filename must be valid UTF-8")?;
+    validate_slug(name)?;
+    Ok(name.to_string())
+}
+
+fn validate_slug(value: &str) -> Result<()> {
+    if value.is_empty()
+        || value.starts_with('-')
+        || value.ends_with('-')
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        bail!("job name must be a lowercase ASCII slug of letters, digits, and hyphens");
+    }
+    Ok(())
+}
+
+pub fn validate_job_name(value: &str) -> Result<()> {
+    validate_slug(value)
+}
+
+fn validate_triggers(triggers: &[Trigger]) -> Result<()> {
+    let mut ids = HashSet::new();
+    for trigger in triggers {
+        validate_slug(&trigger.id).context("invalid trigger id")?;
+        if !ids.insert(&trigger.id) {
+            bail!("duplicate trigger id {:?}", trigger.id);
+        }
+        if trigger.kind != "cron" {
+            bail!("invalid trigger kind {:?}; expected cron", trigger.kind);
+        }
+        let fields = trigger.schedule.split_whitespace().collect::<Vec<_>>();
+        if fields.len() != 5 {
+            bail!("cron schedule must contain exactly five fields");
+        }
+        for (field, minimum, maximum, label) in [
+            (fields[0], 0, 59, "minute"),
+            (fields[1], 0, 23, "hour"),
+            (fields[2], 1, 31, "day of month"),
+            (fields[3], 1, 12, "month"),
+            (fields[4], 0, 7, "day of week"),
+        ] {
+            validate_cron_field(field, minimum, maximum)
+                .with_context(|| format!("invalid cron {label} field {field:?}"))?;
+        }
+        trigger
+            .timezone
+            .parse::<chrono_tz::Tz>()
+            .with_context(|| format!("invalid IANA timezone {:?}", trigger.timezone))?;
+        let _ = trigger.enabled;
+    }
+    Ok(())
+}
+
+fn validate_cron_field(field: &str, minimum: u32, maximum: u32) -> Result<()> {
+    if field.is_empty() {
+        bail!("field is empty");
+    }
+    for part in field.split(',') {
+        if part.is_empty() {
+            bail!("empty list item");
+        }
+        let mut step_parts = part.split('/');
+        let range = step_parts.next().unwrap_or_default();
+        let step = step_parts
+            .next()
+            .map(|value| parse_cron_number(value, 1, maximum - minimum + 1, "step"))
+            .transpose()?;
+        if step_parts.next().is_some() {
+            bail!("too many step separators");
+        }
+        if range == "*" {
+            continue;
+        }
+        let mut bounds = range.split('-');
+        let start =
+            parse_cron_number(bounds.next().unwrap_or_default(), minimum, maximum, "value")?;
+        if let Some(end) = bounds.next() {
+            let end = parse_cron_number(end, minimum, maximum, "range end")?;
+            if bounds.next().is_some() {
+                bail!("too many range separators");
+            }
+            if start > end {
+                bail!("range start exceeds range end");
+            }
+        } else if step.is_some() {
+            bail!("a step requires * or a range");
+        }
+    }
+    Ok(())
+}
+
+fn parse_cron_number(value: &str, minimum: u32, maximum: u32, label: &str) -> Result<u32> {
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        bail!("{label} must be an integer");
+    }
+    let parsed = value
+        .parse::<u32>()
+        .with_context(|| format!("parse {label}"))?;
+    if !(minimum..=maximum).contains(&parsed) {
+        bail!("{label} must be between {minimum} and {maximum}");
+    }
+    Ok(parsed)
+}
+
+fn canonical_workdir(value: &str) -> Result<PathBuf> {
+    let expanded = expand_home(value);
+    let path = std::fs::canonicalize(&expanded)
+        .with_context(|| format!("canonicalize job workdir {expanded}"))?;
+    if !path.is_dir() {
+        bail!("job workdir {} is not a directory", path.display());
+    }
+    Ok(path)
+}
+
+fn expand_home(value: &str) -> String {
+    if value == "~" || value.starts_with("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return format!("{}{}", home.to_string_lossy(), &value[1..]);
+        }
+    }
+    value.to_string()
+}
+
+fn job_error(name: &str, path: PathBuf, error: impl std::fmt::Display) -> JobError {
+    JobError {
+        name: name.to_string(),
+        path,
+        message: error.to_string(),
+    }
+}
+
+pub enum StartOutcome {
+    Claimed {
+        run_id: String,
+        lock: JobLock,
+        job: Job,
+    },
+    Skipped {
+        run_id: String,
+    },
+}
+
+pub struct JobLock {
+    _file: File,
+}
+
+impl JobLock {
+    fn try_acquire(run_dir: &str, job_name: &str) -> Result<Option<Self>> {
+        let lock_dir = Path::new(run_dir).join("locks");
+        std::fs::create_dir_all(&lock_dir)
+            .with_context(|| format!("create job lock directory {}", lock_dir.display()))?;
+        restrict_lock_permissions(&lock_dir, true)?;
+        let path = lock_dir.join(format!("{job_name}.lock"));
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .with_context(|| format!("open job lock {}", path.display()))?;
+        restrict_lock_permissions(&path, false)?;
+        match file.try_lock() {
+            Ok(()) => Ok(Some(Self { _file: file })),
+            Err(TryLockError::WouldBlock) => Ok(None),
+            Err(TryLockError::Error(error)) => {
+                Err(error).with_context(|| format!("lock job file {}", path.display()))
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn restrict_lock_permissions(path: &Path, directory: bool) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = if directory { 0o700 } else { 0o600 };
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .with_context(|| format!("restrict job lock permissions {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn restrict_lock_permissions(_path: &Path, _directory: bool) -> Result<()> {
+    Ok(())
+}
+
+pub struct Ledger {
+    conn: Connection,
+}
+
+#[derive(Debug)]
+pub struct RunRow {
+    pub id: String,
+    pub job_name: String,
+    pub state: String,
+    pub backend: String,
+    pub queued_at_ms: i64,
+    pub result: Option<String>,
+    pub error: Option<String>,
+}
+
+impl Ledger {
+    pub fn open(database_path: &str) -> Result<Self> {
+        drop(History::open(database_path)?);
+        let conn = Connection::open(database_path)?;
+        conn.busy_timeout(Duration::from_secs(5))?;
+        Ok(Self { conn })
+    }
+
+    pub fn start_manual(&mut self, cfg: &Config, job: &Job) -> Result<StartOutcome> {
+        let now = now_ms();
+        let Some(lock) = JobLock::try_acquire(&cfg.jobs_run_dir, &job.name)? else {
+            let run_id = Uuid::new_v4().to_string();
+            self.insert_skipped(
+                &run_id,
+                job,
+                now,
+                "another local executor holds the job lock",
+            )?;
+            return Ok(StartOutcome::Skipped { run_id });
+        };
+        let job = Catalog::load_named(cfg, &job.name)
+            .context("reread and validate job after acquiring its run lock")?;
+        let run_id = Uuid::new_v4().to_string();
+        let tx = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        tx.execute(
+            "UPDATE job_runs
+             SET state = 'failed', finished_at_ms = ?2,
+                 error = 'previous manual executor exited before completion'
+             WHERE job_name = ?1 AND state = 'running' AND owner_kind = 'manual_cli'",
+            params![job.name, now],
+        )?;
+        insert_run(&tx, &run_id, &job, now, "running", None)?;
+        tx.commit()?;
+        Ok(StartOutcome::Claimed { run_id, lock, job })
+    }
+
+    fn insert_skipped(&mut self, id: &str, job: &Job, now: i64, reason: &str) -> Result<()> {
+        let tx = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        insert_run(&tx, id, job, now, "skipped_overlap", Some(reason))?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn finish(
+        &mut self,
+        id: &str,
+        state: &str,
+        result: Option<&str>,
+        error: Option<&str>,
+    ) -> Result<()> {
+        if !matches!(state, "succeeded" | "failed" | "timed_out") {
+            bail!("invalid terminal manual run state {state:?}");
+        }
+        let changed = self.conn.execute(
+            "UPDATE job_runs SET state = ?2, finished_at_ms = ?3, result = ?4, error = ?5
+             WHERE id = ?1 AND state = 'running'",
+            params![
+                id,
+                state,
+                now_ms(),
+                result.map(bound_result),
+                error.map(bound_result)
+            ],
+        )?;
+        if changed != 1 {
+            bail!("running job run {id:?} does not exist");
+        }
+        Ok(())
+    }
+
+    pub fn runs(&self, name: Option<&str>) -> Result<Vec<RunRow>> {
+        let mut statement = self.conn.prepare(
+            "SELECT id, job_name, state, backend, queued_at_ms, result, error
+             FROM job_runs WHERE (?1 IS NULL OR job_name = ?1)
+             ORDER BY queued_at_ms DESC, id DESC LIMIT 100",
+        )?;
+        let rows = statement
+            .query_map([name], |row| {
+                Ok(RunRow {
+                    id: row.get(0)?,
+                    job_name: row.get(1)?,
+                    state: row.get(2)?,
+                    backend: row.get(3)?,
+                    queued_at_ms: row.get(4)?,
+                    result: row.get(5)?,
+                    error: row.get(6)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    #[cfg(test)]
+    fn state(&self, id: &str) -> String {
+        self.conn
+            .query_row("SELECT state FROM job_runs WHERE id = ?1", [id], |row| {
+                row.get(0)
+            })
+            .unwrap()
+    }
+}
+
+fn insert_run(
+    tx: &rusqlite::Transaction<'_>,
+    id: &str,
+    job: &Job,
+    now: i64,
+    state: &str,
+    error: Option<&str>,
+) -> Result<()> {
+    tx.execute(
+        "INSERT INTO job_runs (
+            id, job_name, snapshot_hash, trigger_kind, owner_kind,
+            queued_at_ms, started_at_ms, finished_at_ms, backend, permission_profile,
+            timeout_ms, workdir, state, error
+         ) VALUES (?1, ?2, ?3, 'manual', 'manual_cli', ?4,
+                   CASE WHEN ?5 = 'running' THEN ?4 ELSE NULL END,
+                   CASE WHEN ?5 = 'skipped_overlap' THEN ?4 ELSE NULL END,
+                   ?6, ?7, ?8, ?9, ?5, ?10)",
+        params![
+            id,
+            job.name,
+            job.snapshot_hash,
+            now,
+            state,
+            job.backend.as_str(),
+            job.permission.name,
+            job.timeout.as_millis().min(i64::MAX as u128) as i64,
+            job.workdir.to_string_lossy(),
+            error,
+        ],
+    )?;
+    Ok(())
+}
+
+pub async fn run_manual(cfg: &Config, job: Job) -> Result<(String, String)> {
+    let mut ledger = Ledger::open(&cfg.database_path)?;
+    let outcome = ledger.start_manual(cfg, &job)?;
+    let StartOutcome::Claimed { run_id, lock, job } = outcome else {
+        let StartOutcome::Skipped { run_id } = outcome else {
+            unreachable!()
+        };
+        return Ok((run_id, "skipped_overlap".to_string()));
+    };
+    let _lock = lock;
+
+    match execute(cfg, &job).await {
+        Ok(reply) => {
+            ledger.finish(&run_id, "succeeded", Some(&reply), None)?;
+            Ok((run_id, reply))
+        }
+        Err(ExecutionError::Timeout) => {
+            ledger.finish(&run_id, "timed_out", None, Some("backend run timed out"))?;
+            bail!(
+                "job timed out after {}",
+                humantime::format_duration(job.timeout)
+            );
+        }
+        Err(ExecutionError::Failed(error)) => {
+            ledger.finish(&run_id, "failed", None, Some(&error))?;
+            bail!("job failed: {error}");
+        }
+    }
+}
+
+enum ExecutionError {
+    Timeout,
+    Failed(String),
+}
+
+async fn execute(cfg: &Config, job: &Job) -> std::result::Result<String, ExecutionError> {
+    let current_workdir = std::fs::canonicalize(&job.workdir)
+        .map_err(|error| ExecutionError::Failed(format!("recheck job workdir: {error}")))?;
+    if current_workdir != job.workdir {
+        return Err(ExecutionError::Failed(
+            "job workdir changed after validation".to_string(),
+        ));
+    }
+    let instructions = soul::load(&cfg.assistant_dir)
+        .map_err(|error| ExecutionError::Failed(format!("load SOUL.md: {error}")))?;
+    let runner = match job.backend {
+        AgentBackend::Claude => Runner::Claude(claude::Runner {
+            bin: cfg.claude_bin.clone(),
+        }),
+        AgentBackend::Codex => Runner::Codex(codex::Runner {
+            bin: cfg.codex_bin.clone(),
+            model: cfg.codex_model.clone(),
+        }),
+    };
+    let session_id = runner.initial_session_id();
+    let workdir = job.workdir.to_string_lossy().to_string();
+    let request = Request {
+        session_id: &session_id,
+        is_new: true,
+        work_dir: &workdir,
+        instructions: &instructions,
+        permission: job.permission.capability,
+        prompt: &job.body,
+    };
+    match runner.run(request, job.timeout).await {
+        Ok(output) => Ok(output.reply),
+        Err(RunError::Timeout) => Err(ExecutionError::Timeout),
+        Err(RunError::Failed(error) | RunError::SessionMissing(error)) => {
+            Err(ExecutionError::Failed(format!("backend: {error}")))
+        }
+    }
+}
+
+fn bound_result(value: &str) -> String {
+    if value.len() <= MAX_STORED_RESULT_BYTES {
+        return value.to_string();
+    }
+    const SUFFIX: &str = "\n[truncated by push]";
+    let mut boundary = MAX_STORED_RESULT_BYTES.saturating_sub(SUFFIX.len());
+    while !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    format!("{}{SUFFIX}", &value[..boundary])
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or_default()
+}
+
+pub fn format_job(job: &Job) -> String {
+    format!(
+        "name: {}\npath: {}\nbackend: {}\npermission_profile: {}\ntimeout: {}\nworkdir: {}\nsnapshot: {}\n\n{}\n",
+        job.name,
+        job.path.display(),
+        job.backend.as_str(),
+        job.permission.name,
+        humantime::format_duration(job.timeout),
+        job.workdir.display(),
+        job.snapshot_hash,
+        job.body
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{sh_arg, temp_dir, temp_path, FakeCli};
+
+    fn cfg(jobs_dir: &Path, database: &Path, run_dir: &Path) -> Config {
+        let mut cfg = crate::gateway::tests::test_config_for_jobs(
+            temp_path("jobs-state").to_str().unwrap(),
+            temp_dir("jobs-sessions").to_str().unwrap(),
+            temp_dir("jobs-assistant").to_str().unwrap(),
+        );
+        cfg.jobs_dir = jobs_dir.to_string_lossy().to_string();
+        cfg.database_path = database.to_string_lossy().to_string();
+        cfg.jobs_run_dir = run_dir.to_string_lossy().to_string();
+        cfg.job_permission_profiles = vec!["restricted".to_string(), "workspace".to_string()];
+        cfg
+    }
+
+    fn write_job(dir: &Path, name: &str, body: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(format!("{name}.md")), body).unwrap();
+    }
+
+    fn valid_job(workdir: &Path) -> String {
+        format!(
+            "+++\nversion = 1\npermission_profile = \"restricted\"\ntimeout = \"5s\"\nworkdir = {:?}\nbackend = \"codex\"\n+++\n\nInspect this directory.\n",
+            workdir.to_string_lossy()
+        )
+    }
+
+    #[test]
+    fn loads_valid_jobs_and_isolates_invalid_files() {
+        let jobs_dir = temp_dir("jobs-load");
+        let workdir = temp_dir("jobs-work");
+        let database = temp_path("jobs-load-db");
+        let run_dir = temp_dir("jobs-run");
+        write_job(&jobs_dir, "valid-job", &valid_job(&workdir));
+        write_job(&jobs_dir, "Bad_Name", "not frontmatter");
+        let cfg = cfg(&jobs_dir, &database, &run_dir);
+
+        let catalog = Catalog::load(&cfg).unwrap();
+
+        assert!(catalog.jobs.contains_key("valid-job"));
+        assert_eq!(catalog.errors.len(), 1);
+        assert!(catalog.errors[0].message.contains("lowercase ASCII slug"));
+    }
+
+    #[test]
+    fn validation_enforces_permission_timeout_backend_and_workdir() {
+        let jobs_dir = temp_dir("jobs-validation");
+        let workdir = temp_dir("jobs-validation-work");
+        let database = temp_path("jobs-validation-db");
+        let run_dir = temp_dir("jobs-validation-run");
+        write_job(
+            &jobs_dir,
+            "too-powerful",
+            &format!(
+                "+++\nversion = 1\npermission_profile = \"full-access\"\ntimeout = \"5s\"\nworkdir = {:?}\nbackend = \"other\"\n+++\nbody",
+                workdir.to_string_lossy()
+            ),
+        );
+        write_job(
+            &jobs_dir,
+            "too-slow",
+            &format!(
+                "+++\nversion = 1\npermission_profile = \"restricted\"\ntimeout = \"31m\"\nworkdir = {:?}\n+++\nbody",
+                workdir.to_string_lossy()
+            ),
+        );
+        write_job(
+            &jobs_dir,
+            "bad-backend",
+            &format!(
+                "+++\nversion = 1\npermission_profile = \"restricted\"\ntimeout = \"5s\"\nworkdir = {:?}\nbackend = \"other\"\n+++\nbody",
+                workdir.to_string_lossy()
+            ),
+        );
+        write_job(
+            &jobs_dir,
+            "bad-workdir",
+            "+++\nversion = 1\npermission_profile = \"restricted\"\ntimeout = \"5s\"\nworkdir = \"/definitely/missing/push-job\"\n+++\nbody",
+        );
+        let cfg = cfg(&jobs_dir, &database, &run_dir);
+
+        let catalog = Catalog::load(&cfg).unwrap();
+
+        assert!(catalog.jobs.is_empty());
+        let messages = catalog
+            .errors
+            .iter()
+            .map(|error| error.message.as_str())
+            .collect::<Vec<_>>();
+        assert!(messages
+            .iter()
+            .any(|message| message.contains("not included")));
+        assert!(messages
+            .iter()
+            .any(|message| message.contains("no greater than")));
+        assert!(messages
+            .iter()
+            .any(|message| message.contains("invalid agent")));
+        assert!(messages
+            .iter()
+            .any(|message| message.contains("canonicalize job workdir")));
+    }
+
+    #[test]
+    fn cron_validation_rejects_malformed_fields_and_ranges() {
+        for schedule in [
+            "nonsense * * * *",
+            "60 * * * *",
+            "* 24 * * *",
+            "* * 0 * *",
+            "* * * 13 *",
+            "* * * * 8",
+            "10-5 * * * *",
+            "*/0 * * * *",
+            "1//2 * * * *",
+            "1/2 * * * *",
+            "1,,2 * * * *",
+        ] {
+            let trigger = Trigger {
+                id: "test".to_string(),
+                kind: "cron".to_string(),
+                schedule: schedule.to_string(),
+                timezone: "Europe/London".to_string(),
+                enabled: true,
+            };
+            assert!(
+                validate_triggers(&[trigger]).is_err(),
+                "schedule should be invalid: {schedule}"
+            );
+        }
+
+        let valid = Trigger {
+            id: "weekday".to_string(),
+            kind: "cron".to_string(),
+            schedule: "0,30 8-18/2 * * 1-5".to_string(),
+            timezone: "Europe/London".to_string(),
+            enabled: true,
+        };
+        validate_triggers(&[valid]).unwrap();
+    }
+
+    #[test]
+    fn winning_claim_rereads_and_records_the_installed_snapshot() {
+        let jobs_dir = temp_dir("jobs-snapshot");
+        let workdir = temp_dir("jobs-snapshot-work");
+        let database = temp_path("jobs-snapshot-db");
+        let run_dir = temp_dir("jobs-snapshot-run");
+        write_job(&jobs_dir, "snapshot", &valid_job(&workdir));
+        let cfg = cfg(&jobs_dir, &database, &run_dir);
+        let stale = Catalog::load_named(&cfg, "snapshot").unwrap();
+        let updated = valid_job(&workdir).replace("Inspect this directory.", "Use the new body.");
+        write_job(&jobs_dir, "snapshot", &updated);
+
+        let mut ledger = Ledger::open(&cfg.database_path).unwrap();
+        let StartOutcome::Claimed {
+            run_id,
+            job,
+            lock: _,
+        } = ledger.start_manual(&cfg, &stale).unwrap()
+        else {
+            panic!("run should claim");
+        };
+
+        assert_ne!(job.snapshot_hash, stale.snapshot_hash);
+        assert_eq!(job.body, "\nUse the new body.\n");
+        let recorded: String = ledger
+            .conn
+            .query_row(
+                "SELECT snapshot_hash FROM job_runs WHERE id = ?1",
+                [&run_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(recorded, job.snapshot_hash);
+    }
+
+    #[test]
+    fn preserves_the_instruction_body_verbatim() {
+        let jobs_dir = temp_dir("jobs-verbatim");
+        let workdir = temp_dir("jobs-verbatim-work");
+        let database = temp_path("jobs-verbatim-db");
+        let run_dir = temp_dir("jobs-verbatim-run");
+        let expected = "\n    indented code\n\nTrailing space:  \n";
+        let runbook = valid_job(&workdir).replace("\nInspect this directory.\n", expected);
+        write_job(&jobs_dir, "verbatim", &runbook);
+        let cfg = cfg(&jobs_dir, &database, &run_dir);
+
+        let job = Catalog::load_named(&cfg, "verbatim").unwrap();
+
+        assert_eq!(job.body, expected);
+    }
+
+    #[test]
+    fn lock_and_ledger_prevent_overlap_and_recover_stale_claim() {
+        let jobs_dir = temp_dir("jobs-ledger");
+        let workdir = temp_dir("jobs-ledger-work");
+        let database = temp_path("jobs-ledger-db");
+        let run_dir = temp_dir("jobs-ledger-run");
+        write_job(&jobs_dir, "daily-check", &valid_job(&workdir));
+        let cfg = cfg(&jobs_dir, &database, &run_dir);
+        let job = Catalog::load_named(&cfg, "daily-check").unwrap();
+        let mut first = Ledger::open(&cfg.database_path).unwrap();
+        let StartOutcome::Claimed {
+            run_id: first_id,
+            lock,
+            ..
+        } = first.start_manual(&cfg, &job).unwrap()
+        else {
+            panic!("first run should claim");
+        };
+        let mut second = Ledger::open(&cfg.database_path).unwrap();
+        let StartOutcome::Skipped { run_id: skipped } = second.start_manual(&cfg, &job).unwrap()
+        else {
+            panic!("overlap should skip");
+        };
+        assert_eq!(second.state(&skipped), "skipped_overlap");
+        assert_eq!(first.state(&first_id), "running");
+        drop(lock);
+
+        let StartOutcome::Claimed { run_id: next, .. } = second.start_manual(&cfg, &job).unwrap()
+        else {
+            panic!("released stale claim should recover");
+        };
+        assert_eq!(second.state(&first_id), "failed");
+        assert_eq!(second.state(&next), "running");
+    }
+
+    #[test]
+    fn run_rows_and_results_survive_reopen() {
+        let jobs_dir = temp_dir("jobs-persist");
+        let workdir = temp_dir("jobs-persist-work");
+        let database = temp_path("jobs-persist-db");
+        let run_dir = temp_dir("jobs-persist-run");
+        write_job(&jobs_dir, "persist", &valid_job(&workdir));
+        let cfg = cfg(&jobs_dir, &database, &run_dir);
+        let job = Catalog::load_named(&cfg, "persist").unwrap();
+        let mut ledger = Ledger::open(&cfg.database_path).unwrap();
+        let StartOutcome::Claimed { run_id, lock, .. } = ledger.start_manual(&cfg, &job).unwrap()
+        else {
+            panic!("run should claim");
+        };
+        ledger
+            .finish(&run_id, "failed", None, Some("boom"))
+            .unwrap();
+        drop(lock);
+        drop(ledger);
+
+        let reopened = Ledger::open(&cfg.database_path).unwrap();
+        let rows = reopened.runs(Some("persist")).unwrap();
+        assert_eq!(rows[0].state, "failed");
+        assert_eq!(rows[0].error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn stored_results_are_bounded() {
+        let jobs_dir = temp_dir("jobs-result-bound");
+        let workdir = temp_dir("jobs-result-bound-work");
+        let database = temp_path("jobs-result-bound-db");
+        let run_dir = temp_dir("jobs-result-bound-run");
+        write_job(&jobs_dir, "bounded", &valid_job(&workdir));
+        let cfg = cfg(&jobs_dir, &database, &run_dir);
+        let job = Catalog::load_named(&cfg, "bounded").unwrap();
+        let mut ledger = Ledger::open(&cfg.database_path).unwrap();
+        let StartOutcome::Claimed { run_id, lock, .. } = ledger.start_manual(&cfg, &job).unwrap()
+        else {
+            panic!("run should claim");
+        };
+        ledger
+            .finish(
+                &run_id,
+                "succeeded",
+                Some(&"x".repeat(MAX_STORED_RESULT_BYTES * 2)),
+                None,
+            )
+            .unwrap();
+        drop(lock);
+
+        let result = ledger.runs(Some("bounded")).unwrap()[0]
+            .result
+            .clone()
+            .unwrap();
+        assert!(result.len() <= MAX_STORED_RESULT_BYTES);
+        assert!(result.ends_with("[truncated by push]"));
+    }
+
+    #[tokio::test]
+    async fn manual_codex_runs_use_fresh_sessions_and_persist_results() {
+        let jobs_dir = temp_dir("jobs-execute");
+        let workdir = temp_dir("jobs-execute-work");
+        let database = temp_path("jobs-execute-db");
+        let run_dir = temp_dir("jobs-execute-run");
+        let args_path = temp_path("jobs-execute-args");
+        let script = format!(
+            r#"#!/bin/sh
+printf '%s\n' "$@" >> {}
+out=''
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = '-o' ]; then out="$arg"; fi
+  prev="$arg"
+done
+printf '%s\n' 'manual result' > "$out"
+printf '%s\n' '{{"type":"thread.started","thread_id":"fresh-thread"}}'
+"#,
+            sh_arg(&args_path)
+        );
+        let cli = FakeCli::new("codex", &script);
+        write_job(&jobs_dir, "execute", &valid_job(&workdir));
+        let mut cfg = cfg(&jobs_dir, &database, &run_dir);
+        cfg.codex_bin = cli.bin();
+
+        let first = run_manual(&cfg, Catalog::load_named(&cfg, "execute").unwrap())
+            .await
+            .unwrap();
+        let second = run_manual(&cfg, Catalog::load_named(&cfg, "execute").unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(first.1, "manual result");
+        assert_eq!(second.1, "manual result");
+        let args = std::fs::read_to_string(args_path).unwrap();
+        assert_eq!(args.lines().filter(|line| *line == "exec").count(), 2);
+        assert!(!args.lines().any(|line| line == "resume"));
+        let rows = Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(Some("execute"))
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|row| row.state == "succeeded"));
+        assert!(rows
+            .iter()
+            .all(|row| row.result.as_deref() == Some("manual result")));
+    }
+
+    #[tokio::test]
+    async fn timeout_is_terminal_and_does_not_block_a_later_run() {
+        let jobs_dir = temp_dir("jobs-timeout");
+        let workdir = temp_dir("jobs-timeout-work");
+        let database = temp_path("jobs-timeout-db");
+        let run_dir = temp_dir("jobs-timeout-run");
+        let slow = FakeCli::new("codex", "#!/bin/sh\nsleep 2\n");
+        write_job(
+            &jobs_dir,
+            "timeout",
+            &valid_job(&workdir).replace("timeout = \"5s\"", "timeout = \"10ms\""),
+        );
+        let mut cfg = cfg(&jobs_dir, &database, &run_dir);
+        cfg.codex_bin = slow.bin();
+        let job = Catalog::load_named(&cfg, "timeout").unwrap();
+
+        assert!(run_manual(&cfg, job).await.is_err());
+        let rows = Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(Some("timeout"))
+            .unwrap();
+        assert_eq!(rows[0].state, "timed_out");
+
+        let args_path = temp_path("jobs-timeout-retry-args");
+        let script = format!(
+            r#"#!/bin/sh
+out=''
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = '-o' ]; then out="$arg"; fi
+  prev="$arg"
+done
+printf '%s\n' 'recovered' > "$out"
+printf '%s\n' '{{"type":"thread.started","thread_id":"retry-thread"}}'
+printf '%s\n' ok > {}
+"#,
+            sh_arg(&args_path)
+        );
+        let success = FakeCli::new("codex", &script);
+        cfg.codex_bin = success.bin();
+        write_job(&jobs_dir, "timeout", &valid_job(&workdir));
+        let output = run_manual(&cfg, Catalog::load_named(&cfg, "timeout").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(output.1, "recovered");
+        let rows = Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(Some("timeout"))
+            .unwrap();
+        assert_eq!(rows[0].state, "succeeded");
+        assert_eq!(rows[1].state, "timed_out");
+    }
+
+    #[tokio::test]
+    async fn backend_override_selects_claude_with_a_fresh_session() {
+        let jobs_dir = temp_dir("jobs-claude");
+        let workdir = temp_dir("jobs-claude-work");
+        let database = temp_path("jobs-claude-db");
+        let run_dir = temp_dir("jobs-claude-run");
+        let args_path = temp_path("jobs-claude-args");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nprintf '%s\\n' '{{\"result\":\"claude result\",\"session_id\":\"claude-session\"}}'\n",
+            sh_arg(&args_path)
+        );
+        let cli = FakeCli::new("claude", &script);
+        let runbook = valid_job(&workdir).replace("backend = \"codex\"", "backend = \"claude\"");
+        write_job(&jobs_dir, "claude-job", &runbook);
+        let mut cfg = cfg(&jobs_dir, &database, &run_dir);
+        cfg.claude_bin = cli.bin();
+
+        let output = run_manual(&cfg, Catalog::load_named(&cfg, "claude-job").unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(output.1, "claude result");
+        let args = std::fs::read_to_string(args_path).unwrap();
+        assert!(args.lines().any(|line| line == "--session-id"));
+        assert!(!args.lines().any(|line| line == "--resume"));
+        assert!(args.lines().any(|line| line == "Inspect this directory."));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod config;
 mod gateway;
 mod history;
 mod imessage;
+mod jobs;
 mod rehydration;
 mod soul;
 mod store;
@@ -29,12 +30,16 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt().with_target(false).init();
 
     let args = Args::parse(std::env::args().skip(1).collect())?;
-    if args.command == Command::Doctor {
-        return doctor(&args.config_path);
+    match args.command {
+        Command::Doctor => doctor(&args.config_path),
+        Command::Job(command) => run_job_command(&args.config_path, command).await,
+        Command::Run => {
+            let cfg = config::Config::load(&args.config_path).context("config")?;
+            preflight(&cfg).context("preflight")?;
+            report_invalid_jobs(&cfg)?;
+            gateway::Gateway::new(cfg).context("init")?.run().await
+        }
     }
-    let cfg = config::Config::load(&args.config_path).context("config")?;
-    preflight(&cfg).context("preflight")?;
-    gateway::Gateway::new(cfg).context("init")?.run().await
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -47,19 +52,25 @@ struct Args {
 enum Command {
     Run,
     Doctor,
+    Job(JobCommand),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum JobCommand {
+    Validate,
+    List,
+    Show(String),
+    Run(String),
+    Runs(Option<String>),
 }
 
 impl Args {
     fn parse(args: Vec<String>) -> Result<Self> {
-        let mut command = Command::Run;
         let mut config_path = "config.toml".to_string();
+        let mut positional = Vec::new();
         let mut i = 0;
         while i < args.len() {
             match args[i].as_str() {
-                "doctor" if command == Command::Run => {
-                    command = Command::Doctor;
-                    i += 1;
-                }
                 "--config" => {
                     let Some(path) = args.get(i + 1) else {
                         bail!("--config requires a path");
@@ -67,14 +78,116 @@ impl Args {
                     config_path = path.clone();
                     i += 2;
                 }
-                other => bail!("unknown argument {other:?}; expected doctor or --config <path>"),
+                value => {
+                    positional.push(value.to_string());
+                    i += 1;
+                }
             }
         }
+        let command = match positional.iter().map(String::as_str).collect::<Vec<_>>().as_slice() {
+            [] => Command::Run,
+            ["doctor"] => Command::Doctor,
+            ["job", "validate"] => Command::Job(JobCommand::Validate),
+            ["job", "list"] => Command::Job(JobCommand::List),
+            ["job", "show", name] => Command::Job(JobCommand::Show((*name).to_string())),
+            ["job", "run", name] => Command::Job(JobCommand::Run((*name).to_string())),
+            ["job", "runs"] => Command::Job(JobCommand::Runs(None)),
+            ["job", "runs", name] => Command::Job(JobCommand::Runs(Some((*name).to_string()))),
+            _ => bail!(
+                "unknown command; expected doctor, job validate, job list, job show <name>, job run <name>, job runs [<name>], or --config <path>"
+            ),
+        };
         Ok(Self {
             command,
             config_path,
         })
     }
+}
+
+async fn run_job_command(config_path: &str, command: JobCommand) -> Result<()> {
+    let cfg = config::Config::load(config_path).context("config")?;
+    match command {
+        JobCommand::Validate => {
+            let catalog = jobs::Catalog::load(&cfg)?;
+            for job in catalog.jobs.values() {
+                println!("VALID\t{}", job.name);
+            }
+            for error in &catalog.errors {
+                println!(
+                    "INVALID\t{}\t{}\t{}",
+                    error.name,
+                    error.path.display(),
+                    error.message
+                );
+            }
+            if catalog.errors.is_empty() {
+                Ok(())
+            } else {
+                bail!("{} invalid job(s)", catalog.errors.len())
+            }
+        }
+        JobCommand::List => {
+            let catalog = jobs::Catalog::load(&cfg)?;
+            for job in catalog.jobs.values() {
+                println!(
+                    "{}\tvalid\t{}\t{}",
+                    job.name,
+                    job.backend.as_str(),
+                    job.permission.name
+                );
+            }
+            for error in catalog.errors {
+                println!("{}\tinvalid\t{}", error.name, error.message);
+            }
+            Ok(())
+        }
+        JobCommand::Show(name) => {
+            let job = jobs::Catalog::load_named(&cfg, &name)?;
+            print!("{}", jobs::format_job(&job));
+            Ok(())
+        }
+        JobCommand::Run(name) => {
+            let job = jobs::Catalog::load_named(&cfg, &name)?;
+            let (run_id, output) = jobs::run_manual(&cfg, job).await?;
+            println!("run_id: {run_id}");
+            println!("{output}");
+            Ok(())
+        }
+        JobCommand::Runs(name) => {
+            if let Some(name) = name.as_deref() {
+                jobs::validate_job_name(name)?;
+            }
+            let ledger = jobs::Ledger::open(&cfg.database_path)?;
+            for run in ledger.runs(name.as_deref())? {
+                println!(
+                    "{}\t{}\t{}\t{}\t{}\t{}",
+                    run.id,
+                    run.job_name,
+                    run.state,
+                    run.backend,
+                    run.queued_at_ms,
+                    run.result
+                        .or(run.error)
+                        .unwrap_or_default()
+                        .replace('\n', " ")
+                );
+            }
+            Ok(())
+        }
+    }
+}
+
+fn report_invalid_jobs(cfg: &config::Config) -> Result<()> {
+    let catalog = jobs::Catalog::load(cfg)?;
+    for error in catalog.errors {
+        tracing::warn!(
+            "job {:?} disabled ({}): {}",
+            error.name,
+            error.path.display(),
+            error.message
+        );
+    }
+    Ok(())
 }
 
 /// Fails fast with actionable messages when the environment is not ready.
@@ -423,6 +536,71 @@ mod tests {
     }
 
     #[test]
+    fn parses_all_job_commands_with_config_anywhere() {
+        assert_eq!(
+            Args::parse(vec!["job".into(), "validate".into()])
+                .unwrap()
+                .command,
+            Command::Job(JobCommand::Validate)
+        );
+        assert_eq!(
+            Args::parse(vec![
+                "--config".into(),
+                "x.toml".into(),
+                "job".into(),
+                "list".into()
+            ])
+            .unwrap(),
+            Args {
+                command: Command::Job(JobCommand::List),
+                config_path: "x.toml".to_string(),
+            }
+        );
+        assert_eq!(
+            Args::parse(vec!["job".into(), "show".into(), "daily".into()])
+                .unwrap()
+                .command,
+            Command::Job(JobCommand::Show("daily".to_string()))
+        );
+        assert_eq!(
+            Args::parse(vec!["job".into(), "run".into(), "daily".into()])
+                .unwrap()
+                .command,
+            Command::Job(JobCommand::Run("daily".to_string()))
+        );
+        assert_eq!(
+            Args::parse(vec!["job".into(), "runs".into()])
+                .unwrap()
+                .command,
+            Command::Job(JobCommand::Runs(None))
+        );
+        assert_eq!(
+            Args::parse(vec!["job".into(), "runs".into(), "daily".into()])
+                .unwrap()
+                .command,
+            Command::Job(JobCommand::Runs(Some("daily".to_string())))
+        );
+    }
+
+    #[test]
+    fn invalid_jobs_are_non_fatal_during_gateway_startup() {
+        let jobs_dir = temp_dir("invalid-startup-jobs");
+        std::fs::write(jobs_dir.join("invalid.md"), "not a runbook").unwrap();
+        let state_path = temp_path("invalid-startup-state");
+        let sessions_dir = temp_dir("invalid-startup-sessions");
+        let assistant_dir = temp_dir("invalid-startup-assistant");
+        let mut cfg = crate::gateway::tests::test_config_for_jobs(
+            state_path.to_str().unwrap(),
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        );
+        cfg.jobs_dir = jobs_dir.to_string_lossy().to_string();
+
+        assert!(report_invalid_jobs(&cfg).is_ok());
+        assert!(gateway::Gateway::new(cfg).is_ok());
+    }
+
+    #[test]
     fn defaults_to_toml_config_path() {
         assert_eq!(
             Args::parse(Vec::new()).unwrap(),
@@ -446,6 +624,14 @@ mod tests {
         assert!(cfg.telegram_allow_chat_ids.is_empty());
         assert_eq!(cfg.permission_profile, "restricted");
         assert!(cfg.permission_profiles.is_empty());
+        assert_eq!(cfg.jobs_agent, None);
+        assert_eq!(cfg.jobs_max_timeout, "30m");
+        assert_eq!(
+            cfg.jobs_dir,
+            Path::new(&std::env::var("HOME").unwrap())
+                .join(".push/jobs")
+                .to_string_lossy()
+        );
         assert_eq!(
             cfg.database_path,
             Path::new(&std::env::var("HOME").unwrap())
@@ -951,6 +1137,10 @@ capability = "workspace"
             permission_profile: "restricted".to_string(),
             job_permission_profiles: vec!["restricted".to_string()],
             permission_profiles: std::collections::HashMap::new(),
+            jobs_dir: "/fake/jobs".to_string(),
+            jobs_agent: None,
+            jobs_max_timeout: "30m".to_string(),
+            jobs_run_dir: "/fake/run".to_string(),
             claude_bin: "/fake/claude".to_string(),
             codex_bin: "/fake/codex".to_string(),
             codex_model: None,

--- a/tests/manual_job_crash.rs
+++ b/tests/manual_job_crash.rs
@@ -1,0 +1,292 @@
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use rusqlite::{Connection, OptionalExtension};
+use uuid::Uuid;
+
+#[test]
+fn job_cli_validates_lists_shows_runs_and_reads_history() {
+    let root = std::env::temp_dir().join(format!("push-job-cli-{}", Uuid::new_v4()));
+    let jobs = root.join("jobs");
+    let work = root.join("work");
+    let run = root.join("run");
+    let database = root.join("push.db");
+    let config = root.join("config.toml");
+    let codex = root.join("fake-codex");
+    std::fs::create_dir_all(&jobs).unwrap();
+    std::fs::create_dir_all(&work).unwrap();
+    write_executable(
+        &codex,
+        r#"#!/bin/sh
+out=''
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = '-o' ]; then out="$arg"; fi
+  prev="$arg"
+done
+printf '%s\n' 'cli result' > "$out"
+printf '%s\n' '{"type":"thread.started","thread_id":"cli-thread"}'
+"#,
+    );
+    write_job_and_config(&jobs, &work, &run, &database, &config, &codex);
+    let binary = env!("CARGO_BIN_EXE_push");
+
+    let validate = run_cli(binary, &config, &["job", "validate"]);
+    assert!(validate.status.success());
+    assert!(stdout(&validate).contains("VALID\tcrash-test"));
+
+    let list = run_cli(binary, &config, &["job", "list"]);
+    assert!(list.status.success());
+    assert!(stdout(&list).contains("crash-test\tvalid\tcodex\trestricted"));
+
+    let show = run_cli(binary, &config, &["job", "show", "crash-test"]);
+    assert!(show.status.success());
+    assert!(stdout(&show).contains("name: crash-test"));
+    assert!(stdout(&show).contains("Return a short result."));
+
+    let run_result = run_cli(binary, &config, &["job", "run", "crash-test"]);
+    assert!(run_result.status.success());
+    assert!(stdout(&run_result).contains("cli result"));
+
+    let history = run_cli(binary, &config, &["job", "runs", "crash-test"]);
+    assert!(history.status.success());
+    assert!(stdout(&history).contains("\tcrash-test\tsucceeded\tcodex\t"));
+    assert!(stdout(&history).contains("cli result"));
+
+    std::fs::write(jobs.join("invalid.md"), "not a runbook").unwrap();
+    let invalid = run_cli(binary, &config, &["job", "validate"]);
+    assert!(!invalid.status.success());
+    assert!(stdout(&invalid).contains("INVALID\tinvalid"));
+    assert!(String::from_utf8_lossy(&invalid.stderr).contains("1 invalid job(s)"));
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn concurrent_first_runs_on_a_fresh_database_skip_without_sqlite_errors() {
+    let root = std::env::temp_dir().join(format!("push-job-race-{}", Uuid::new_v4()));
+    let jobs = root.join("jobs");
+    let work = root.join("work");
+    let run = root.join("run");
+    let database = root.join("push.db");
+    let config = root.join("config.toml");
+    let codex = root.join("fake-codex");
+    std::fs::create_dir_all(&jobs).unwrap();
+    std::fs::create_dir_all(&work).unwrap();
+    write_executable(&codex, "#!/bin/sh\nsleep 30\n");
+    write_job_and_config(&jobs, &work, &run, &database, &config, &codex);
+
+    let binary = env!("CARGO_BIN_EXE_push");
+    let mut first = spawn_run(binary, &config);
+    let mut second = spawn_run(binary, &config);
+    wait_for_counts(&database, 1, 1);
+
+    let first_status = first.try_wait().unwrap();
+    let second_status = second.try_wait().unwrap();
+    assert!(first_status.is_none() ^ second_status.is_none());
+    let skipped_status = first_status.or(second_status).unwrap();
+    assert!(skipped_status.success());
+    if first_status.is_none() {
+        first.kill().unwrap();
+        first.wait().unwrap();
+    } else {
+        second.kill().unwrap();
+        second.wait().unwrap();
+    }
+
+    assert_eq!(count_state(&database, "running"), 1);
+    assert_eq!(count_state(&database, "skipped_overlap"), 1);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn live_cli_is_not_reclaimed_and_crashed_cli_is_recovered() {
+    let root = std::env::temp_dir().join(format!("push-job-crash-{}", Uuid::new_v4()));
+    let jobs = root.join("jobs");
+    let work = root.join("work");
+    let run = root.join("run");
+    let database = root.join("push.db");
+    let config = root.join("config.toml");
+    let codex = root.join("fake-codex");
+    std::fs::create_dir_all(&jobs).unwrap();
+    std::fs::create_dir_all(&work).unwrap();
+    write_executable(&codex, "#!/bin/sh\nsleep 30\n");
+    write_job_and_config(&jobs, &work, &run, &database, &config, &codex);
+
+    let binary = env!("CARGO_BIN_EXE_push");
+    let mut live = Command::new(binary)
+        .args(["job", "run", "crash-test", "--config"])
+        .arg(&config)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_for_state(&database, "running");
+
+    let overlap = Command::new(binary)
+        .args(["job", "run", "crash-test", "--config"])
+        .arg(&config)
+        .output()
+        .unwrap();
+    assert!(overlap.status.success());
+    assert!(String::from_utf8_lossy(&overlap.stdout).contains("skipped_overlap"));
+    assert_eq!(count_state(&database, "running"), 1);
+
+    live.kill().unwrap();
+    let _ = live.wait();
+    write_executable(
+        &codex,
+        r#"#!/bin/sh
+out=''
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = '-o' ]; then out="$arg"; fi
+  prev="$arg"
+done
+printf '%s\n' 'recovered result' > "$out"
+printf '%s\n' '{"type":"thread.started","thread_id":"fresh-thread"}'
+"#,
+    );
+
+    let recovered = Command::new(binary)
+        .args(["job", "run", "crash-test", "--config"])
+        .arg(&config)
+        .output()
+        .unwrap();
+    assert!(
+        recovered.status.success(),
+        "{}",
+        String::from_utf8_lossy(&recovered.stderr)
+    );
+    assert!(String::from_utf8_lossy(&recovered.stdout).contains("recovered result"));
+    assert_eq!(count_state(&database, "succeeded"), 1);
+    assert_eq!(count_state(&database, "failed"), 1);
+    assert_eq!(count_state(&database, "skipped_overlap"), 1);
+    assert_eq!(count_state(&database, "running"), 0);
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+fn spawn_run(binary: &str, config: &Path) -> std::process::Child {
+    Command::new(binary)
+        .args(["job", "run", "crash-test", "--config"])
+        .arg(config)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap()
+}
+
+fn run_cli(binary: &str, config: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(binary)
+        .args(args)
+        .arg("--config")
+        .arg(config)
+        .output()
+        .unwrap()
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn write_job_and_config(
+    jobs: &Path,
+    work: &Path,
+    run: &Path,
+    database: &Path,
+    config: &Path,
+    codex: &Path,
+) {
+    std::fs::write(
+        jobs.join("crash-test.md"),
+        format!(
+            "+++\nversion = 1\npermission_profile = \"restricted\"\ntimeout = \"1m\"\nworkdir = {:?}\nbackend = \"codex\"\n+++\n\nReturn a short result.\n",
+            work.to_string_lossy()
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        config,
+        format!(
+            "channel = \"telegram\"\nagent = \"codex\"\ntelegram_bot_token = \"test\"\ntelegram_allow_user_ids = [1]\ndatabase_path = {:?}\njobs_dir = {:?}\njobs_run_dir = {:?}\ncodex_bin = {:?}\njob_permission_profiles = [\"restricted\"]\n",
+            database.to_string_lossy(),
+            jobs.to_string_lossy(),
+            run.to_string_lossy(),
+            codex.to_string_lossy(),
+        ),
+    )
+    .unwrap();
+}
+
+fn wait_for_state(database: &Path, state: &str) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if database.exists() {
+            if let Ok(connection) = Connection::open(database) {
+                let found = connection
+                    .query_row(
+                        "SELECT 1 FROM job_runs WHERE state = ?1 LIMIT 1",
+                        [state],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .optional()
+                    .ok()
+                    .flatten()
+                    .is_some();
+                if found {
+                    return;
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("timed out waiting for job state {state}");
+}
+
+fn wait_for_counts(database: &Path, running: i64, skipped: i64) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if database.exists()
+            && count_state_if_ready(database, "running") == Some(running)
+            && count_state_if_ready(database, "skipped_overlap") == Some(skipped)
+        {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("timed out waiting for concurrent run states");
+}
+
+fn count_state_if_ready(database: &Path, state: &str) -> Option<i64> {
+    Connection::open(database)
+        .ok()?
+        .query_row(
+            "SELECT COUNT(*) FROM job_runs WHERE state = ?1",
+            [state],
+            |row| row.get(0),
+        )
+        .ok()
+}
+
+fn count_state(database: &Path, state: &str) -> i64 {
+    Connection::open(database)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM job_runs WHERE state = ?1",
+            [state],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+fn write_executable(path: &PathBuf, content: &str) {
+    let temporary = path.with_extension("tmp");
+    std::fs::write(&temporary, content).unwrap();
+    std::fs::set_permissions(&temporary, std::fs::Permissions::from_mode(0o700)).unwrap();
+    std::fs::rename(temporary, path).unwrap();
+}


### PR DESCRIPTION
## Summary

- load and strictly validate Markdown runbook jobs with named permission, backend, timeout, workdir, trigger, and snapshot rules
- add durable SQLite run claims, bounded results, non-blocking per-job OS locks, stale manual-claim recovery, and fresh Claude/Codex execution
- add `job validate`, `list`, `show`, `run`, and `runs` commands plus non-fatal gateway startup reporting
- document configuration and manual job operations

## Why

This provides the first usable jobs runtime while preserving the approved separation between manual execution and later scheduling/delivery work.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (157 unit tests and 3 subprocess tests)
- subprocess coverage verifies all jobs CLI commands, fresh-database contention, live overlap, process termination, stale-claim recovery, and durable history
- independent diff review completed with no remaining actionable findings

## Risks

The SQLite schema advances to version 3. The additive migration is transactional and covered from fresh, v1, and v2 databases, including concurrent first-run processes. Cron definitions are validated but not scheduled in this issue.

## Related issue

Closes #61