### PR TITLE
feat: schedule jobs and persist delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,7 +113,11 @@ version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -116,6 +129,12 @@ dependencies = [
  "chrono",
  "phf",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -408,6 +427,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +727,7 @@ name = "push"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "chrono-tz",
  "humantime",
  "reqwest",
@@ -1488,10 +1532,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1"
 humantime = "2"
 sha2 = "0.10"
 chrono-tz = "0.10"
+chrono = "0.4"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ jobs_dir = "~/.push/jobs"
 jobs_agent = "codex"
 jobs_max_timeout = "30m"
 jobs_run_dir = "~/.push/run"
+jobs_max_workers = 2
 
 [permission_profiles.research]
 capability = "read-only"
@@ -380,8 +381,31 @@ for its full lifetime. An overlap is recorded as `skipped_overlap`. Once the
 lock is released, the next start safely marks a stale `running` manual claim as
 failed before claiming a new run. Results and diagnostics are bounded and
 remain visible through `push job runs`; manual results are printed to the
-terminal and are never proactively sent to a chat. Scheduling is not enabled in
-this release.
+terminal and are never proactively sent to a chat.
+
+Add one or more cron triggers to schedule a job. Cron uses five fields and an
+explicit IANA timezone:
+
+```toml
+[[triggers]]
+id = "weekday-morning"
+kind = "cron"
+schedule = "0 8 * * 1-5"
+timezone = "Europe/London"
+enabled = true
+```
+
+Scheduling starts only when `primary_delivery` resolves to an enabled,
+allowlisted destination. Missing or invalid primary delivery disables cron
+without affecting replies or manual jobs. The gateway runs at most
+`jobs_max_workers` scheduled jobs concurrently. It does not catch up occurrences
+missed while offline, and daylight-saving gaps are skipped while repeated local
+times run once at their first instant.
+
+Scheduled state and bounded output are persisted before delivery. Success,
+failure, timeout, overlap, and delivery state remain separate in
+`push job runs`. Delivery retries up to three times with backoff from the stored
+result, including after restart, and never reruns the backend.
 
 push reads TOML only. Convert any earlier `config.json` file to `config.toml`
 before upgrading. The old JSON filename remains gitignored to reduce the risk

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,6 +206,19 @@ Optional `primary_delivery` selects one enabled, allowlisted channel target for
 proactive output. Resolution is lazy: an absent or invalid primary returns a
 scoped error to the proactive caller without affecting reply polling.
 
+When primary delivery resolves, the gateway also runs the cron scheduler. It
+evaluates validated five-field triggers against their IANA timezone, enqueues at
+most one occurrence after an in-process clock jump, and initializes future-only
+occurrences after restart so downtime is never caught up. A configured worker
+limit bounds fresh-session job execution. Scheduled and manual processes share
+the per-job advisory lock and SQLite active-run uniqueness boundary.
+
+Scheduled output or bounded failure detail is committed before notification.
+Delivery has its own persisted state and is retried up to three times from that
+stored result. Restart recovery resumes queued work and pending delivery, but
+never reruns a backend run that had already started. A running row is marked
+interrupted only after the released advisory lock proves its executor is gone.
+
 `push.db` stores channel-qualified conversations and their inbound and outbound
 messages. Accepted inbound messages are inserted before gateway commands or
 backend dispatch. Generated backend, command, and error replies are inserted

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -142,6 +142,7 @@ user prompt.
 | `jobs_agent` | Optional default job backend; otherwise uses `agent`. |
 | `jobs_max_timeout` | Maximum validated job timeout; defaults to `30m`. |
 | `jobs_run_dir` | Local advisory-lock state; defaults to `~/.push/run`. |
+| `jobs_max_workers` | Maximum concurrent scheduled jobs; defaults to `2`. |
 | `imessage.db_path` | Path to Messages `chat.db`. |
 | `poll_interval` | How often to poll. |
 | `run_timeout` | Max backend run time. |

--- a/docs/services.md
+++ b/docs/services.md
@@ -164,6 +164,14 @@ managed service. Use the same config file so the CLI and service share
 `push.db`, `jobs_dir`, and the local per-job lock directory. Invalid job files
 are reported and disabled individually; they do not stop the messaging service.
 
+## Scheduled Jobs
+
+Cron triggers run inside the managed gateway only when `primary_delivery`
+resolves. Keep `push.db`, `jobs_dir`, and `jobs_run_dir` on persistent local
+storage. Restarting the service resumes queued runs and pending result delivery;
+it does not catch up missed cron times or rerun interrupted agent execution.
+Use `push job runs` to distinguish execution state from delivery attempts.
+
 ## Restart Behavior
 
 `push` only advances the selected channel cursor after a message is ignored or

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,8 @@ pub struct Config {
     pub jobs_max_timeout: String,
     #[serde(default = "default_jobs_run_dir")]
     pub jobs_run_dir: String,
+    #[serde(default = "default_jobs_max_workers")]
+    pub jobs_max_workers: usize,
     #[serde(default = "default_claude_bin")]
     pub claude_bin: String,
     #[serde(default = "default_codex_bin")]
@@ -321,6 +323,9 @@ impl Config {
         if self.jobs_dir.trim().is_empty() || self.jobs_run_dir.trim().is_empty() {
             bail!("jobs_dir and jobs_run_dir cannot be empty");
         }
+        if self.jobs_max_workers == 0 {
+            bail!("jobs_max_workers must be positive");
+        }
         self.resolve_permission_profile(&self.permission_profile)
             .context("invalid default permission profile")?;
         for (name, profile) in &self.permission_profiles {
@@ -579,6 +584,9 @@ fn default_jobs_max_timeout() -> String {
 }
 fn default_jobs_run_dir() -> String {
     "~/.push/run".to_string()
+}
+fn default_jobs_max_workers() -> usize {
+    2
 }
 fn default_sessions_dir() -> String {
     "~/.push/sessions".to_string()

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -26,6 +26,7 @@ use crate::claude;
 use crate::codex;
 use crate::config::{AgentBackend, ChannelKind, Config, PermissionProfile, PrimaryDeliveryConfig};
 use crate::history::{DeliveryStatus, History, OutboundMessage, OutboundOrigin};
+use crate::jobs;
 use crate::rehydration::{self, RehydrationPrompt};
 use crate::soul;
 use crate::store::Store;
@@ -87,6 +88,7 @@ pub struct Gateway {
 pub struct GatewayGroup {
     gateways: Vec<Gateway>,
     primary_delivery: Option<PrimaryDeliveryConfig>,
+    cfg: Config,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -123,7 +125,8 @@ impl GatewayGroup {
         }
         Ok(Self {
             gateways,
-            primary_delivery: cfg.primary_delivery,
+            primary_delivery: cfg.primary_delivery.clone(),
+            cfg,
         })
     }
 
@@ -200,6 +203,23 @@ impl GatewayGroup {
         S: Future<Output = ()>,
     {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let scheduler = match self.primary_destination() {
+            Ok(destination) => {
+                jobs::Scheduler::new(self.cfg.clone(), destination.channel, destination.target)
+            }
+            Err(error) => {
+                warn!("scheduled jobs disabled: {error:#}");
+                jobs::Scheduler::delivery_only(self.cfg.clone())
+            }
+        };
+        let contexts = self
+            .gateways
+            .iter()
+            .map(|gateway| (gateway.channel.id().to_string(), gateway.ctx.clone()))
+            .collect::<HashMap<_, _>>();
+        let receiver = shutdown_rx.clone();
+        let scheduler =
+            tokio::spawn(async move { run_scheduler(scheduler, contexts, receiver).await });
         let mut tasks = JoinSet::new();
         for gateway in self.gateways {
             let channel = gateway.channel.id();
@@ -213,8 +233,56 @@ impl GatewayGroup {
             });
         }
         drop(shutdown_rx);
-        coordinate_channel_tasks(tasks, shutdown_tx, shutdown).await
+        let result = coordinate_channel_tasks(tasks, shutdown_tx, shutdown).await;
+        match scheduler.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => error!("job scheduler stopped: {error:#}"),
+            Err(error) => error!("job scheduler task failed: {error}"),
+        }
+        result
     }
+}
+
+async fn run_scheduler(
+    mut scheduler: jobs::Scheduler,
+    contexts: HashMap<String, Ctx>,
+    mut shutdown: watch::Receiver<bool>,
+) -> Result<()> {
+    let contexts = Arc::new(contexts);
+    let mut ticker = tokio::time::interval(Duration::from_secs(1));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            changed = shutdown.changed() => {
+                if changed.is_err() || *shutdown.borrow() {
+                    break;
+                }
+            }
+            _ = ticker.tick() => {
+                let contexts = contexts.clone();
+                if let Err(error) = scheduler.tick(now_ms(), move |channel, target, text| {
+                    let contexts = contexts.clone();
+                    async move {
+                        let ctx = contexts.get(&channel).with_context(|| {
+                            format!("persisted delivery channel {channel:?} is not enabled")
+                        })?;
+                        let target = ctx.channel.primary_target(&target).context(
+                            "persisted delivery target is no longer allowlisted",
+                        )?;
+                        if reply_to(ctx, &target, &text).await {
+                            Ok(())
+                        } else {
+                            anyhow::bail!("delivery to {channel} target {target:?} failed")
+                        }
+                    }
+                }).await {
+                    error!("job scheduler tick failed: {error:#}");
+                }
+            }
+        }
+    }
+    scheduler.shutdown().await;
+    Ok(())
 }
 
 async fn coordinate_channel_tasks<S>(
@@ -2983,6 +3051,57 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn missing_primary_disables_new_schedules_without_stopping_gateway() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("missing-primary-sessions");
+        let assistant_dir = temp_path("missing-primary-assistant");
+        let jobs_dir = temp_path("missing-primary-jobs");
+        let workdir = temp_path("missing-primary-work");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        std::fs::create_dir_all(&jobs_dir).unwrap();
+        std::fs::create_dir_all(&workdir).unwrap();
+        let mut cfg = test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        );
+        cfg.jobs_dir = jobs_dir.to_string_lossy().to_string();
+        std::fs::write(
+            jobs_dir.join("disabled.md"),
+            format!(
+                "+++\nversion = 1\npermission_profile = \"restricted\"\ntimeout = \"5s\"\nworkdir = {:?}\nbackend = \"codex\"\n\n[[triggers]]\nid = \"minute\"\nkind = \"cron\"\nschedule = \"* * * * *\"\ntimezone = \"UTC\"\nenabled = true\n+++\n\nRun.\n",
+                workdir.to_string_lossy()
+            ),
+        )
+        .unwrap();
+        let group = GatewayGroup::new(cfg.clone()).unwrap();
+        group.gateways[0]
+            .store
+            .lock()
+            .unwrap()
+            .set_cursor("imessage", 1)
+            .unwrap();
+
+        group
+            .run_until(tokio::time::sleep(Duration::from_millis(50)))
+            .await
+            .unwrap();
+
+        let rows = crate::jobs::Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(Some("disabled"))
+            .unwrap();
+        assert!(rows.is_empty());
+        let _ = std::fs::remove_file(&state_path);
+        let _ = std::fs::remove_file(format!("{state_path}.db"));
+        let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+        let _ = std::fs::remove_dir_all(sessions_dir);
+        let _ = std::fs::remove_dir_all(assistant_dir);
+        let _ = std::fs::remove_dir_all(jobs_dir);
+        let _ = std::fs::remove_dir_all(workdir);
+    }
+
+    #[tokio::test]
     async fn one_channel_failure_does_not_stop_another_and_shutdown_reaches_survivor() {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let healthy_started = Arc::new(AtomicBool::new(false));
@@ -3091,6 +3210,7 @@ pub(crate) mod tests {
             jobs_agent: None,
             jobs_max_timeout: "30m".to_string(),
             jobs_run_dir: format!("{state_path}.run"),
+            jobs_max_workers: 2,
             claude_bin: "claude".to_string(),
             codex_bin: "codex".to_string(),
             codex_model: None,

--- a/src/history.rs
+++ b/src/history.rs
@@ -11,7 +11,7 @@ use crate::approval::{
     NormalizedAnswer, Question, QuestionState,
 };
 
-const SCHEMA_VERSION: i64 = 3;
+const SCHEMA_VERSION: i64 = 4;
 const MAX_HISTORY_READ_BYTES: usize = 8 * 1024;
 const READ_TRUNCATED: &str = "\n[truncated by push while reading history]";
 
@@ -647,6 +647,16 @@ fn migrate(conn: &Connection) -> Result<()> {
              PRAGMA user_version = 3;",
         )?;
     }
+    if version <= 3 {
+        conn.execute_batch(
+            "ALTER TABLE job_runs ADD COLUMN delivery_channel TEXT;
+             ALTER TABLE job_runs ADD COLUMN delivery_target TEXT;
+             CREATE UNIQUE INDEX job_runs_scheduled_occurrence
+                 ON job_runs(job_name, trigger_id, scheduled_at_ms)
+                 WHERE trigger_kind = 'cron';
+             PRAGMA user_version = 4;",
+        )?;
+    }
     conn.execute_batch("COMMIT;")?;
     Ok(())
 }
@@ -809,7 +819,7 @@ mod tests {
                 .conn
                 .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
                 .unwrap(),
-            3
+            SCHEMA_VERSION
         );
         let run_table: i64 = reopened
             .conn
@@ -820,6 +830,16 @@ mod tests {
             )
             .unwrap();
         assert_eq!(run_table, 1);
+        let delivery_columns: i64 = reopened
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('job_runs')
+                 WHERE name IN ('delivery_channel', 'delivery_target')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(delivery_columns, 2);
         let _ = std::fs::remove_file(path);
     }
 

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -1,15 +1,18 @@
 //! Validated Markdown runbooks and the durable manual-run runtime.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::{File, OpenOptions, TryLockError};
+use std::future::Future;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context, Result};
+use chrono::{Datelike, LocalResult, TimeZone, Timelike, Utc};
 use rusqlite::{params, Connection, TransactionBehavior};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
+use tokio::task::JoinSet;
 use uuid::Uuid;
 
 use crate::agent::{Request, RunError, Runner};
@@ -31,7 +34,7 @@ struct Frontmatter {
     triggers: Vec<Trigger>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Trigger {
     pub id: String,
@@ -51,6 +54,7 @@ pub struct Job {
     pub workdir: PathBuf,
     pub backend: AgentBackend,
     pub snapshot_hash: String,
+    pub triggers: Vec<Trigger>,
 }
 
 #[derive(Debug, Clone)]
@@ -195,6 +199,7 @@ fn load_file(cfg: &Config, name: &str, path: &Path) -> Result<Job> {
         workdir,
         backend,
         snapshot_hash,
+        triggers: metadata.triggers,
     })
 }
 
@@ -286,6 +291,108 @@ fn validate_triggers(triggers: &[Trigger]) -> Result<()> {
     Ok(())
 }
 
+#[derive(Clone)]
+struct CronSpec {
+    fields: [Vec<bool>; 5],
+    day_of_month_wildcard: bool,
+    day_of_week_wildcard: bool,
+    timezone: chrono_tz::Tz,
+}
+
+impl Trigger {
+    pub fn next_after_ms(&self, after_ms: i64) -> Result<i64> {
+        let spec = CronSpec::parse(self)?;
+        spec.next_after_ms(after_ms)
+            .context("cron schedule has no occurrence within two years")
+    }
+}
+
+impl CronSpec {
+    fn parse(trigger: &Trigger) -> Result<Self> {
+        let parts = trigger.schedule.split_whitespace().collect::<Vec<_>>();
+        if parts.len() != 5 {
+            bail!("cron schedule must contain exactly five fields");
+        }
+        Ok(Self {
+            fields: [
+                expand_cron_field(parts[0], 0, 59)?,
+                expand_cron_field(parts[1], 0, 23)?,
+                expand_cron_field(parts[2], 1, 31)?,
+                expand_cron_field(parts[3], 1, 12)?,
+                expand_cron_field(parts[4], 0, 7)?,
+            ],
+            day_of_month_wildcard: parts[2].starts_with('*'),
+            day_of_week_wildcard: parts[4].starts_with('*'),
+            timezone: trigger.timezone.parse()?,
+        })
+    }
+
+    fn next_after_ms(&self, after_ms: i64) -> Option<i64> {
+        let mut candidate_ms = after_ms.div_euclid(60_000) * 60_000 + 60_000;
+        let limit = candidate_ms.saturating_add(2 * 366 * 24 * 60 * 60_000);
+        while candidate_ms <= limit {
+            let utc = chrono::DateTime::<Utc>::from_timestamp_millis(candidate_ms)?;
+            let local = utc.with_timezone(&self.timezone);
+            if self.matches(&local) && self.is_first_ambiguous_instant(&local) {
+                return Some(candidate_ms);
+            }
+            candidate_ms = candidate_ms.saturating_add(60_000);
+        }
+        None
+    }
+
+    fn matches(&self, local: &chrono::DateTime<chrono_tz::Tz>) -> bool {
+        let minute = self.fields[0][local.minute() as usize];
+        let hour = self.fields[1][local.hour() as usize];
+        let month = self.fields[3][local.month() as usize];
+        let dom = self.fields[2][local.day() as usize];
+        let dow_value = local.weekday().num_days_from_sunday() as usize;
+        let dow = self.fields[4][dow_value]
+            || (dow_value == 0 && self.fields[4].get(7).copied().unwrap_or(false));
+        let day_matches = match (self.day_of_month_wildcard, self.day_of_week_wildcard) {
+            (true, true) => true,
+            (true, false) => dow,
+            (false, true) => dom,
+            (false, false) => dom || dow,
+        };
+        minute && hour && month && day_matches
+    }
+
+    fn is_first_ambiguous_instant(&self, local: &chrono::DateTime<chrono_tz::Tz>) -> bool {
+        match self.timezone.from_local_datetime(&local.naive_local()) {
+            LocalResult::Ambiguous(first, second) => {
+                local.timestamp_millis() == first.timestamp_millis().min(second.timestamp_millis())
+            }
+            LocalResult::Single(_) => true,
+            LocalResult::None => false,
+        }
+    }
+}
+
+fn expand_cron_field(field: &str, minimum: u32, maximum: u32) -> Result<Vec<bool>> {
+    validate_cron_field(field, minimum, maximum)?;
+    let mut values = vec![false; maximum as usize + 1];
+    for part in field.split(',') {
+        let (range, step) = if let Some((range, step)) = part.split_once('/') {
+            (range, step.parse::<usize>().context("parse cron step")?)
+        } else {
+            (part, 1)
+        };
+        let (start, end) = if range == "*" {
+            (minimum, maximum)
+        } else if let Some((start, end)) = range.split_once('-') {
+            (start.parse()?, end.parse()?)
+        } else {
+            let value = range.parse()?;
+            (value, value)
+        };
+        for value in (start..=end).step_by(step) {
+            values[value as usize] = true;
+        }
+    }
+    Ok(values)
+}
+
 fn validate_cron_field(field: &str, minimum: u32, maximum: u32) -> Result<()> {
     if field.is_empty() {
         bail!("field is empty");
@@ -368,7 +475,7 @@ pub enum StartOutcome {
     Claimed {
         run_id: String,
         lock: JobLock,
-        job: Job,
+        job: Box<Job>,
     },
     Skipped {
         run_id: String,
@@ -430,6 +537,35 @@ pub struct RunRow {
     pub queued_at_ms: i64,
     pub result: Option<String>,
     pub error: Option<String>,
+    pub trigger_kind: String,
+    pub trigger_id: Option<String>,
+    pub scheduled_at_ms: Option<i64>,
+    pub delivery_state: String,
+    pub delivery_attempts: i64,
+    pub delivery_error: Option<String>,
+    pub delivery_channel: Option<String>,
+    pub delivery_target: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueuedRun {
+    pub id: String,
+    pub job_name: String,
+    pub snapshot_hash: String,
+    pub trigger_id: String,
+}
+
+#[derive(Debug)]
+pub struct DeliveryRun {
+    pub id: String,
+    pub job_name: String,
+    pub state: String,
+    pub result: Option<String>,
+    pub error: Option<String>,
+    pub channel: String,
+    pub target: String,
+    pub attempts: i64,
+    pub last_attempt_ms: Option<i64>,
 }
 
 impl Ledger {
@@ -458,16 +594,39 @@ impl Ledger {
         let tx = self
             .conn
             .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let queued = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM job_runs WHERE job_name = ?1 AND state = 'queued')",
+            [&job.name],
+            |row| row.get::<_, bool>(0),
+        )?;
+        if queued {
+            insert_run(
+                &tx,
+                &run_id,
+                &job,
+                now,
+                "skipped_overlap",
+                Some("a scheduled run is already queued"),
+            )?;
+            tx.commit()?;
+            return Ok(StartOutcome::Skipped { run_id });
+        }
         tx.execute(
             "UPDATE job_runs
              SET state = 'failed', finished_at_ms = ?2,
-                 error = 'previous manual executor exited before completion'
-             WHERE job_name = ?1 AND state = 'running' AND owner_kind = 'manual_cli'",
+                 error = 'previous executor exited before completion',
+                 delivery_state = CASE WHEN owner_kind = 'gateway_scheduler'
+                     THEN 'pending' ELSE delivery_state END
+             WHERE job_name = ?1 AND state = 'running'",
             params![job.name, now],
         )?;
         insert_run(&tx, &run_id, &job, now, "running", None)?;
         tx.commit()?;
-        Ok(StartOutcome::Claimed { run_id, lock, job })
+        Ok(StartOutcome::Claimed {
+            run_id,
+            lock,
+            job: Box::new(job),
+        })
     }
 
     fn insert_skipped(&mut self, id: &str, job: &Job, now: i64, reason: &str) -> Result<()> {
@@ -508,7 +667,9 @@ impl Ledger {
 
     pub fn runs(&self, name: Option<&str>) -> Result<Vec<RunRow>> {
         let mut statement = self.conn.prepare(
-            "SELECT id, job_name, state, backend, queued_at_ms, result, error
+            "SELECT id, job_name, state, backend, queued_at_ms, result, error,
+                    trigger_kind, trigger_id, scheduled_at_ms, delivery_state,
+                    delivery_attempts, delivery_error, delivery_channel, delivery_target
              FROM job_runs WHERE (?1 IS NULL OR job_name = ?1)
              ORDER BY queued_at_ms DESC, id DESC LIMIT 100",
         )?;
@@ -522,10 +683,258 @@ impl Ledger {
                     queued_at_ms: row.get(4)?,
                     result: row.get(5)?,
                     error: row.get(6)?,
+                    trigger_kind: row.get(7)?,
+                    trigger_id: row.get(8)?,
+                    scheduled_at_ms: row.get(9)?,
+                    delivery_state: row.get(10)?,
+                    delivery_attempts: row.get(11)?,
+                    delivery_error: row.get(12)?,
+                    delivery_channel: row.get(13)?,
+                    delivery_target: row.get(14)?,
                 })
             })?
             .collect::<rusqlite::Result<Vec<_>>>()?;
         Ok(rows)
+    }
+
+    pub fn enqueue_scheduled(
+        &mut self,
+        job: &Job,
+        trigger: &Trigger,
+        scheduled_at_ms: i64,
+        queued_at_ms: i64,
+        delivery_channel: &str,
+        delivery_target: &str,
+    ) -> Result<String> {
+        let id = Uuid::new_v4().to_string();
+        let tx = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let active = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM job_runs WHERE job_name = ?1 AND state IN ('queued','running'))",
+            [&job.name],
+            |row| row.get::<_, bool>(0),
+        )?;
+        let state = if active { "skipped_overlap" } else { "queued" };
+        let error = active.then_some("another run of this job is active");
+        tx.execute(
+            "INSERT INTO job_runs (
+                id, job_name, snapshot_hash, trigger_kind, trigger_id, owner_kind,
+                scheduled_at_ms, queued_at_ms, finished_at_ms, backend,
+                permission_profile, timeout_ms, workdir, state, error,
+                delivery_state, delivery_channel, delivery_target
+             ) VALUES (?1, ?2, ?3, 'cron', ?4, 'gateway_scheduler', ?5, ?6,
+                CASE WHEN ?7 = 'skipped_overlap' THEN ?6 ELSE NULL END,
+                ?8, ?9, ?10, ?11, ?7, ?12,
+                CASE WHEN ?7 = 'skipped_overlap' THEN 'pending' ELSE 'not_requested' END,
+                ?13, ?14)
+             ON CONFLICT DO NOTHING",
+            params![
+                id,
+                job.name,
+                job.snapshot_hash,
+                trigger.id,
+                scheduled_at_ms,
+                queued_at_ms,
+                state,
+                job.backend.as_str(),
+                job.permission.name,
+                duration_ms(job.timeout),
+                job.workdir.to_string_lossy(),
+                error,
+                delivery_channel,
+                delivery_target,
+            ],
+        )?;
+        let existing = tx.query_row(
+            "SELECT id FROM job_runs WHERE job_name = ?1 AND trigger_id = ?2 AND scheduled_at_ms = ?3",
+            params![job.name, trigger.id, scheduled_at_ms],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok(existing)
+    }
+
+    pub fn queued_runs(&self, limit: usize) -> Result<Vec<QueuedRun>> {
+        let mut statement = self.conn.prepare(
+            "SELECT id, job_name, snapshot_hash, trigger_id
+             FROM job_runs WHERE state = 'queued'
+             ORDER BY scheduled_at_ms, queued_at_ms LIMIT ?1",
+        )?;
+        let rows = statement
+            .query_map([limit as i64], |row| {
+                Ok(QueuedRun {
+                    id: row.get(0)?,
+                    job_name: row.get(1)?,
+                    snapshot_hash: row.get(2)?,
+                    trigger_id: row.get(3)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    pub fn claim_scheduled(
+        &mut self,
+        cfg: &Config,
+        queued: &QueuedRun,
+        now: i64,
+    ) -> Result<Option<(String, Job, JobLock)>> {
+        let Some(lock) = JobLock::try_acquire(&cfg.jobs_run_dir, &queued.job_name)? else {
+            self.conn.execute(
+                "UPDATE job_runs SET state = 'skipped_overlap', finished_at_ms = ?2,
+                    error = 'another local executor holds the job lock', delivery_state = 'pending'
+                 WHERE id = ?1 AND state = 'queued'",
+                params![queued.id, now],
+            )?;
+            return Ok(None);
+        };
+        let job = match Catalog::load_named(cfg, &queued.job_name) {
+            Ok(job)
+                if job.snapshot_hash == queued.snapshot_hash
+                    && job
+                        .triggers
+                        .iter()
+                        .any(|trigger| trigger.enabled && trigger.id == queued.trigger_id) =>
+            {
+                job
+            }
+            Ok(_) | Err(_) => {
+                self.conn.execute(
+                    "UPDATE job_runs SET state = 'cancelled', finished_at_ms = ?2,
+                        error = 'installed job or trigger changed before execution',
+                        delivery_state = 'pending'
+                     WHERE id = ?1 AND state = 'queued'",
+                    params![queued.id, now],
+                )?;
+                return Ok(None);
+            }
+        };
+        let tx = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        tx.execute(
+            "UPDATE job_runs SET state = 'failed', finished_at_ms = ?2,
+                error = 'previous executor exited before completion',
+                delivery_state = CASE WHEN owner_kind = 'gateway_scheduler'
+                    THEN 'pending' ELSE delivery_state END
+             WHERE job_name = ?1 AND state = 'running'",
+            params![queued.job_name, now],
+        )?;
+        let changed = tx.execute(
+            "UPDATE job_runs SET state = 'running', started_at_ms = ?2
+             WHERE id = ?1 AND state = 'queued'",
+            params![queued.id, now],
+        )?;
+        tx.commit()?;
+        if changed == 0 {
+            return Ok(None);
+        }
+        Ok(Some((queued.id.clone(), job, lock)))
+    }
+
+    pub fn finish_scheduled(
+        &mut self,
+        id: &str,
+        state: &str,
+        result: Option<&str>,
+        error: Option<&str>,
+        now: i64,
+    ) -> Result<()> {
+        if !matches!(state, "succeeded" | "failed" | "timed_out") {
+            bail!("invalid terminal scheduled run state {state:?}");
+        }
+        let changed = self.conn.execute(
+            "UPDATE job_runs SET state = ?2, finished_at_ms = ?3, result = ?4,
+                error = ?5, delivery_state = 'pending'
+             WHERE id = ?1 AND state = 'running'",
+            params![
+                id,
+                state,
+                now,
+                result.map(bound_result),
+                error.map(bound_result)
+            ],
+        )?;
+        if changed != 1 {
+            bail!("running scheduled job {id:?} does not exist");
+        }
+        Ok(())
+    }
+
+    pub fn recover_stale_runs(&mut self, cfg: &Config, now: i64) -> Result<()> {
+        let mut statement = self.conn.prepare(
+            "SELECT DISTINCT job_name FROM job_runs WHERE state = 'running' ORDER BY job_name",
+        )?;
+        let names = statement
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(statement);
+        for name in names {
+            let Some(_lock) = JobLock::try_acquire(&cfg.jobs_run_dir, &name)? else {
+                continue;
+            };
+            self.conn.execute(
+                "UPDATE job_runs SET state = 'failed', finished_at_ms = ?2,
+                    error = 'executor exited before completion',
+                    delivery_state = CASE WHEN owner_kind = 'gateway_scheduler'
+                        THEN 'pending' ELSE delivery_state END
+                 WHERE job_name = ?1 AND state = 'running'",
+                params![name, now],
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn due_deliveries(&self, now: i64) -> Result<Vec<DeliveryRun>> {
+        let mut statement = self.conn.prepare(
+            "SELECT id, job_name, state, result, error, delivery_channel,
+                    delivery_target, delivery_attempts, delivery_last_attempt_ms
+             FROM job_runs WHERE delivery_state = 'pending'
+             ORDER BY finished_at_ms, id",
+        )?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok(DeliveryRun {
+                    id: row.get(0)?,
+                    job_name: row.get(1)?,
+                    state: row.get(2)?,
+                    result: row.get(3)?,
+                    error: row.get(4)?,
+                    channel: row.get(5)?,
+                    target: row.get(6)?,
+                    attempts: row.get(7)?,
+                    last_attempt_ms: row.get(8)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows
+            .into_iter()
+            .filter(|row| {
+                row.attempts < 3
+                    && row.last_attempt_ms.is_none_or(|last| {
+                        now.saturating_sub(last) >= delivery_backoff_ms(row.attempts)
+                    })
+            })
+            .collect())
+    }
+
+    pub fn record_delivery(
+        &mut self,
+        id: &str,
+        delivered: bool,
+        error: Option<&str>,
+        now: i64,
+    ) -> Result<()> {
+        self.conn.execute(
+            "UPDATE job_runs SET delivery_attempts = delivery_attempts + 1,
+                delivery_last_attempt_ms = ?2, delivery_error = ?3,
+                delivery_state = CASE WHEN ?4 THEN 'delivered'
+                    WHEN delivery_attempts + 1 >= 3 THEN 'failed' ELSE 'pending' END
+             WHERE id = ?1 AND delivery_state = 'pending'",
+            params![id, now, error.map(bound_result), delivered],
+        )?;
+        Ok(())
     }
 
     #[cfg(test)]
@@ -563,12 +972,184 @@ fn insert_run(
             state,
             job.backend.as_str(),
             job.permission.name,
-            job.timeout.as_millis().min(i64::MAX as u128) as i64,
+            duration_ms(job.timeout),
             job.workdir.to_string_lossy(),
             error,
         ],
     )?;
     Ok(())
+}
+
+fn duration_ms(duration: Duration) -> i64 {
+    duration.as_millis().min(i64::MAX as u128) as i64
+}
+
+fn delivery_backoff_ms(attempts: i64) -> i64 {
+    match attempts {
+        0 => 0,
+        1 => 1_000,
+        _ => 5_000,
+    }
+}
+
+#[derive(Clone)]
+struct NextOccurrence {
+    schedule: String,
+    timezone: String,
+    snapshot_hash: String,
+    at_ms: i64,
+}
+
+pub struct Scheduler {
+    cfg: Config,
+    delivery_channel: String,
+    delivery_target: String,
+    next: HashMap<(String, String), NextOccurrence>,
+    workers: JoinSet<Result<()>>,
+    scheduling_enabled: bool,
+}
+
+impl Scheduler {
+    pub fn new(cfg: Config, delivery_channel: String, delivery_target: String) -> Self {
+        Self {
+            cfg,
+            delivery_channel,
+            delivery_target,
+            next: HashMap::new(),
+            workers: JoinSet::new(),
+            scheduling_enabled: true,
+        }
+    }
+
+    pub fn delivery_only(cfg: Config) -> Self {
+        Self {
+            cfg,
+            delivery_channel: String::new(),
+            delivery_target: String::new(),
+            next: HashMap::new(),
+            workers: JoinSet::new(),
+            scheduling_enabled: false,
+        }
+    }
+
+    pub async fn tick<F, Fut>(&mut self, now: i64, deliver: F) -> Result<()>
+    where
+        F: Fn(String, String, String) -> Fut,
+        Fut: Future<Output = Result<()>>,
+    {
+        while let Some(result) = self.workers.try_join_next() {
+            result.context("scheduled worker task failed")??;
+        }
+        let mut ledger = Ledger::open(&self.cfg.database_path)?;
+        ledger.recover_stale_runs(&self.cfg, now)?;
+
+        let catalog = Catalog::load(&self.cfg)?;
+        let mut seen = HashSet::new();
+        for job in catalog.jobs.values().filter(|_| self.scheduling_enabled) {
+            for trigger in job.triggers.iter().filter(|trigger| trigger.enabled) {
+                let key = (job.name.clone(), trigger.id.clone());
+                seen.insert(key.clone());
+                let changed = self.next.get(&key).is_none_or(|existing| {
+                    existing.schedule != trigger.schedule
+                        || existing.timezone != trigger.timezone
+                        || existing.snapshot_hash != job.snapshot_hash
+                });
+                if changed {
+                    self.next.insert(
+                        key,
+                        NextOccurrence {
+                            schedule: trigger.schedule.clone(),
+                            timezone: trigger.timezone.clone(),
+                            snapshot_hash: job.snapshot_hash.clone(),
+                            at_ms: trigger.next_after_ms(now)?,
+                        },
+                    );
+                    continue;
+                }
+                let due = self
+                    .next
+                    .get(&key)
+                    .map(|next| next.at_ms <= now)
+                    .unwrap_or(false);
+                if due {
+                    let scheduled_at = self.next[&key].at_ms;
+                    ledger.enqueue_scheduled(
+                        job,
+                        trigger,
+                        scheduled_at,
+                        now,
+                        &self.delivery_channel,
+                        &self.delivery_target,
+                    )?;
+                    if let Some(next) = self.next.get_mut(&key) {
+                        next.at_ms = trigger.next_after_ms(now)?;
+                    }
+                }
+            }
+        }
+        self.next.retain(|key, _| seen.contains(key));
+
+        let available = self.cfg.jobs_max_workers.saturating_sub(self.workers.len());
+        for queued in ledger.queued_runs(available)? {
+            let cfg = self.cfg.clone();
+            self.workers
+                .spawn(async move { run_scheduled(cfg, queued).await });
+        }
+
+        for row in ledger.due_deliveries(now)? {
+            let text = format_delivery(&row);
+            match deliver(row.channel.clone(), row.target.clone(), text).await {
+                Ok(()) => ledger.record_delivery(&row.id, true, None, now)?,
+                Err(error) => {
+                    ledger.record_delivery(&row.id, false, Some(&error.to_string()), now)?
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn shutdown(&mut self) {
+        while let Some(result) = self.workers.join_next().await {
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    tracing::error!("scheduled worker failed during shutdown: {error:#}")
+                }
+                Err(error) => {
+                    tracing::error!("scheduled worker task failed during shutdown: {error}")
+                }
+            }
+        }
+    }
+}
+
+async fn run_scheduled(cfg: Config, queued: QueuedRun) -> Result<()> {
+    let mut ledger = Ledger::open(&cfg.database_path)?;
+    let Some((run_id, job, _lock)) = ledger.claim_scheduled(&cfg, &queued, now_ms())? else {
+        return Ok(());
+    };
+    match execute(&cfg, &job).await {
+        Ok(reply) => ledger.finish_scheduled(&run_id, "succeeded", Some(&reply), None, now_ms()),
+        Err(ExecutionError::Timeout) => ledger.finish_scheduled(
+            &run_id,
+            "timed_out",
+            None,
+            Some("backend run timed out"),
+            now_ms(),
+        ),
+        Err(ExecutionError::Failed(error)) => {
+            ledger.finish_scheduled(&run_id, "failed", None, Some(&error), now_ms())
+        }
+    }
+}
+
+fn format_delivery(row: &DeliveryRun) -> String {
+    let detail = row
+        .result
+        .as_deref()
+        .or(row.error.as_deref())
+        .unwrap_or("No result details were recorded.");
+    format!("Job `{}` {}.\n\n{}", row.job_name, row.state, detail)
 }
 
 pub async fn run_manual(cfg: &Config, job: Job) -> Result<(String, String)> {
@@ -664,8 +1245,22 @@ fn now_ms() -> i64 {
 }
 
 pub fn format_job(job: &Job) -> String {
+    let triggers = if job.triggers.is_empty() {
+        "none".to_string()
+    } else {
+        job.triggers
+            .iter()
+            .map(|trigger| {
+                format!(
+                    "{} cron {:?} {} enabled={}",
+                    trigger.id, trigger.schedule, trigger.timezone, trigger.enabled
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
     format!(
-        "name: {}\npath: {}\nbackend: {}\npermission_profile: {}\ntimeout: {}\nworkdir: {}\nsnapshot: {}\n\n{}\n",
+        "name: {}\npath: {}\nbackend: {}\npermission_profile: {}\ntimeout: {}\nworkdir: {}\nsnapshot: {}\ntriggers:\n{}\n\n{}\n",
         job.name,
         job.path.display(),
         job.backend.as_str(),
@@ -673,6 +1268,7 @@ pub fn format_job(job: &Job) -> String {
         humantime::format_duration(job.timeout),
         job.workdir.display(),
         job.snapshot_hash,
+        triggers,
         job.body
     )
 }
@@ -681,6 +1277,27 @@ pub fn format_job(job: &Job) -> String {
 mod tests {
     use super::*;
     use crate::test_support::{sh_arg, temp_dir, temp_path, FakeCli};
+    use std::sync::Arc;
+
+    #[cfg(unix)]
+    #[test]
+    fn manual_claim_process_helper() {
+        let Ok(jobs_dir) = std::env::var("PUSH_TEST_CLAIM_JOBS_DIR") else {
+            return;
+        };
+        let database = PathBuf::from(std::env::var("PUSH_TEST_CLAIM_DATABASE").unwrap());
+        let run_dir = PathBuf::from(std::env::var("PUSH_TEST_CLAIM_RUN_DIR").unwrap());
+        let ready = PathBuf::from(std::env::var("PUSH_TEST_CLAIM_READY").unwrap());
+        let cfg = cfg(Path::new(&jobs_dir), &database, &run_dir);
+        let job = Catalog::load_named(&cfg, "cli-live").unwrap();
+        let mut ledger = Ledger::open(&cfg.database_path).unwrap();
+        let StartOutcome::Claimed { lock: _lock, .. } = ledger.start_manual(&cfg, &job).unwrap()
+        else {
+            panic!("helper manual run should claim");
+        };
+        std::fs::write(ready, "ready").unwrap();
+        std::thread::sleep(Duration::from_secs(30));
+    }
 
     fn cfg(jobs_dir: &Path, database: &Path, run_dir: &Path) -> Config {
         let mut cfg = crate::gateway::tests::test_config_for_jobs(
@@ -703,6 +1320,13 @@ mod tests {
     fn valid_job(workdir: &Path) -> String {
         format!(
             "+++\nversion = 1\npermission_profile = \"restricted\"\ntimeout = \"5s\"\nworkdir = {:?}\nbackend = \"codex\"\n+++\n\nInspect this directory.\n",
+            workdir.to_string_lossy()
+        )
+    }
+
+    fn scheduled_job(workdir: &Path, enabled: bool) -> String {
+        format!(
+            "+++\nversion = 1\npermission_profile = \"restricted\"\ntimeout = \"5s\"\nworkdir = {:?}\nbackend = \"codex\"\n\n[[triggers]]\nid = \"every-minute\"\nkind = \"cron\"\nschedule = \"* * * * *\"\ntimezone = \"UTC\"\nenabled = {enabled}\n+++\n\nRun once.\n",
             workdir.to_string_lossy()
         )
     }
@@ -822,6 +1446,550 @@ mod tests {
     }
 
     #[test]
+    fn cron_skips_nonexistent_dst_time_and_uses_first_ambiguous_instant() {
+        let trigger = |schedule: &str| Trigger {
+            id: "dst".to_string(),
+            kind: "cron".to_string(),
+            schedule: schedule.to_string(),
+            timezone: "Europe/London".to_string(),
+            enabled: true,
+        };
+        let utc = |year, month, day, hour, minute| {
+            Utc.with_ymd_and_hms(year, month, day, hour, minute, 0)
+                .single()
+                .unwrap()
+                .timestamp_millis()
+        };
+
+        let spring = trigger("30 1 * * *");
+        assert_eq!(
+            spring.next_after_ms(utc(2026, 3, 29, 0, 0)).unwrap(),
+            utc(2026, 3, 30, 0, 30)
+        );
+
+        let autumn = trigger("30 1 * * *");
+        let first = autumn.next_after_ms(utc(2026, 10, 24, 23, 59)).unwrap();
+        assert_eq!(first, utc(2026, 10, 25, 0, 30));
+        assert_eq!(
+            autumn.next_after_ms(first).unwrap(),
+            utc(2026, 10, 26, 1, 30)
+        );
+    }
+
+    #[tokio::test]
+    async fn scheduler_skips_missed_ticks_and_retries_stored_output_without_rerunning() {
+        let jobs_dir = temp_dir("scheduler-jobs");
+        let workdir = temp_dir("scheduler-work");
+        let database = temp_path("scheduler-db");
+        let run_dir = temp_dir("scheduler-run");
+        let args_path = temp_path("scheduler-args");
+        let script = format!(
+            r#"#!/bin/sh
+printf '%s\n' run >> {}
+out=''
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = '-o' ]; then out="$arg"; fi
+  prev="$arg"
+done
+printf '%s\n' 'scheduled output' > "$out"
+printf '%s\n' '{{"type":"thread.started","thread_id":"scheduled"}}'
+"#,
+            sh_arg(&args_path)
+        );
+        let cli = FakeCli::new("codex", &script);
+        write_job(&jobs_dir, "scheduled", &scheduled_job(&workdir, true));
+        let mut cfg = cfg(&jobs_dir, &database, &run_dir);
+        cfg.codex_bin = cli.bin();
+        let mut scheduler = Scheduler::new(cfg.clone(), "telegram".into(), "7".into());
+        let start = Utc
+            .with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+            .single()
+            .unwrap()
+            .timestamp_millis();
+
+        scheduler
+            .tick(start, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        scheduler
+            .tick(start + 3 * 60_000, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        scheduler.shutdown().await;
+        write_job(&jobs_dir, "scheduled", &scheduled_job(&workdir, false));
+
+        scheduler
+            .tick(start + 3 * 60_000, |_, _, _| async {
+                bail!("temporary delivery failure")
+            })
+            .await
+            .unwrap();
+        drop(scheduler);
+        let mut scheduler = Scheduler::new(cfg.clone(), "telegram".into(), "7".into());
+        scheduler
+            .tick(start + 3 * 60_000 + 1_000, |_, _, _| async {
+                bail!("temporary delivery failure")
+            })
+            .await
+            .unwrap();
+        let delivered = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = delivered.clone();
+        scheduler
+            .tick(start + 3 * 60_000 + 6_000, move |channel, target, text| {
+                let captured = captured.clone();
+                async move {
+                    captured.lock().unwrap().push((channel, target, text));
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+
+        let rows = Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(Some("scheduled"))
+            .unwrap();
+        assert_eq!(rows.len(), 1, "missed minutes must not be caught up");
+        assert_eq!(rows[0].state, "succeeded");
+        assert_eq!(rows[0].scheduled_at_ms, Some(start + 60_000));
+        assert_eq!(rows[0].delivery_state, "delivered");
+        assert_eq!(rows[0].delivery_attempts, 3);
+        assert_eq!(
+            std::fs::read_to_string(args_path).unwrap().lines().count(),
+            1
+        );
+        assert_eq!(delivered.lock().unwrap().len(), 1);
+        assert!(delivered.lock().unwrap()[0].2.contains("scheduled output"));
+    }
+
+    #[tokio::test]
+    async fn queued_run_resumes_after_restart_and_exhausted_delivery_stays_failed() {
+        let jobs_dir = temp_dir("queued-restart-jobs");
+        let workdir = temp_dir("queued-restart-work");
+        let database = temp_path("queued-restart-db");
+        let run_dir = temp_dir("queued-restart-run");
+        let args_path = temp_path("queued-restart-args");
+        let script = format!(
+            r#"#!/bin/sh
+printf '%s\n' run >> {}
+out=''
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = '-o' ]; then out="$arg"; fi
+  prev="$arg"
+done
+printf '%s\n' 'restart output' > "$out"
+printf '%s\n' '{{"type":"thread.started","thread_id":"restart"}}'
+"#,
+            sh_arg(&args_path)
+        );
+        let cli = FakeCli::new("codex", &script);
+        write_job(&jobs_dir, "restart", &scheduled_job(&workdir, true));
+        let mut cfg = cfg(&jobs_dir, &database, &run_dir);
+        cfg.codex_bin = cli.bin();
+        let job = Catalog::load_named(&cfg, "restart").unwrap();
+        let mut ledger = Ledger::open(&cfg.database_path).unwrap();
+        let first_id = ledger
+            .enqueue_scheduled(&job, &job.triggers[0], 60_000, 60_000, "telegram", "7")
+            .unwrap();
+        let duplicate_id = ledger
+            .enqueue_scheduled(&job, &job.triggers[0], 60_000, 60_001, "telegram", "7")
+            .unwrap();
+        assert_eq!(first_id, duplicate_id);
+        assert_eq!(ledger.runs(Some("restart")).unwrap().len(), 1);
+        drop(ledger);
+
+        let mut restarted = Scheduler::new(cfg.clone(), "telegram".into(), "7".into());
+        restarted
+            .tick(60_000, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        restarted.shutdown().await;
+        for now in [60_000, 61_000, 66_000] {
+            restarted
+                .tick(now, |_, _, _| async {
+                    bail!("delivery remains unavailable")
+                })
+                .await
+                .unwrap();
+        }
+
+        let rows = Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(Some("restart"))
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].state, "succeeded");
+        assert_eq!(rows[0].delivery_state, "failed");
+        assert_eq!(rows[0].delivery_attempts, 3);
+        assert_eq!(
+            std::fs::read_to_string(args_path).unwrap().lines().count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_delivery_replays_without_a_current_primary_destination() {
+        let jobs_dir = temp_dir("delivery-only-jobs");
+        let workdir = temp_dir("delivery-only-work");
+        let database = temp_path("delivery-only-db");
+        let run_dir = temp_dir("delivery-only-run");
+        let script = r#"#!/bin/sh
+out=''
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = '-o' ]; then out="$arg"; fi
+  prev="$arg"
+done
+printf '%s\n' stored > "$out"
+printf '%s\n' '{"type":"thread.started","thread_id":"delivery-only"}'
+"#;
+        let cli = FakeCli::new("codex", script);
+        write_job(&jobs_dir, "delivery-only", &scheduled_job(&workdir, true));
+        let mut cfg = cfg(&jobs_dir, &database, &run_dir);
+        cfg.codex_bin = cli.bin();
+        let job = Catalog::load_named(&cfg, "delivery-only").unwrap();
+        Ledger::open(&cfg.database_path)
+            .unwrap()
+            .enqueue_scheduled(&job, &job.triggers[0], 60_000, 60_000, "telegram", "7")
+            .unwrap();
+        let mut scheduler = Scheduler::delivery_only(cfg.clone());
+        scheduler
+            .tick(60_000, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        scheduler.shutdown().await;
+
+        let delivered = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = delivered.clone();
+        scheduler
+            .tick(61_000, move |channel, target, text| {
+                let captured = captured.clone();
+                async move {
+                    captured.lock().unwrap().push((channel, target, text));
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+
+        let row = Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(Some("delivery-only"))
+            .unwrap()
+            .remove(0);
+        assert_eq!(row.delivery_state, "delivered");
+        assert_eq!(delivered.lock().unwrap()[0].0, "telegram");
+        assert_eq!(delivered.lock().unwrap()[0].1, "7");
+    }
+
+    #[tokio::test]
+    async fn scheduled_timeout_is_persisted_before_delivery() {
+        let jobs_dir = temp_dir("scheduled-timeout-jobs");
+        let workdir = temp_dir("scheduled-timeout-work");
+        let database = temp_path("scheduled-timeout-db");
+        let run_dir = temp_dir("scheduled-timeout-run");
+        let slow = FakeCli::new("codex", "#!/bin/sh\nsleep 2\n");
+        write_job(
+            &jobs_dir,
+            "timeout",
+            &scheduled_job(&workdir, true).replace("timeout = \"5s\"", "timeout = \"10ms\""),
+        );
+        let mut cfg = cfg(&jobs_dir, &database, &run_dir);
+        cfg.codex_bin = slow.bin();
+        let job = Catalog::load_named(&cfg, "timeout").unwrap();
+        Ledger::open(&cfg.database_path)
+            .unwrap()
+            .enqueue_scheduled(&job, &job.triggers[0], 60_000, 60_000, "telegram", "7")
+            .unwrap();
+        let mut scheduler = Scheduler::new(cfg.clone(), "telegram".into(), "7".into());
+
+        scheduler
+            .tick(60_000, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        scheduler.shutdown().await;
+
+        let rows = Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(Some("timeout"))
+            .unwrap();
+        assert_eq!(rows[0].state, "timed_out");
+        assert_eq!(rows[0].delivery_state, "pending");
+        assert!(rows[0]
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("timed out")));
+    }
+
+    #[tokio::test]
+    async fn scheduled_execution_failure_is_distinct_from_delivery_failure() {
+        let jobs_dir = temp_dir("scheduled-failure-jobs");
+        let workdir = temp_dir("scheduled-failure-work");
+        let database = temp_path("scheduled-failure-db");
+        let run_dir = temp_dir("scheduled-failure-run");
+        let failed = FakeCli::new("codex", "#!/bin/sh\nprintf '%s\n' boom >&2\nexit 1\n");
+        write_job(&jobs_dir, "failure", &scheduled_job(&workdir, true));
+        let mut cfg = cfg(&jobs_dir, &database, &run_dir);
+        cfg.codex_bin = failed.bin();
+        let job = Catalog::load_named(&cfg, "failure").unwrap();
+        Ledger::open(&cfg.database_path)
+            .unwrap()
+            .enqueue_scheduled(&job, &job.triggers[0], 60_000, 60_000, "telegram", "7")
+            .unwrap();
+        let mut scheduler = Scheduler::new(cfg.clone(), "telegram".into(), "7".into());
+
+        scheduler
+            .tick(60_000, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        scheduler.shutdown().await;
+
+        let row = Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(Some("failure"))
+            .unwrap()
+            .remove(0);
+        assert_eq!(row.state, "failed");
+        assert_eq!(row.delivery_state, "pending");
+        assert_eq!(row.delivery_attempts, 0);
+        assert!(row
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("boom")));
+    }
+
+    #[tokio::test]
+    async fn scheduled_workers_obey_the_configured_limit() {
+        let jobs_dir = temp_dir("worker-limit-jobs");
+        let workdir = temp_dir("worker-limit-work");
+        let database = temp_path("worker-limit-db");
+        let run_dir = temp_dir("worker-limit-run");
+        let script = r#"#!/bin/sh
+sleep 0.1
+out=''
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = '-o' ]; then out="$arg"; fi
+  prev="$arg"
+done
+printf '%s\n' done > "$out"
+printf '%s\n' '{"type":"thread.started","thread_id":"limited"}'
+"#;
+        let cli = FakeCli::new("codex", script);
+        write_job(&jobs_dir, "first", &scheduled_job(&workdir, true));
+        write_job(&jobs_dir, "second", &scheduled_job(&workdir, true));
+        let mut cfg = cfg(&jobs_dir, &database, &run_dir);
+        cfg.codex_bin = cli.bin();
+        cfg.jobs_max_workers = 1;
+        let catalog = Catalog::load(&cfg).unwrap();
+        let mut ledger = Ledger::open(&cfg.database_path).unwrap();
+        for job in catalog.jobs.values() {
+            ledger
+                .enqueue_scheduled(job, &job.triggers[0], 60_000, 60_000, "telegram", "7")
+                .unwrap();
+        }
+        let mut scheduler = Scheduler::new(cfg.clone(), "telegram".into(), "7".into());
+
+        scheduler
+            .tick(60_000, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        assert_eq!(scheduler.workers.len(), 1);
+        for _ in 0..100 {
+            if Ledger::open(&cfg.database_path)
+                .unwrap()
+                .queued_runs(10)
+                .unwrap()
+                .len()
+                == 1
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            Ledger::open(&cfg.database_path)
+                .unwrap()
+                .queued_runs(10)
+                .unwrap()
+                .len(),
+            1
+        );
+        scheduler.shutdown().await;
+        scheduler
+            .tick(61_000, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        assert_eq!(scheduler.workers.len(), 1);
+        scheduler.shutdown().await;
+
+        let rows = Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(None)
+            .unwrap();
+        assert_eq!(
+            rows.iter().filter(|row| row.state == "succeeded").count(),
+            2
+        );
+    }
+
+    #[test]
+    fn live_scheduled_claim_survives_restart_and_stale_claim_becomes_deliverable() {
+        let jobs_dir = temp_dir("scheduled-stale-jobs");
+        let workdir = temp_dir("scheduled-stale-work");
+        let database = temp_path("scheduled-stale-db");
+        let run_dir = temp_dir("scheduled-stale-run");
+        write_job(&jobs_dir, "stale", &scheduled_job(&workdir, true));
+        let cfg = cfg(&jobs_dir, &database, &run_dir);
+        let job = Catalog::load_named(&cfg, "stale").unwrap();
+        let mut ledger = Ledger::open(&cfg.database_path).unwrap();
+        let id = ledger
+            .enqueue_scheduled(&job, &job.triggers[0], 60_000, 60_000, "telegram", "7")
+            .unwrap();
+        let queued = ledger.queued_runs(1).unwrap().remove(0);
+        let Some((_, _, lock)) = ledger.claim_scheduled(&cfg, &queued, 60_000).unwrap() else {
+            panic!("scheduled run should claim");
+        };
+
+        let mut restarted = Ledger::open(&cfg.database_path).unwrap();
+        restarted.recover_stale_runs(&cfg, 61_000).unwrap();
+        assert_eq!(restarted.state(&id), "running");
+        drop(lock);
+        restarted.recover_stale_runs(&cfg, 62_000).unwrap();
+
+        let row = restarted.runs(Some("stale")).unwrap().remove(0);
+        assert_eq!(row.state, "failed");
+        assert_eq!(row.delivery_state, "pending");
+        assert!(row
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("exited before completion")));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn restarted_scheduler_respects_live_cli_process_then_recovers_after_crash() {
+        use std::process::{Command, Stdio};
+        use std::time::Instant;
+
+        let jobs_dir = temp_dir("scheduler-cli-restart-jobs");
+        let workdir = temp_dir("scheduler-cli-restart-work");
+        let database = temp_path("scheduler-cli-restart-db");
+        let run_dir = temp_dir("scheduler-cli-restart-run");
+        let ready = temp_path("scheduler-cli-restart-ready");
+        let script = r#"#!/bin/sh
+out=''
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = '-o' ]; then out="$arg"; fi
+  prev="$arg"
+done
+printf '%s\n' recovered > "$out"
+printf '%s\n' '{"type":"thread.started","thread_id":"after-crash"}'
+"#;
+        let cli = FakeCli::new("codex", script);
+        write_job(&jobs_dir, "cli-live", &scheduled_job(&workdir, true));
+        let mut cfg = cfg(&jobs_dir, &database, &run_dir);
+        cfg.codex_bin = cli.bin();
+        let start = 1_800_000_000_000i64;
+        let mut before_restart = Scheduler::new(cfg.clone(), "telegram".into(), "7".into());
+        before_restart
+            .tick(start, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        drop(before_restart);
+
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "jobs::tests::manual_claim_process_helper",
+                "--nocapture",
+            ])
+            .env("PUSH_TEST_CLAIM_JOBS_DIR", &jobs_dir)
+            .env("PUSH_TEST_CLAIM_DATABASE", &database)
+            .env("PUSH_TEST_CLAIM_RUN_DIR", &run_dir)
+            .env("PUSH_TEST_CLAIM_READY", &ready)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !ready.exists() && Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(ready.exists(), "manual claim helper did not become ready");
+        assert!(child.try_wait().unwrap().is_none());
+
+        let mut restarted = Scheduler::new(cfg.clone(), "telegram".into(), "7".into());
+        restarted
+            .tick(start + 60_000, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        restarted
+            .tick(start + 120_000, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        let live_rows = Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(Some("cli-live"))
+            .unwrap();
+        assert!(live_rows.iter().any(|row| row.state == "running"));
+        assert!(live_rows.iter().any(|row| row.state == "skipped_overlap"));
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+        restarted
+            .tick(start + 180_000, |_, _, _| async { Ok(()) })
+            .await
+            .unwrap();
+        restarted.shutdown().await;
+
+        let rows = Ledger::open(&cfg.database_path)
+            .unwrap()
+            .runs(Some("cli-live"))
+            .unwrap();
+        assert!(rows
+            .iter()
+            .any(|row| { row.trigger_kind == "manual" && row.state == "failed" }));
+        assert_eq!(
+            rows.iter()
+                .filter(|row| row.trigger_kind == "cron" && row.state == "succeeded")
+                .count(),
+            1
+        );
+        let _ = std::fs::remove_file(ready);
+    }
+
+    #[test]
+    fn live_claim_is_not_recovered_and_overlap_is_recorded_for_schedule() {
+        let jobs_dir = temp_dir("scheduled-overlap-jobs");
+        let workdir = temp_dir("scheduled-overlap-work");
+        let database = temp_path("scheduled-overlap-db");
+        let run_dir = temp_dir("scheduled-overlap-run");
+        write_job(&jobs_dir, "overlap", &scheduled_job(&workdir, true));
+        let cfg = cfg(&jobs_dir, &database, &run_dir);
+        let job = Catalog::load_named(&cfg, "overlap").unwrap();
+        let mut ledger = Ledger::open(&cfg.database_path).unwrap();
+        let StartOutcome::Claimed { run_id, lock, .. } = ledger.start_manual(&cfg, &job).unwrap()
+        else {
+            panic!("manual run should hold the lock");
+        };
+        ledger.recover_stale_runs(&cfg, 10).unwrap();
+        assert_eq!(ledger.state(&run_id), "running");
+
+        ledger
+            .enqueue_scheduled(&job, &job.triggers[0], 60_000, 60_000, "telegram", "7")
+            .unwrap();
+        let rows = ledger.runs(Some("overlap")).unwrap();
+        assert!(rows.iter().any(|row| row.state == "skipped_overlap"));
+        drop(lock);
+        ledger.recover_stale_runs(&cfg, 70_000).unwrap();
+        assert_eq!(ledger.state(&run_id), "failed");
+    }
+
+    #[test]
     fn winning_claim_rereads_and_records_the_installed_snapshot() {
         let jobs_dir = temp_dir("jobs-snapshot");
         let workdir = temp_dir("jobs-snapshot-work");
@@ -897,6 +2065,7 @@ mod tests {
         };
         assert_eq!(second.state(&skipped), "skipped_overlap");
         assert_eq!(first.state(&first_id), "running");
+        lock._file.unlock().unwrap();
         drop(lock);
 
         let StartOutcome::Claimed { run_id: next, .. } = second.start_manual(&cfg, &job).unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,17 +159,40 @@ async fn run_job_command(config_path: &str, command: JobCommand) -> Result<()> {
             }
             let ledger = jobs::Ledger::open(&cfg.database_path)?;
             for run in ledger.runs(name.as_deref())? {
+                let trigger = run
+                    .trigger_id
+                    .as_deref()
+                    .map(|id| format!("{}:{id}", run.trigger_kind))
+                    .unwrap_or(run.trigger_kind);
+                let scheduled = run
+                    .scheduled_at_ms
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_string());
+                let delivery = format!("{}({})", run.delivery_state, run.delivery_attempts);
+                let destination = run
+                    .delivery_channel
+                    .zip(run.delivery_target)
+                    .map(|(channel, target)| format!("{channel}:{target}"))
+                    .unwrap_or_else(|| "-".to_string());
+                let execution_detail = run
+                    .result
+                    .or(run.error)
+                    .unwrap_or_default()
+                    .replace('\n', " ");
+                let delivery_error = run.delivery_error.unwrap_or_default().replace('\n', " ");
                 println!(
-                    "{}\t{}\t{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
                     run.id,
                     run.job_name,
                     run.state,
                     run.backend,
+                    trigger,
+                    scheduled,
                     run.queued_at_ms,
-                    run.result
-                        .or(run.error)
-                        .unwrap_or_default()
-                        .replace('\n', " ")
+                    delivery,
+                    destination,
+                    execution_detail,
+                    delivery_error,
                 );
             }
             Ok(())
@@ -639,6 +662,7 @@ mod tests {
         assert!(cfg.permission_profiles.is_empty());
         assert_eq!(cfg.jobs_agent, None);
         assert_eq!(cfg.jobs_max_timeout, "30m");
+        assert_eq!(cfg.jobs_max_workers, 2);
         assert_eq!(
             cfg.jobs_dir,
             Path::new(&std::env::var("HOME").unwrap())
@@ -1234,6 +1258,7 @@ capability = "workspace"
             jobs_agent: None,
             jobs_max_timeout: "30m".to_string(),
             jobs_run_dir: "/fake/run".to_string(),
+            jobs_max_workers: 2,
             claude_bin: "/fake/claude".to_string(),
             codex_bin: "/fake/codex".to_string(),
             codex_model: None,

--- a/tests/manual_job_crash.rs
+++ b/tests/manual_job_crash.rs
@@ -57,6 +57,21 @@ printf '%s\n' '{"type":"thread.started","thread_id":"cli-thread"}'
     assert!(stdout(&history).contains("\tcrash-test\tsucceeded\tcodex\t"));
     assert!(stdout(&history).contains("cli result"));
 
+    Connection::open(&database)
+        .unwrap()
+        .execute(
+            "UPDATE job_runs SET delivery_state = 'failed', delivery_attempts = 3,
+                delivery_error = 'delivery boom', delivery_channel = 'telegram',
+                delivery_target = '7' WHERE job_name = 'crash-test'",
+            [],
+        )
+        .unwrap();
+    let failed_delivery = run_cli(binary, &config, &["job", "runs", "crash-test"]);
+    let failed_output = stdout(&failed_delivery);
+    assert!(failed_output.contains("cli result"));
+    assert!(failed_output.contains("delivery boom"));
+    assert!(failed_output.contains("failed(3)\ttelegram:7"));
+
     std::fs::write(jobs.join("invalid.md"), "not a runbook").unwrap();
     let invalid = run_cli(binary, &config, &["job", "validate"]);
     assert!(!invalid.status.success());


### PR DESCRIPTION
## Summary

- add validated five-field cron schedules with IANA timezone handling
- persist queued, running, completed, timed out, and delivery states in SQLite
- enforce per-job overlap protection and a configurable worker limit
- deliver scheduled results through persisted primary destinations with bounded retries
- resume queued work and pending delivery after restart without rerunning completed jobs
- expose schedule and delivery state through `push job runs`
- document scheduling, restart, and delivery behavior

## Why

Issue #63 requires durable scheduled job execution in the gateway, including restart recovery, destination safety, and result delivery without duplicate backend execution.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (176 unit tests and 3 integration tests)
- focused cross-process restart and delivery-only recovery tests
- `git diff --check`
- independent complete-diff review with no remaining actionable findings

## Risks

Cron evaluation and recovery add durable state transitions around process crashes. Coverage includes DST gaps and ambiguity, missed ticks, duplicate occurrences, live and stale cross-process locks, timeouts, worker limits, retry exhaustion, restart replay, and missing-primary behavior.

## Related issue

Closes #63.
