### PR TITLE
feat: approve agent-drafted jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ assistant_dir = "~/.push"
 permission_profile = "restricted"
 job_permission_profiles = ["restricted", "research"]
 jobs_dir = "~/.push/jobs"
+drafts_dir = "~/.push/drafts"
 jobs_agent = "codex"
 jobs_max_timeout = "30m"
 jobs_run_dir = "~/.push/run"
@@ -329,12 +330,13 @@ Backend translation is intentionally conservative:
 - `workspace`: Claude gets read and file-edit tools but no Bash because Claude
   Code has no equivalent to Codex filesystem sandboxing; Codex uses
   `workspace-write` with approvals disabled.
-- `full-access`: Claude uses `bypassPermissions`; Codex uses
-  `danger-full-access`. Select it by name only in environments you control.
+- `full-access`: maps to backend bypass modes, but push rejects it for
+  unattended routes and jobs because it cannot protect installed jobs,
+  configuration, or state from direct writes.
 
 Future jobs request only a profile name explicitly listed in
 `job_permission_profiles`. The allow-list defaults to only `restricted`; adding
-`workspace`, `full-access`, or a custom profile is an explicit operator choice.
+`workspace` or a contained custom profile is an explicit operator choice.
 Unknown route profiles fail startup. Unknown or unapproved job references return
 a job-scoped validation error without invalidating messaging routes.
 
@@ -406,6 +408,32 @@ Scheduled state and bounded output are persisted before delivery. Success,
 failure, timeout, overlap, and delivery state remain separate in
 `push job runs`. Delivery retries up to three times with backoff from the stored
 result, including after restart, and never reruns the backend.
+
+## Agent-Drafted Jobs
+
+A route using the `workspace` profile can propose a job by writing one complete
+runbook to the identity-specific inbox Push provides beneath `drafts_dir`, which
+defaults to `~/.push/drafts`. Push gives the backend only that opaque inbox as
+its extra writable root, so concurrent senders and topics cannot claim each
+other's files. `restricted` routes
+remain read-only, and `full-access` routes and jobs are rejected because their
+backend bypass modes cannot enforce this boundary.
+
+After a route run finishes, fails, times out, or resumes from a persisted
+outbound reply, Push reconciles every unrecorded revision in that route's inbox.
+It validates each filename,
+complete contents, work directory, timeout, backend, triggers, and named
+permission profile. Invalid files, symlinks, path escapes, protected Push paths,
+and profiles above the configured job ceiling never reach approval. A valid
+draft is sent in full to the originating allowlisted channel followed by an
+Approve or Reject `ask_user` question.
+
+Approval is bound to that channel, sender, chat, thread or topic, and the exact
+SHA-256 revision shown in the question. Push stores the proposal bytes and both
+identities in `push.db`. It revalidates the current draft and configured ceiling
+before installing from the stored bytes with an atomic no-clobber operation.
+Any edit after presentation invalidates the approval. Rejection leaves the file
+inactive in `drafts_dir`; duplicate answers cannot install twice.
 
 push reads TOML only. Convert any earlier `config.json` file to `config.toml`
 before upgrading. The old JSON filename remains gitignored to reduce the risk

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -248,6 +248,20 @@ the rehydrated conversation transcript. Workflows can poll the durable question
 state and consume an answered value once; crossing the expiry first records an
 expired terminal state, so later cancellation cannot overwrite the timeout.
 
+Agent-written job proposals live separately under identity-specific inboxes in
+`drafts_dir`. Route backends receive only their exact inbox as an additional
+writable root under contained
+permission profiles; full-access routes and jobs are rejected. Push snapshots
+and validates a changed regular file, stores its exact bytes, hash, proposer,
+and bound approval question in SQLite, then sends the full proposal to the
+originating channel. Reconciliation also runs after backend failure or timeout
+and before replaying a persisted outbound reply, so a crash cannot orphan an
+unrecorded revision. Approval rechecks the path, symlink status, revision, job
+schema, protected work directory, and configured permission ceiling. A valid
+stored revision is staged inside `jobs_dir` and installed with an atomic
+no-clobber link. Rejection and revision mismatch never activate the draft, and
+consumed or duplicate answers cannot repeat installation.
+
 `audit_log_path` stores a local JSONL event stream for production debugging.
 Audit events record message metadata, routing decisions, approval outcomes,
 backend run starts and failures, reply delivery metadata, and row completion.
@@ -277,14 +291,14 @@ the trust boundary. iMessage uses `imessage.self_handles` and
 `imessage.allow_from`; Telegram uses stable numeric `telegram.allow_user_ids`
 and `telegram.allow_chat_ids`.
 
-Routes select a named Push permission profile. `restricted` is the default,
-future jobs may use only explicitly allow-listed profile names, and
-`full-access` is explicit. Push translates the common capability into backend
-controls for every request. Claude receives a fixed tool allowlist and denies
-Bash outside full access; Codex receives `read-only`, `workspace-write`, or
-`danger-full-access`. Claude does not provide a Codex-equivalent filesystem
-sandbox, so its `workspace` mapping permits file tools but deliberately omits
-shell access. Custom profiles select a capability, not raw backend flags.
+Routes select a named Push permission profile. `restricted` is the default and
+jobs may use only explicitly allow-listed profile names. Push rejects
+`full-access` for routes and jobs because backend bypass modes cannot protect
+Push-owned files. Claude receives a fixed tool allowlist and denies Bash;
+Codex receives `read-only` or `workspace-write`. Claude does not provide a
+Codex-equivalent filesystem sandbox, so its `workspace` mapping permits file
+tools but deliberately omits shell access. Custom profiles select a capability,
+not raw backend flags.
 
 ## Extension Points
 

--- a/docs/jobs/design.md
+++ b/docs/jobs/design.md
@@ -241,9 +241,30 @@ execution:
 
 Push is the only writer to the run ledger. The CLI owns the manual run it
 claims, and the gateway owns scheduled runs. Installed job files remain
-operator-owned. A later draft workflow may let an agent write under
-`~/.push/drafts/`, but activation must revalidate and atomically install the
-exact approved revision into `~/.push/jobs/`.
+operator-owned.
+
+### Agent-authored draft extension
+
+Route agents may write proposals only in an opaque, exact-identity inbox under
+`~/.push/drafts/`, which Push adds as the only extra writable root for contained
+workspace profiles. Concurrent channels, senders, chats, and topics therefore
+cannot claim each other's files. Full-access
+routes and jobs are rejected because backend bypass modes cannot prevent direct
+writes to Push-owned files. Job work directories may not overlap Push identity,
+configuration, session, draft, installed-job, lock, audit, or database paths.
+
+After a route run completes, fails, times out, or resumes from a persisted
+outbound reply, Push reconciles unrecorded revisions in that identity's inbox.
+It validates each full runbook and sends its complete contents to the
+originating allowlisted channel. The
+following `ask_user` question binds Approve and Reject to that channel, sender,
+chat, thread or topic, and exact SHA-256 revision. SQLite stores the exact bytes
+and proposer identity with the question. Approval rereads and revalidates the
+draft and current permission ceiling. A changed revision is invalidated; a
+valid stored revision is staged inside `jobs_dir` and installed with an atomic
+no-clobber link. Rejection leaves the draft inactive. Proposal and approver
+identities, terminal status, and errors remain durable across restart, while
+duplicate answers cannot repeat installation.
 
 ## Alternatives and tradeoffs
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -139,6 +139,7 @@ user prompt.
 | `permission_profiles` | Custom names mapped to a common capability. |
 | `job_permission_profiles` | Explicit profile names future jobs may request; defaults to `restricted`. |
 | `jobs_dir` | Installed Markdown runbooks; defaults to `~/.push/jobs`. |
+| `drafts_dir` | Agent-written inactive job proposals; defaults to `~/.push/drafts`. |
 | `jobs_agent` | Optional default job backend; otherwise uses `agent`. |
 | `jobs_max_timeout` | Maximum validated job timeout; defaults to `30m`. |
 | `jobs_run_dir` | Local advisory-lock state; defaults to `~/.push/run`. |
@@ -176,6 +177,8 @@ user prompt.
 - `/clear` starts a fresh backend session.
 - Claude backend can create and resume a session.
 - Codex backend can create a session, store the Codex thread id, and resume it.
+- Workspace routes can propose a validated job draft, but only an exact-revision
+  approval from the bound allowlisted identity can install it.
 - Fresh or lost backend sessions receive bounded recent canonical history;
   resumed sessions receive only the new request.
 - Assistant identity is included in backend runs at instruction priority.

--- a/docs/services.md
+++ b/docs/services.md
@@ -172,6 +172,14 @@ storage. Restarting the service resumes queued runs and pending result delivery;
 it does not catch up missed cron times or rerun interrupted agent execution.
 Use `push job runs` to distinguish execution state from delivery attempts.
 
+## Drafted Jobs
+
+The service creates `drafts_dir` and `jobs_dir` with owner-only permissions.
+A workspace route may write proposals only to its identity-specific drafts
+inbox, but they
+remain inactive until the exact revision is approved from its originating
+allowlisted channel identity. Pending questions survive service restart.
+
 ## Restart Behavior
 
 `push` only advances the selected channel cursor after a message is ignored or
@@ -190,7 +198,8 @@ Managed services run without a person watching the terminal. An allowed sender
 can instruct the configured backend to use its tools, subject to your backend
 settings. Keep `imessage.allow_from` narrow and use the least-powerful named
 permission profile that works. The default `restricted` profile omits shell and
-write tools; select `full-access` only in an environment you control.
+write tools. Push rejects `full-access` for unattended routes and jobs because
+it cannot enforce the drafted-job boundary.
 
 Store config files, state files, audit logs, backend credentials, and service
 logs with permissions appropriate for the service user. Logs may contain

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -13,6 +13,7 @@ pub struct Request<'a> {
     pub session_id: &'a str,
     pub is_new: bool,
     pub work_dir: &'a str,
+    pub additional_write_dir: Option<&'a str>,
     pub instructions: &'a str,
     pub permission: PermissionCapability,
     pub prompt: &'a str,
@@ -89,6 +90,7 @@ pub struct FakeRunner {
     pub session_id: String,
     pub calls: std::sync::Arc<std::sync::Mutex<Vec<FakeRunCall>>>,
     pub before_return: Option<std::sync::Arc<dyn Fn() + Send + Sync>>,
+    pub failure: Option<String>,
     pub resume_missing_once: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 }
 
@@ -122,6 +124,9 @@ impl FakeRunner {
         }
         if let Some(before_return) = &self.before_return {
             before_return();
+        }
+        if let Some(message) = &self.failure {
+            return Err(RunError::Failed(message.clone()));
         }
         Ok(RunOutput {
             reply: format!("fake reply: {}", req.prompt),

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -62,6 +62,9 @@ impl Runner {
             .arg(controls.permission_mode)
             .arg("--add-dir")
             .arg(req.work_dir);
+        if let Some(path) = req.additional_write_dir {
+            cmd.arg("--add-dir").arg(path);
+        }
         if req.is_new {
             cmd.arg("--session-id").arg(req.session_id);
         } else {
@@ -268,6 +271,7 @@ mod tests {
                     session_id: "push-session",
                     is_new: true,
                     work_dir: work_dir.to_str().unwrap(),
+                    additional_write_dir: None,
                     instructions: "assistant identity",
                     permission: PermissionCapability::ReadOnly,
                     prompt: "hello",
@@ -297,6 +301,7 @@ mod tests {
     async fn runs_resumed_session_with_resume_flag() {
         let args_path = temp_path("claude-resume-args");
         let work_dir = temp_dir("claude-resume-work");
+        let drafts_dir = temp_dir("claude-resume-drafts");
         let script = format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nprintf '%s\\n' '{{\"result\":\"resumed\",\"session_id\":\"claude-returned\"}}'\n",
             sh_arg(&args_path)
@@ -310,6 +315,7 @@ mod tests {
                     session_id: "existing-session",
                     is_new: false,
                     work_dir: work_dir.to_str().unwrap(),
+                    additional_write_dir: Some(drafts_dir.to_str().unwrap()),
                     instructions: "assistant identity",
                     permission: PermissionCapability::Workspace,
                     prompt: "continue",
@@ -324,6 +330,9 @@ mod tests {
         assert_arg_pair(&args, "--resume", "existing-session");
         assert!(!args.contains(&"--session-id".to_string()));
         assert_arg_pair(&args, "--append-system-prompt", "assistant identity");
+        assert!(args
+            .windows(2)
+            .any(|pair| { pair == ["--add-dir", drafts_dir.to_str().unwrap()] }));
         assert_arg_pair(&args, "-p", "continue");
         assert!(args
             .windows(2)
@@ -346,6 +355,7 @@ mod tests {
                     session_id: "missing",
                     is_new: false,
                     work_dir: work_dir.to_str().unwrap(),
+                    additional_write_dir: None,
                     instructions: "",
                     permission: PermissionCapability::ReadOnly,
                     prompt: "continue",
@@ -403,6 +413,7 @@ mod tests {
             session_id: "session",
             is_new: true,
             work_dir,
+            additional_write_dir: None,
             instructions: "",
             permission: PermissionCapability::ReadOnly,
             prompt: "hello",

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -53,13 +53,19 @@ impl Runner {
                 .arg(req.work_dir)
                 .arg("-o")
                 .arg(&out_path);
+            if let Some(path) = req.additional_write_dir {
+                cmd.arg("--add-dir").arg(path);
+            }
             if let Some(model) = self.model.as_deref() {
                 cmd.arg("-m").arg(model);
             }
             cmd.arg(req.prompt);
         } else {
-            cmd.arg("exec")
-                .arg("resume")
+            cmd.arg("exec");
+            if let Some(path) = req.additional_write_dir {
+                cmd.arg("--add-dir").arg(path);
+            }
+            cmd.arg("resume")
                 .arg("--json")
                 .arg("--skip-git-repo-check")
                 .arg("-o")
@@ -342,6 +348,7 @@ mod tests {
                     session_id: "",
                     is_new: true,
                     work_dir: work_dir.to_str().unwrap(),
+                    additional_write_dir: None,
                     instructions: "assistant identity",
                     permission: PermissionCapability::Workspace,
                     prompt: "hello",
@@ -368,6 +375,7 @@ mod tests {
     async fn runs_resumed_session_with_resume_command() {
         let args_path = temp_path("codex-resume-args");
         let work_dir = temp_dir("codex-resume-work");
+        let drafts_dir = temp_dir("codex-resume-drafts");
         let script = codex_success_script(&args_path, "resumed reply", None);
         let cli = FakeCli::new("codex", &script);
         let runner = runner(cli.bin());
@@ -378,6 +386,7 @@ mod tests {
                     session_id: "existing-thread",
                     is_new: false,
                     work_dir: work_dir.to_str().unwrap(),
+                    additional_write_dir: Some(drafts_dir.to_str().unwrap()),
                     instructions: "assistant identity",
                     permission: PermissionCapability::ReadOnly,
                     prompt: "continue",
@@ -390,9 +399,13 @@ mod tests {
         assert_eq!(out.reply, "resumed reply");
         assert_eq!(out.session_id, None);
         let args = read_args(&args_path);
-        assert_arg_sequence(&args, &["exec", "resume"]);
+        assert_arg_sequence(
+            &args,
+            &["exec", "--add-dir", drafts_dir.to_str().unwrap(), "resume"],
+        );
         assert_arg_present(&args, "existing-thread");
         assert_arg_pair(&args, "--sandbox", "read-only");
+        assert_arg_pair(&args, "--add-dir", drafts_dir.to_str().unwrap());
         assert_arg_pair(&args, "-c", &developer_instructions("assistant identity"));
         assert_eq!(args.last().unwrap(), "continue");
         assert!(!args.contains(&"-C".to_string()));
@@ -413,6 +426,7 @@ mod tests {
                     session_id: "missing",
                     is_new: false,
                     work_dir: work_dir.to_str().unwrap(),
+                    additional_write_dir: None,
                     instructions: "",
                     permission: PermissionCapability::ReadOnly,
                     prompt: "continue",
@@ -474,6 +488,7 @@ mod tests {
             session_id: "",
             is_new: true,
             work_dir,
+            additional_write_dir: None,
             instructions: "",
             permission: PermissionCapability::ReadOnly,
             prompt: "hello",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 //! Gateway configuration loaded from a TOML file.
 
 use std::collections::{HashMap, HashSet};
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
@@ -44,6 +45,8 @@ pub struct Config {
     pub permission_profiles: HashMap<String, PermissionProfileConfig>,
     #[serde(default = "default_jobs_dir")]
     pub jobs_dir: String,
+    #[serde(default = "default_drafts_dir")]
+    pub drafts_dir: String,
     #[serde(default)]
     pub jobs_agent: Option<String>,
     #[serde(default = "default_jobs_max_timeout")]
@@ -132,8 +135,10 @@ impl Config {
         c.database_path = expand_home(&c.database_path);
         c.assistant_dir = expand_home(&c.assistant_dir);
         c.jobs_dir = expand_home(&c.jobs_dir);
+        c.drafts_dir = expand_home(&c.drafts_dir);
         c.jobs_run_dir = expand_home(&c.jobs_run_dir);
         c.validate()?;
+        validate_config_path(path, &c)?;
         Ok(c)
     }
 
@@ -223,6 +228,12 @@ impl Config {
                 profile.name
             );
         }
+        if profile.capability == PermissionCapability::FullAccess {
+            bail!(
+                "job permission profile {:?} uses full-access, which cannot protect Push jobs, drafts, or state",
+                profile.name
+            );
+        }
         Ok(profile)
     }
 
@@ -234,6 +245,37 @@ impl Config {
     pub fn jobs_max_timeout_dur(&self) -> Result<Duration> {
         humantime::parse_duration(&self.jobs_max_timeout)
             .with_context(|| format!("invalid jobs_max_timeout {}", self.jobs_max_timeout))
+    }
+
+    pub fn validate_job_workdir(
+        &self,
+        workdir: &Path,
+        capability: PermissionCapability,
+    ) -> Result<()> {
+        if capability == PermissionCapability::ReadOnly {
+            return Ok(());
+        }
+        let workdir = resolved_absolute("job workdir", workdir)?;
+        for (label, protected) in [
+            ("assistant_dir", self.assistant_dir.as_str()),
+            ("sessions_dir", self.sessions_dir.as_str()),
+            ("jobs_dir", self.jobs_dir.as_str()),
+            ("drafts_dir", self.drafts_dir.as_str()),
+            ("jobs_run_dir", self.jobs_run_dir.as_str()),
+            ("state_path", self.state_path.as_str()),
+            ("database_path", self.database_path.as_str()),
+            ("audit_log_path", self.audit_log_path.as_str()),
+        ] {
+            let protected = resolved_absolute(label, Path::new(protected))?;
+            if paths_overlap(&workdir, &protected) {
+                bail!(
+                    "job workdir {} overlaps Push-owned {label} {}",
+                    workdir.display(),
+                    protected.display()
+                );
+            }
+        }
+        Ok(())
     }
 
     fn resolve_route(&self, route: &RouteRule) -> Result<RouteSelection> {
@@ -320,14 +362,19 @@ impl Config {
         if self.jobs_max_timeout_dur()?.is_zero() {
             bail!("jobs_max_timeout must be positive");
         }
-        if self.jobs_dir.trim().is_empty() || self.jobs_run_dir.trim().is_empty() {
-            bail!("jobs_dir and jobs_run_dir cannot be empty");
+        if self.jobs_dir.trim().is_empty()
+            || self.drafts_dir.trim().is_empty()
+            || self.jobs_run_dir.trim().is_empty()
+        {
+            bail!("jobs_dir, drafts_dir, and jobs_run_dir cannot be empty");
         }
         if self.jobs_max_workers == 0 {
             bail!("jobs_max_workers must be positive");
         }
-        self.resolve_permission_profile(&self.permission_profile)
+        let default_profile = self
+            .resolve_permission_profile(&self.permission_profile)
             .context("invalid default permission profile")?;
+        reject_uncontained_route_profile(&default_profile)?;
         for (name, profile) in &self.permission_profiles {
             if name.trim().is_empty() {
                 bail!("permission profile names cannot be empty");
@@ -359,13 +406,119 @@ impl Config {
                 .permission_profile
                 .as_deref()
                 .unwrap_or(&self.permission_profile);
-            self.resolve_permission_profile(profile)
+            let profile = self
+                .resolve_permission_profile(profile)
                 .with_context(|| format!("invalid permission profile for route {route:?}"))?;
+            reject_uncontained_route_profile(&profile)?;
         }
+        validate_protected_paths(self)?;
         self.poll_interval_dur()?;
         self.run_timeout_dur()?;
         Ok(())
     }
+}
+
+fn reject_uncontained_route_profile(profile: &PermissionProfile) -> Result<()> {
+    if profile.capability == PermissionCapability::FullAccess {
+        bail!(
+            "route permission profile {:?} uses full-access, which cannot prevent direct writes to Push jobs or state",
+            profile.name
+        );
+    }
+    Ok(())
+}
+
+fn validate_protected_paths(cfg: &Config) -> Result<()> {
+    let sessions = resolved_absolute("sessions_dir", Path::new(&cfg.sessions_dir))?;
+    let jobs = resolved_absolute("jobs_dir", Path::new(&cfg.jobs_dir))?;
+    let drafts = resolved_absolute("drafts_dir", Path::new(&cfg.drafts_dir))?;
+    let run = resolved_absolute("jobs_run_dir", Path::new(&cfg.jobs_run_dir))?;
+    let assistant = resolved_absolute("assistant_dir", Path::new(&cfg.assistant_dir))?;
+    if paths_overlap(&jobs, &drafts) {
+        bail!("jobs_dir and drafts_dir must not overlap");
+    }
+    for (label, path) in [
+        ("jobs_dir", &jobs),
+        ("drafts_dir", &drafts),
+        ("jobs_run_dir", &run),
+    ] {
+        if paths_overlap(&sessions, path) {
+            bail!("sessions_dir and {label} must not overlap");
+        }
+    }
+    if assistant.starts_with(&sessions) {
+        bail!("assistant_dir must not be inside sessions_dir");
+    }
+    if assistant.starts_with(&drafts) {
+        bail!("assistant_dir must not be inside drafts_dir");
+    }
+    for (label, value) in [
+        ("state_path", cfg.state_path.as_str()),
+        ("database_path", cfg.database_path.as_str()),
+        ("audit_log_path", cfg.audit_log_path.as_str()),
+    ] {
+        let path = resolved_absolute(label, Path::new(value))?;
+        if path.starts_with(&sessions) {
+            bail!("{label} must not be inside sessions_dir");
+        }
+        if path.starts_with(&drafts) {
+            bail!("{label} must not be inside drafts_dir");
+        }
+    }
+    Ok(())
+}
+
+fn validate_config_path(path: &str, cfg: &Config) -> Result<()> {
+    let config = std::fs::canonicalize(path).with_context(|| format!("resolve config {path}"))?;
+    let sessions = resolved_absolute("sessions_dir", Path::new(&cfg.sessions_dir))?;
+    let drafts = resolved_absolute("drafts_dir", Path::new(&cfg.drafts_dir))?;
+    if config.starts_with(&sessions) {
+        bail!("config file must not be inside sessions_dir");
+    }
+    if config.starts_with(&drafts) {
+        bail!("config file must not be inside drafts_dir");
+    }
+    Ok(())
+}
+
+fn normalized_absolute(label: &str, path: &Path) -> Result<PathBuf> {
+    if !path.is_absolute() {
+        bail!("{label} must be an absolute path");
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => bail!("{label} cannot contain '..'"),
+            Component::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    Ok(normalized)
+}
+
+fn resolved_absolute(label: &str, path: &Path) -> Result<PathBuf> {
+    let normalized = normalized_absolute(label, path)?;
+    let mut existing = normalized.as_path();
+    let mut missing = Vec::new();
+    while !existing.exists() {
+        let name = existing
+            .file_name()
+            .with_context(|| format!("{label} has no existing ancestor"))?;
+        missing.push(name.to_os_string());
+        existing = existing
+            .parent()
+            .with_context(|| format!("{label} has no existing ancestor"))?;
+    }
+    let mut resolved = std::fs::canonicalize(existing)
+        .with_context(|| format!("resolve existing ancestor for {label}"))?;
+    for component in missing.into_iter().rev() {
+        resolved.push(component);
+    }
+    Ok(resolved)
+}
+
+fn paths_overlap(left: &Path, right: &Path) -> bool {
+    left.starts_with(right) || right.starts_with(left)
 }
 
 fn flatten_provider_section(
@@ -579,6 +732,10 @@ fn default_job_permission_profiles() -> Vec<String> {
 fn default_jobs_dir() -> String {
     "~/.push/jobs".to_string()
 }
+
+fn default_drafts_dir() -> String {
+    "~/.push/drafts".to_string()
+}
 fn default_jobs_max_timeout() -> String {
     "30m".to_string()
 }
@@ -605,4 +762,103 @@ fn default_assistant_dir() -> String {
 }
 fn default_reply_marker() -> String {
     "\n\n-- sent by push".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::temp_dir;
+
+    fn config() -> Config {
+        let root = temp_dir("config-draft-boundary");
+        Config {
+            channel: "imessage".to_string(),
+            channels: Vec::new(),
+            primary_delivery: None,
+            db_path: root.join("chat.db").to_string_lossy().to_string(),
+            poll_interval: "1s".to_string(),
+            run_timeout: "1s".to_string(),
+            self_handles: vec!["me@example.com".to_string()],
+            allow_from: Vec::new(),
+            telegram_bot_token: None,
+            telegram_bot_token_env: "TELEGRAM_BOT_TOKEN".to_string(),
+            telegram_allow_user_ids: Vec::new(),
+            telegram_allow_chat_ids: Vec::new(),
+            agent: "codex".to_string(),
+            routes: Vec::new(),
+            permission_profile: "workspace".to_string(),
+            job_permission_profiles: vec!["restricted".to_string()],
+            permission_profiles: HashMap::new(),
+            jobs_dir: root.join("jobs").to_string_lossy().to_string(),
+            drafts_dir: root.join("drafts").to_string_lossy().to_string(),
+            jobs_agent: None,
+            jobs_max_timeout: "30m".to_string(),
+            jobs_run_dir: root.join("run").to_string_lossy().to_string(),
+            jobs_max_workers: 2,
+            claude_bin: "claude".to_string(),
+            codex_bin: "codex".to_string(),
+            codex_model: None,
+            sessions_dir: root.join("sessions").to_string_lossy().to_string(),
+            state_path: root.join("state.json").to_string_lossy().to_string(),
+            audit_log_path: root.join("audit.jsonl").to_string_lossy().to_string(),
+            database_path: root.join("push.db").to_string_lossy().to_string(),
+            audit_log_content: false,
+            assistant_dir: root.to_string_lossy().to_string(),
+            reply_marker: String::new(),
+        }
+    }
+
+    #[test]
+    fn rejects_uncontained_routes_jobs_and_protected_path_overlap() {
+        let mut cfg = config();
+        assert!(cfg.validate().is_ok());
+
+        cfg.permission_profile = "full-access".to_string();
+        assert!(cfg
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("full-access"));
+
+        cfg.permission_profile = "workspace".to_string();
+        cfg.job_permission_profiles = vec!["full-access".to_string()];
+        assert!(cfg
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("full-access"));
+
+        cfg.job_permission_profiles = vec!["restricted".to_string()];
+        cfg.drafts_dir = format!("{}/drafts", cfg.jobs_dir);
+        assert!(cfg
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("must not overlap"));
+
+        let mut cfg = config();
+        cfg.assistant_dir = format!("{}/identity", cfg.sessions_dir);
+        assert!(cfg
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("assistant_dir must not be inside sessions_dir"));
+
+        let mut cfg = config();
+        cfg.assistant_dir = format!("{}/identity", cfg.drafts_dir);
+        assert!(cfg
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("assistant_dir must not be inside drafts_dir"));
+
+        let cfg = config();
+        std::fs::create_dir_all(&cfg.sessions_dir).unwrap();
+        let config_path = Path::new(&cfg.sessions_dir).join("config.toml");
+        std::fs::write(&config_path, "channel = 'imessage'").unwrap();
+        assert!(validate_config_path(config_path.to_str().unwrap(), &cfg)
+            .unwrap_err()
+            .to_string()
+            .contains("config file must not be inside sessions_dir"));
+    }
 }

--- a/src/drafts.rs
+++ b/src/drafts.rs
@@ -1,0 +1,754 @@
+//! Agent-authored job proposals and exact-revision installation.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::approval::AnswerOrigin;
+use crate::config::Config;
+use crate::history::{DraftProposal, History};
+use crate::jobs;
+
+const MAX_DRAFT_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct Candidate {
+    pub name: String,
+    pub path: PathBuf,
+    pub snapshot_hash: String,
+    pub contents: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecisionOutcome {
+    Installed(String),
+    Rejected(String),
+    Invalidated(String),
+    Failed(String),
+    AlreadyHandled,
+}
+
+pub fn prepare(cfg: &Config) -> Result<()> {
+    let drafts = prepare_directory("drafts", Path::new(&cfg.drafts_dir))?;
+    let jobs = prepare_directory("jobs", Path::new(&cfg.jobs_dir))?;
+    let canonical_drafts = std::fs::canonicalize(&drafts)?;
+    let canonical_jobs = std::fs::canonicalize(&jobs)?;
+    if canonical_drafts.starts_with(&canonical_jobs)
+        || canonical_jobs.starts_with(&canonical_drafts)
+    {
+        bail!("canonical drafts and jobs directories must not overlap");
+    }
+    Ok(())
+}
+
+pub fn origin_directory(cfg: &Config, origin: &AnswerOrigin) -> Result<PathBuf> {
+    prepare(cfg)?;
+    let identity = format!(
+        "{}\0{}\0{}\0{}",
+        origin.channel, origin.thread_key, origin.sender_key, origin.chat_key
+    );
+    let path = Path::new(&cfg.drafts_dir).join(hash(identity.as_bytes()));
+    prepare_directory("origin draft", &path)?;
+    let root = std::fs::canonicalize(&cfg.drafts_dir)?;
+    let canonical = std::fs::canonicalize(&path)?;
+    if canonical.parent() != Some(root.as_path()) {
+        bail!("origin draft directory escaped configured drafts_dir");
+    }
+    Ok(path)
+}
+
+pub fn candidates(cfg: &Config, directory: &Path) -> Result<Vec<(String, Result<Candidate>)>> {
+    prepare(cfg)?;
+    let root = std::fs::canonicalize(&cfg.drafts_dir)?;
+    let directory = std::fs::canonicalize(directory)?;
+    if directory.parent() != Some(root.as_path()) {
+        bail!("draft inbox escaped configured drafts_dir");
+    }
+    let mut candidates = Vec::new();
+    for entry in sorted_entries(&directory)? {
+        let display = entry.file_name().to_string_lossy().to_string();
+        let path = entry.path();
+        candidates.push((display, read_candidate(cfg, &path)));
+    }
+    Ok(candidates)
+}
+
+pub fn proposal(question_id: String, candidate: &Candidate, proposed_by: String) -> DraftProposal {
+    DraftProposal {
+        question_id,
+        name: candidate.name.clone(),
+        path: candidate.path.to_string_lossy().to_string(),
+        snapshot_hash: candidate.snapshot_hash.clone(),
+        contents: candidate.contents.clone(),
+        proposed_by,
+        approved_by: None,
+        status: "pending".to_string(),
+    }
+}
+
+pub fn decide(
+    cfg: &Config,
+    history: &mut History,
+    question_id: &str,
+    approved_by: &str,
+    now_ms: i64,
+) -> Result<DecisionOutcome> {
+    let Some(proposal) = history.draft_proposal(question_id)? else {
+        return Ok(DecisionOutcome::AlreadyHandled);
+    };
+    if proposal.status != "pending" {
+        return Ok(DecisionOutcome::AlreadyHandled);
+    }
+    let Some(answer) = history.draft_answer(question_id)? else {
+        return Ok(DecisionOutcome::AlreadyHandled);
+    };
+    if answer.value == "reject" {
+        history.finish_draft_decision(question_id, "rejected", Some(approved_by), None, now_ms)?;
+        return Ok(DecisionOutcome::Rejected(proposal.name));
+    }
+    if answer.value != "approve" {
+        bail!("unsupported draft decision {:?}", answer.value);
+    }
+
+    let expected_path = PathBuf::from(&proposal.path);
+    if !safe_proposal_path(cfg, &proposal, &expected_path)? {
+        let message = "stored draft path is outside the configured drafts directory";
+        history.finish_draft_decision(
+            question_id,
+            "invalidated",
+            Some(approved_by),
+            Some(message),
+            now_ms,
+        )?;
+        return Ok(DecisionOutcome::Invalidated(message.to_string()));
+    }
+    let current = match read_candidate(cfg, &expected_path) {
+        Ok(candidate) => candidate,
+        Err(error) => {
+            if std::fs::symlink_metadata(&expected_path)
+                .is_err_and(|read_error| read_error.kind() == std::io::ErrorKind::NotFound)
+                && installed_revision(cfg, &proposal)?
+            {
+                history.finish_draft_decision(
+                    question_id,
+                    "installed",
+                    Some(approved_by),
+                    None,
+                    now_ms,
+                )?;
+                return Ok(DecisionOutcome::Installed(proposal.name));
+            }
+            let message = format!("draft is no longer valid: {error:#}");
+            history.finish_draft_decision(
+                question_id,
+                "invalidated",
+                Some(approved_by),
+                Some(&message),
+                now_ms,
+            )?;
+            return Ok(DecisionOutcome::Invalidated(message));
+        }
+    };
+    if current.snapshot_hash != proposal.snapshot_hash {
+        let message = "draft changed after it was presented; request approval for the new revision";
+        history.finish_draft_decision(
+            question_id,
+            "invalidated",
+            Some(approved_by),
+            Some(message),
+            now_ms,
+        )?;
+        return Ok(DecisionOutcome::Invalidated(message.to_string()));
+    }
+    let stored_hash = hash(proposal.contents.as_bytes());
+    if stored_hash != proposal.snapshot_hash {
+        let message = "stored draft revision failed its integrity check";
+        history.finish_draft_decision(
+            question_id,
+            "failed",
+            Some(approved_by),
+            Some(message),
+            now_ms,
+        )?;
+        return Ok(DecisionOutcome::Failed(message.to_string()));
+    }
+    if let Err(error) = jobs::validate_contents(
+        cfg,
+        &proposal.name,
+        &expected_path,
+        proposal.contents.as_bytes(),
+    ) {
+        let message =
+            format!("draft no longer satisfies the configured capability ceiling: {error:#}");
+        history.finish_draft_decision(
+            question_id,
+            "invalidated",
+            Some(approved_by),
+            Some(&message),
+            now_ms,
+        )?;
+        return Ok(DecisionOutcome::Invalidated(message));
+    }
+
+    match install_exact(cfg, &proposal) {
+        Ok(()) => {
+            remove_if_revision(&expected_path, &proposal.snapshot_hash)?;
+            history.finish_draft_decision(
+                question_id,
+                "installed",
+                Some(approved_by),
+                None,
+                now_ms,
+            )?;
+            Ok(DecisionOutcome::Installed(proposal.name))
+        }
+        Err(error) => {
+            let message = format!("install draft: {error:#}");
+            history.finish_draft_decision(
+                question_id,
+                "failed",
+                Some(approved_by),
+                Some(&message),
+                now_ms,
+            )?;
+            Ok(DecisionOutcome::Failed(message))
+        }
+    }
+}
+
+fn read_candidate(cfg: &Config, path: &Path) -> Result<Candidate> {
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("inspect draft {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        bail!("drafts must be regular Markdown files; symlinks and directories are rejected");
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .context("draft filename must be valid UTF-8")?;
+    let name = file_name
+        .strip_suffix(".md")
+        .context("draft filename must end in .md")?;
+    jobs::validate_slug(name)?;
+    let mut file = File::open(path).with_context(|| format!("open draft {}", path.display()))?;
+    let opened = file.metadata()?;
+    if !same_file(&metadata, &opened) {
+        bail!("draft changed while it was being opened; retry the proposal");
+    }
+    if opened.len() > MAX_DRAFT_BYTES as u64 {
+        bail!("draft exceeds {MAX_DRAFT_BYTES} bytes");
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_DRAFT_BYTES {
+        bail!("draft exceeds {MAX_DRAFT_BYTES} bytes");
+    }
+    jobs::validate_contents(cfg, name, path, &bytes)?;
+    let contents = String::from_utf8(bytes).context("draft must be valid UTF-8")?;
+    Ok(Candidate {
+        name: name.to_string(),
+        path: path.to_path_buf(),
+        snapshot_hash: hash(contents.as_bytes()),
+        contents,
+    })
+}
+
+fn install_exact(cfg: &Config, proposal: &DraftProposal) -> Result<()> {
+    prepare(cfg)?;
+    let jobs_dir = Path::new(&cfg.jobs_dir);
+    let destination = jobs_dir.join(format!("{}.md", proposal.name));
+    if destination.exists() {
+        let installed = read_regular_bytes(&destination)?;
+        if hash(&installed) == proposal.snapshot_hash {
+            return Ok(());
+        }
+        bail!(
+            "installed job {:?} already exists with different contents",
+            proposal.name
+        );
+    }
+    let temporary = jobs_dir.join(format!(".{}.{}.tmp", proposal.name, Uuid::new_v4()));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+            .with_context(|| format!("create install staging file {}", temporary.display()))?;
+        restrict_permissions(&temporary, false)?;
+        file.write_all(proposal.contents.as_bytes())?;
+        file.sync_all()?;
+        jobs::validate_contents(
+            cfg,
+            &proposal.name,
+            &temporary,
+            proposal.contents.as_bytes(),
+        )?;
+        std::fs::hard_link(&temporary, &destination)
+            .with_context(|| format!("atomically install job at {}", destination.display()))?;
+        File::open(jobs_dir)?.sync_all()?;
+        Ok(())
+    })();
+    let _ = std::fs::remove_file(&temporary);
+    result
+}
+
+fn prepare_directory(label: &str, path: &Path) -> Result<PathBuf> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            bail!(
+                "{label} directory {} must not be a symlink or file",
+                path.display()
+            );
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(path)
+                .with_context(|| format!("create {label} directory {}", path.display()))?;
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspect {label} directory {}", path.display()))
+        }
+    }
+    restrict_permissions(path, true)?;
+    Ok(path.to_path_buf())
+}
+
+fn installed_revision(cfg: &Config, proposal: &DraftProposal) -> Result<bool> {
+    let destination = Path::new(&cfg.jobs_dir).join(format!("{}.md", proposal.name));
+    if !destination.exists() {
+        return Ok(false);
+    }
+    Ok(hash(&read_regular_bytes(&destination)?) == proposal.snapshot_hash)
+}
+
+fn remove_if_revision(path: &Path, expected_hash: &str) -> Result<()> {
+    remove_if_revision_after_inspection(path, expected_hash, || {})
+}
+
+fn remove_if_revision_after_inspection(
+    path: &Path,
+    expected_hash: &str,
+    after_inspection: impl FnOnce(),
+) -> Result<()> {
+    let expected = std::fs::symlink_metadata(path)?;
+    let bytes = read_regular_bytes(path)?;
+    if hash(&bytes) != expected_hash {
+        return Ok(());
+    }
+    after_inspection();
+    let quarantine = path.with_file_name(format!(".approved-{}.tmp", Uuid::new_v4()));
+    std::fs::rename(path, &quarantine)
+        .with_context(|| format!("quarantine installed draft {}", path.display()))?;
+    let quarantined = std::fs::symlink_metadata(&quarantine)?;
+    let unchanged = same_file(&expected, &quarantined)
+        && hash(&read_regular_bytes(&quarantine)?) == expected_hash;
+    if unchanged {
+        std::fs::remove_file(&quarantine)?;
+        return Ok(());
+    }
+    if std::fs::hard_link(&quarantine, path).is_ok() {
+        std::fs::remove_file(&quarantine)?;
+    }
+    Ok(())
+}
+
+fn safe_proposal_path(cfg: &Config, proposal: &DraftProposal, path: &Path) -> Result<bool> {
+    let expected_name = format!("{}.md", proposal.name);
+    if path.file_name().and_then(|value| value.to_str()) != Some(expected_name.as_str()) {
+        return Ok(false);
+    }
+    let Some(parent) = path.parent() else {
+        return Ok(false);
+    };
+    let metadata = match std::fs::symlink_metadata(parent) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Ok(false);
+    }
+    let root = std::fs::canonicalize(&cfg.drafts_dir)?;
+    let parent = std::fs::canonicalize(parent)?;
+    Ok(parent.parent() == Some(root.as_path()))
+}
+
+fn read_regular_bytes(path: &Path) -> Result<Vec<u8>> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        bail!("{} is not a regular file", path.display());
+    }
+    let file = File::open(path)?;
+    let opened = file.metadata()?;
+    if !same_file(&metadata, &opened) {
+        bail!("{} changed while opening", path.display());
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_DRAFT_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_DRAFT_BYTES {
+        bail!("{} exceeds {MAX_DRAFT_BYTES} bytes", path.display());
+    }
+    Ok(bytes)
+}
+
+fn sorted_entries(dir: &Path) -> Result<Vec<std::fs::DirEntry>> {
+    let mut entries = std::fs::read_dir(dir)?.collect::<std::io::Result<Vec<_>>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+    Ok(entries)
+}
+
+fn hash(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+#[cfg(unix)]
+fn same_file(expected: &std::fs::Metadata, opened: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    expected.dev() == opened.dev() && expected.ino() == opened.ino()
+}
+
+#[cfg(not(unix))]
+fn same_file(expected: &std::fs::Metadata, opened: &std::fs::Metadata) -> bool {
+    expected.len() == opened.len()
+        && expected.modified().ok() == opened.modified().ok()
+        && opened.is_file()
+}
+
+#[cfg(unix)]
+fn restrict_permissions(path: &Path, directory: bool) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = if directory { 0o700 } else { 0o600 };
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn restrict_permissions(_path: &Path, _directory: bool) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use crate::approval::{AnswerOrigin, AnswerOutcome, Choice, Question};
+    use crate::config::Config;
+    use crate::test_support::{temp_dir, temp_path};
+
+    fn cfg() -> (Config, PathBuf) {
+        let root = temp_dir("drafts-root");
+        let workdir = temp_dir("drafts-workdir");
+        (
+            Config {
+                channel: "telegram".to_string(),
+                channels: vec!["telegram".to_string()],
+                primary_delivery: None,
+                db_path: temp_path("drafts-chat").to_string_lossy().to_string(),
+                poll_interval: "1s".to_string(),
+                run_timeout: "1s".to_string(),
+                self_handles: Vec::new(),
+                allow_from: Vec::new(),
+                telegram_bot_token: Some("token".to_string()),
+                telegram_bot_token_env: "TELEGRAM_BOT_TOKEN".to_string(),
+                telegram_allow_user_ids: vec![7],
+                telegram_allow_chat_ids: Vec::new(),
+                agent: "codex".to_string(),
+                routes: Vec::new(),
+                permission_profile: "workspace".to_string(),
+                job_permission_profiles: vec!["restricted".to_string(), "workspace".to_string()],
+                permission_profiles: HashMap::new(),
+                jobs_dir: root.join("jobs").to_string_lossy().to_string(),
+                drafts_dir: root.join("drafts").to_string_lossy().to_string(),
+                jobs_agent: None,
+                jobs_max_timeout: "30m".to_string(),
+                jobs_run_dir: root.join("run").to_string_lossy().to_string(),
+                jobs_max_workers: 2,
+                claude_bin: "claude".to_string(),
+                codex_bin: "codex".to_string(),
+                codex_model: None,
+                sessions_dir: root.join("sessions").to_string_lossy().to_string(),
+                state_path: root.join("state.json").to_string_lossy().to_string(),
+                audit_log_path: root.join("audit.jsonl").to_string_lossy().to_string(),
+                database_path: root.join("push.db").to_string_lossy().to_string(),
+                audit_log_content: false,
+                assistant_dir: root.to_string_lossy().to_string(),
+                reply_marker: String::new(),
+            },
+            workdir,
+        )
+    }
+
+    fn runbook(workdir: &Path, profile: &str) -> String {
+        format!(
+            "+++\nversion = 1\npermission_profile = {profile:?}\ntimeout = \"5s\"\nworkdir = {:?}\nbackend = \"codex\"\n+++\n\nInspect safely.\n",
+            workdir.to_string_lossy()
+        )
+    }
+
+    fn origin() -> AnswerOrigin {
+        AnswerOrigin {
+            channel: "telegram".to_string(),
+            thread_key: "telegram:dm:7:topic:9".to_string(),
+            sender_key: "7".to_string(),
+            chat_key: "7".to_string(),
+        }
+    }
+
+    fn question() -> Question {
+        Question::new(
+            origin(),
+            "7:9",
+            "Install exact draft?",
+            vec![
+                Choice {
+                    label: "Approve".to_string(),
+                    value: "approve".to_string(),
+                },
+                Choice {
+                    label: "Reject".to_string(),
+                    value: "reject".to_string(),
+                },
+            ],
+            10_000,
+        )
+        .unwrap()
+    }
+
+    fn candidate(cfg: &Config, workdir: &Path, name: &str) -> Candidate {
+        let directory = origin_directory(cfg, &origin()).unwrap();
+        let path = directory.join(format!("{name}.md"));
+        std::fs::write(&path, runbook(workdir, "restricted")).unwrap();
+        read_candidate(cfg, &path).unwrap()
+    }
+
+    fn record(history: &mut History, candidate: &Candidate, question: &Question) {
+        let proposal = proposal(
+            question.id.clone(),
+            candidate,
+            "channel=telegram thread=telegram:dm:7:topic:9 sender=7 chat=7".to_string(),
+        );
+        history
+            .create_draft_question(question, &proposal, 1_000)
+            .unwrap();
+    }
+
+    #[test]
+    fn approval_survives_restart_and_installs_once_for_exact_channel_identity() {
+        let (cfg, workdir) = cfg();
+        let candidate = candidate(&cfg, &workdir, "morning-note");
+        let question = question();
+        let mut history = History::open(&cfg.database_path).unwrap();
+        record(&mut history, &candidate, &question);
+        drop(history);
+
+        let mut history = History::open(&cfg.database_path).unwrap();
+        let mut wrong = origin();
+        wrong.thread_key = "telegram:dm:7".to_string();
+        assert_eq!(
+            history
+                .answer_question(&wrong, &format!("{} 1", question.id), 2_000)
+                .unwrap(),
+            AnswerOutcome::Mismatched(question.id.clone())
+        );
+        assert!(matches!(
+            history
+                .answer_question(&origin(), &format!("{} 1", question.id), 2_100)
+                .unwrap(),
+            AnswerOutcome::Selected(_)
+        ));
+        assert_eq!(
+            decide(&cfg, &mut history, &question.id, "sender=7", 2_200).unwrap(),
+            DecisionOutcome::Installed("morning-note".to_string())
+        );
+        let installed = Path::new(&cfg.jobs_dir).join("morning-note.md");
+        assert_eq!(
+            std::fs::read_to_string(&installed).unwrap(),
+            candidate.contents
+        );
+        assert!(!candidate.path.exists());
+        assert!(matches!(
+            history
+                .answer_question(&origin(), &format!("{} 1", question.id), 2_300)
+                .unwrap(),
+            AnswerOutcome::Duplicate(_)
+        ));
+        assert_eq!(
+            decide(&cfg, &mut history, &question.id, "sender=7", 2_400).unwrap(),
+            DecisionOutcome::AlreadyHandled
+        );
+        assert_eq!(std::fs::read_dir(&cfg.jobs_dir).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn edit_after_presentation_invalidates_approval_and_reject_keeps_draft_inactive() {
+        let (cfg, workdir) = cfg();
+        let raced = candidate(&cfg, &workdir, "race");
+        let race_question = question();
+        let mut history = History::open(&cfg.database_path).unwrap();
+        record(&mut history, &raced, &race_question);
+        std::fs::write(&raced.path, runbook(&workdir, "workspace")).unwrap();
+        history
+            .answer_question(&origin(), &format!("{} 1", race_question.id), 2_000)
+            .unwrap();
+        assert!(matches!(
+            decide(&cfg, &mut history, &race_question.id, "sender=7", 2_100).unwrap(),
+            DecisionOutcome::Invalidated(_)
+        ));
+        assert!(!Path::new(&cfg.jobs_dir).join("race.md").exists());
+
+        let rejected = candidate(&cfg, &workdir, "rejected");
+        let reject_question = question();
+        record(&mut history, &rejected, &reject_question);
+        history
+            .answer_question(&origin(), &format!("{} 2", reject_question.id), 3_000)
+            .unwrap();
+        assert_eq!(
+            decide(&cfg, &mut history, &reject_question.id, "sender=7", 3_100,).unwrap(),
+            DecisionOutcome::Rejected("rejected".to_string())
+        );
+        assert!(rejected.path.exists());
+        assert!(!Path::new(&cfg.jobs_dir).join("rejected.md").exists());
+    }
+
+    #[test]
+    fn invalid_escape_symlink_and_permission_escalation_never_become_candidates() {
+        let (cfg, workdir) = cfg();
+        assert!(cfg
+            .validate_job_workdir(
+                Path::new(&cfg.assistant_dir),
+                crate::config::PermissionCapability::Workspace,
+            )
+            .is_err());
+        assert_eq!(
+            cfg.permission_for_job("workspace").unwrap().capability,
+            crate::config::PermissionCapability::Workspace
+        );
+        let parsed = jobs::validate_contents(
+            &cfg,
+            "push-state",
+            Path::new(&cfg.drafts_dir).join("push-state.md").as_path(),
+            runbook(Path::new(&cfg.assistant_dir), "workspace").as_bytes(),
+        );
+        assert!(parsed.is_err(), "parsed={parsed:?}");
+        let directory = origin_directory(&cfg, &origin()).unwrap();
+        std::fs::write(
+            directory.join("../escape.md"),
+            runbook(&workdir, "restricted"),
+        )
+        .unwrap();
+        std::fs::write(
+            directory.join("too-powerful.md"),
+            runbook(&workdir, "full-access"),
+        )
+        .unwrap();
+        std::fs::write(
+            directory.join("push-state.md"),
+            runbook(Path::new(&cfg.assistant_dir), "workspace"),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            directory.join("too-powerful.md"),
+            directory.join("linked.md"),
+        )
+        .unwrap();
+
+        let changed = candidates(&cfg, &directory).unwrap();
+        assert!(changed.iter().any(|(name, result)| {
+            name == "too-powerful.md"
+                && result
+                    .as_ref()
+                    .unwrap_err()
+                    .to_string()
+                    .contains("full-access")
+        }));
+        assert!(changed.iter().any(|(name, result)| {
+            name == "push-state.md"
+                && result
+                    .as_ref()
+                    .unwrap_err()
+                    .to_string()
+                    .contains("overlaps Push-owned")
+        }));
+        #[cfg(unix)]
+        assert!(changed.iter().any(|(name, result)| {
+            name == "linked.md"
+                && result
+                    .as_ref()
+                    .unwrap_err()
+                    .to_string()
+                    .contains("symlinks")
+        }));
+        assert!(!changed.iter().any(|(name, _)| name == "escape.md"));
+    }
+
+    #[test]
+    fn restart_finalizes_an_exact_install_completed_before_database_update() {
+        let (cfg, workdir) = cfg();
+        let candidate = candidate(&cfg, &workdir, "crash-window");
+        let question = question();
+        let mut history = History::open(&cfg.database_path).unwrap();
+        record(&mut history, &candidate, &question);
+        history
+            .answer_question(&origin(), &format!("{} 1", question.id), 2_000)
+            .unwrap();
+        let proposal = history.draft_proposal(&question.id).unwrap().unwrap();
+        install_exact(&cfg, &proposal).unwrap();
+        std::fs::remove_file(&candidate.path).unwrap();
+        drop(history);
+
+        let mut restarted = History::open(&cfg.database_path).unwrap();
+        assert_eq!(
+            decide(&cfg, &mut restarted, &question.id, "sender=7", 2_100).unwrap(),
+            DecisionOutcome::Installed("crash-window".to_string())
+        );
+        assert_eq!(
+            restarted
+                .draft_proposal(&question.id)
+                .unwrap()
+                .unwrap()
+                .status,
+            "installed"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_drafts_directory_cannot_be_a_symlink_to_installed_jobs() {
+        let (cfg, _) = cfg();
+        std::fs::create_dir_all(&cfg.jobs_dir).unwrap();
+        std::os::unix::fs::symlink(&cfg.jobs_dir, &cfg.drafts_dir).unwrap();
+
+        assert!(prepare(&cfg)
+            .unwrap_err()
+            .to_string()
+            .contains("must not be a symlink"));
+    }
+
+    #[test]
+    fn cleanup_does_not_delete_a_replacement_revision() {
+        let directory = temp_dir("draft-cleanup-race");
+        let path = directory.join("race.md");
+        let approved = b"approved revision";
+        std::fs::write(&path, approved).unwrap();
+        let replacement_path = path.clone();
+
+        remove_if_revision_after_inspection(&path, &hash(approved), move || {
+            std::fs::remove_file(&replacement_path).unwrap();
+            std::fs::write(&replacement_path, "new unapproved revision").unwrap();
+        })
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "new unapproved revision"
+        );
+    }
+}

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -8,6 +8,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 use std::future::Future;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -18,7 +19,7 @@ use tracing::{error, info, warn};
 
 use crate::agent::{Request, RunError, Runner};
 use crate::approval::{
-    AnswerOrigin, AnswerOutcome, DeliveryStatus as ApprovalDeliveryStatus, Question,
+    AnswerOrigin, AnswerOutcome, Choice, DeliveryStatus as ApprovalDeliveryStatus, Question,
 };
 use crate::audit::{AuditEvent, AuditLog};
 use crate::channel::{Channel, RawMessage};
@@ -50,12 +51,14 @@ struct Job {
     target: String,
     backend: AgentBackend,
     permission: PermissionProfile,
+    approval_origin: AnswerOrigin,
     text: String,
 }
 
 /// Shared, cheaply cloneable context handed to each worker task.
 #[derive(Clone)]
 struct Ctx {
+    cfg: Config,
     store: Arc<Mutex<Store>>,
     history: Arc<Mutex<History>>,
     ack: Arc<Mutex<AckState>>,
@@ -348,6 +351,7 @@ impl Gateway {
         runners: Arc<HashMap<AgentBackend, Runner>>,
         audit_lock: Arc<Mutex<()>>,
     ) -> Result<Self> {
+        crate::drafts::prepare(&cfg).context("prepare agent job draft boundary")?;
         let ack = Arc::new(Mutex::new(AckState::default()));
         let channel = Channel::new_for(&cfg, kind)?;
         let audit = Arc::new(AuditLog::with_lock(
@@ -357,6 +361,7 @@ impl Gateway {
             audit_lock,
         ));
         let ctx = Ctx {
+            cfg: cfg.clone(),
             store: store.clone(),
             history,
             ack: ack.clone(),
@@ -535,13 +540,38 @@ impl Gateway {
                 continue;
             }
             if let Some((thread, target)) = self.channel.accept(m) {
+                let approval_origin = approval_origin(m, &thread);
                 let approval = self.ctx.history.lock().unwrap().answer_question(
-                    &approval_origin(m, &thread),
+                    &approval_origin,
                     m.text.trim(),
                     now_ms(),
                 );
                 match approval {
                     Ok(AnswerOutcome::NotAnAnswer) => {}
+                    Ok(outcome @ (AnswerOutcome::Selected(_) | AnswerOutcome::Duplicate(_))) => {
+                        self.audit_approval(m.row_id, &thread, &outcome);
+                        let question_id = match &outcome {
+                            AnswerOutcome::Selected(answer) => &answer.correlation_id,
+                            AnswerOutcome::Duplicate(id) => id,
+                            _ => unreachable!(),
+                        };
+                        if let Err(error) = self
+                            .handle_draft_answer(question_id, &approval_origin, &target)
+                            .await
+                        {
+                            error!("[{thread}] draft approval failed: {error:#}");
+                            self.audit(self.ctx.audit.failed(
+                                "draft_approval_failed",
+                                m.row_id,
+                                &thread,
+                                None,
+                                error.to_string(),
+                            ));
+                            return;
+                        }
+                        self.complete_row(m.row_id, "approval_answer");
+                        continue;
+                    }
                     Ok(outcome) => {
                         self.audit_approval(m.row_id, &thread, &outcome);
                         self.complete_row(m.row_id, "approval_answer");
@@ -610,6 +640,7 @@ impl Gateway {
                     target,
                     backend,
                     permission: route.permission,
+                    approval_origin,
                     text: m.text.trim().to_string(),
                 };
                 if !self.route(job).await {
@@ -717,6 +748,46 @@ impl Gateway {
         };
         self.audit(self.ctx.audit.approval(event, row_id, thread, reason));
     }
+
+    async fn handle_draft_answer(
+        &self,
+        question_id: &str,
+        origin: &AnswerOrigin,
+        target: &str,
+    ) -> Result<()> {
+        let approved_by = format!(
+            "channel={} thread={} sender={} chat={}",
+            origin.channel, origin.thread_key, origin.sender_key, origin.chat_key
+        );
+        let outcome = crate::drafts::decide(
+            &self.cfg,
+            &mut self.ctx.history.lock().unwrap(),
+            question_id,
+            &approved_by,
+            now_ms(),
+        )?;
+        let message = match outcome {
+            crate::drafts::DecisionOutcome::Installed(name) => {
+                Some(format!("Installed approved job `{name}`."))
+            }
+            crate::drafts::DecisionOutcome::Rejected(name) => Some(format!(
+                "Rejected job draft `{name}`. It remains inactive in drafts."
+            )),
+            crate::drafts::DecisionOutcome::Invalidated(message) => {
+                Some(format!("Draft approval was invalidated: {message}"))
+            }
+            crate::drafts::DecisionOutcome::Failed(message) => {
+                Some(format!("Draft approval failed safely: {message}"))
+            }
+            crate::drafts::DecisionOutcome::AlreadyHandled => None,
+        };
+        if let Some(message) = message {
+            if !reply_to(&self.ctx, target, &message).await {
+                warn!("draft decision reply delivery failed for question {question_id}");
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Processes one thread's jobs strictly in order, exiting when the queue closes.
@@ -727,9 +798,30 @@ async fn worker(ctx: Ctx, mut rx: mpsc::Receiver<Job>) {
 }
 
 async fn handle(ctx: &Ctx, job: Job) {
+    let draft_directory =
+        if job.permission.capability == crate::config::PermissionCapability::Workspace {
+            match crate::drafts::origin_directory(&ctx.cfg, &job.approval_origin) {
+                Ok(directory) => Some(directory),
+                Err(error) => {
+                    error!("[{}] draft boundary error: {error:#}", job.thread);
+                    return;
+                }
+            }
+        } else {
+            None
+        };
     let existing_outbound = { ctx.history.lock().unwrap().outbound_for(job.inbound_id) };
     match existing_outbound {
         Ok(Some(outbound)) => {
+            if let Some(directory) = &draft_directory {
+                if let Err(error) = present_drafts(ctx, &job, directory).await {
+                    error!(
+                        "[{}] recovered draft presentation failed: {error:#}",
+                        job.thread
+                    );
+                    return;
+                }
+            }
             match deliver_stored(ctx, &job, &outbound).await {
                 Ok(DeliveryOutcome::Delivered | DeliveryOutcome::AlreadyDelivered) => {
                     audit(
@@ -844,7 +936,7 @@ async fn handle(ctx: &Ctx, job: Job) {
         return;
     }
 
-    let instructions = match soul::load(&ctx.assistant_dir) {
+    let mut instructions = match soul::load(&ctx.assistant_dir) {
         Ok(instructions) => instructions,
         Err(error) => {
             error!("[{}] assistant identity error: {error}", job.thread);
@@ -862,6 +954,13 @@ async fn handle(ctx: &Ctx, job: Job) {
             return;
         }
     };
+    let draft_write_dir = draft_directory.as_ref().and_then(|path| path.to_str());
+    if let Some(draft_write_dir) = draft_write_dir {
+        instructions.push_str(&format!(
+            "\n\nTo propose a recurring job, write one complete validated Markdown runbook to {}/<lowercase-slug>.md. This drafts directory is the only Push-owned path you may write. A draft remains inactive until the allowlisted user approves its exact revision. Never write to the installed jobs directory, Push configuration, or Push state.",
+            draft_write_dir
+        ));
+    }
 
     let run = async {
         let mut session_id = session_id;
@@ -913,6 +1012,7 @@ async fn handle(ctx: &Ctx, job: Job) {
                     &session_id,
                     is_new,
                     &work_dir,
+                    draft_write_dir,
                     &instructions,
                     job.permission.capability,
                     prompt,
@@ -932,6 +1032,7 @@ async fn handle(ctx: &Ctx, job: Job) {
                                 &session_id,
                                 false,
                                 &work_dir,
+                                draft_write_dir,
                                 &instructions,
                                 job.permission.capability,
                                 &job.text,
@@ -995,6 +1096,7 @@ async fn handle(ctx: &Ctx, job: Job) {
                         &session_id,
                         true,
                         &work_dir,
+                        draft_write_dir,
                         &instructions,
                         job.permission.capability,
                         prompt,
@@ -1068,7 +1170,24 @@ async fn handle(ctx: &Ctx, job: Job) {
                 );
                 return;
             }
-            match deliver_stored(ctx, &job, &outbound).await {
+            let delivery = deliver_stored(ctx, &job, &outbound).await;
+            if let Some(directory) = &draft_directory {
+                if let Err(error) = present_drafts(ctx, &job, directory).await {
+                    error!("[{}] draft presentation failed: {error:#}", job.thread);
+                    audit(
+                        ctx,
+                        ctx.audit.failed(
+                            "draft_presentation_failed",
+                            job.row_id,
+                            &job.thread,
+                            Some(job.backend),
+                            error.to_string(),
+                        ),
+                    );
+                    return;
+                }
+            }
+            match delivery {
                 Ok(DeliveryOutcome::Delivered | DeliveryOutcome::AlreadyDelivered) => {
                     info!("[{}] reply sent via {}", job.thread, ctx.channel.id());
                     audit(
@@ -1099,7 +1218,25 @@ async fn handle(ctx: &Ctx, job: Job) {
                 ),
             );
             let reply = "That took too long and was stopped. Try again or simplify the request.";
-            match record_and_deliver(ctx, &job, OutboundOrigin::Gateway, reply).await {
+            let outbound = match ctx.history.lock().unwrap().record_outbound(
+                job.inbound_id,
+                OutboundOrigin::Gateway,
+                Some(job.backend.as_str()),
+                reply,
+            ) {
+                Ok(outbound) => outbound,
+                Err(error) => {
+                    history_error(ctx, &job, "record timeout reply", error);
+                    return;
+                }
+            };
+            if let Some(directory) = &draft_directory {
+                if let Err(error) = present_drafts(ctx, &job, directory).await {
+                    history_error(ctx, &job, "present timed-out run drafts", error);
+                    return;
+                }
+            }
+            match deliver_stored(ctx, &job, &outbound).await {
                 Ok(DeliveryOutcome::Delivered | DeliveryOutcome::AlreadyDelivered) => {
                     audit(
                         ctx,
@@ -1113,7 +1250,7 @@ async fn handle(ctx: &Ctx, job: Job) {
                     );
                     complete_job(ctx, &job, "timeout");
                 }
-                Err(error) => history_error(ctx, &job, "record timeout reply", error),
+                Err(error) => history_error(ctx, &job, "deliver timeout reply", error),
             }
         }
         Err(RunError::Failed(msg) | RunError::SessionMissing(msg)) => {
@@ -1129,7 +1266,25 @@ async fn handle(ctx: &Ctx, job: Job) {
                 ),
             );
             let reply = format!("⚠️ {}", short(&msg));
-            match record_and_deliver(ctx, &job, OutboundOrigin::Gateway, &reply).await {
+            let outbound = match ctx.history.lock().unwrap().record_outbound(
+                job.inbound_id,
+                OutboundOrigin::Gateway,
+                Some(job.backend.as_str()),
+                &reply,
+            ) {
+                Ok(outbound) => outbound,
+                Err(error) => {
+                    history_error(ctx, &job, "record failure reply", error);
+                    return;
+                }
+            };
+            if let Some(directory) = &draft_directory {
+                if let Err(error) = present_drafts(ctx, &job, directory).await {
+                    history_error(ctx, &job, "present failed run drafts", error);
+                    return;
+                }
+            }
+            match deliver_stored(ctx, &job, &outbound).await {
                 Ok(DeliveryOutcome::Delivered | DeliveryOutcome::AlreadyDelivered) => {
                     audit(
                         ctx,
@@ -1143,10 +1298,101 @@ async fn handle(ctx: &Ctx, job: Job) {
                     );
                     complete_job(ctx, &job, "backend_failed");
                 }
-                Err(error) => history_error(ctx, &job, "record failure reply", error),
+                Err(error) => history_error(ctx, &job, "deliver failure reply", error),
             }
         }
     }
+}
+
+async fn present_drafts(ctx: &Ctx, job: &Job, directory: &Path) -> Result<()> {
+    for (display_name, result) in crate::drafts::candidates(&ctx.cfg, directory)? {
+        let candidate = match result {
+            Ok(candidate) => candidate,
+            Err(error) => {
+                let message = format!(
+                    "Job draft `{display_name}` is inactive and cannot be approved: {error:#}"
+                );
+                if !reply_to(ctx, &job.target, &message).await {
+                    warn!("[{}] invalid draft notice delivery failed", job.thread);
+                }
+                continue;
+            }
+        };
+        let existing = ctx
+            .history
+            .lock()
+            .unwrap()
+            .draft_revision(&candidate.path, &candidate.snapshot_hash)?;
+        let proposal = if let Some(proposal) = existing {
+            proposal
+        } else {
+            let question = Question::new(
+                job.approval_origin.clone(),
+                job.target.clone(),
+                format!(
+                    "Install job draft `{}` at exact revision `{}`?",
+                    candidate.name, candidate.snapshot_hash
+                ),
+                vec![
+                    Choice {
+                        label: "Approve and install".to_string(),
+                        value: "approve".to_string(),
+                    },
+                    Choice {
+                        label: "Reject and leave inactive".to_string(),
+                        value: "reject".to_string(),
+                    },
+                ],
+                now_ms() + 86_400_000,
+            )?;
+            let proposed_by = format!(
+                "channel={} thread={} sender={} chat={}",
+                job.approval_origin.channel,
+                job.approval_origin.thread_key,
+                job.approval_origin.sender_key,
+                job.approval_origin.chat_key
+            );
+            let proposal = crate::drafts::proposal(question.id.clone(), &candidate, proposed_by);
+            let _ = ctx.history.lock().unwrap().create_draft_question(
+                &question,
+                &proposal,
+                now_ms(),
+            )?;
+            ctx.history
+                .lock()
+                .unwrap()
+                .draft_revision(&candidate.path, &candidate.snapshot_hash)?
+                .context("persisted draft revision disappeared")?
+        };
+        let Some(question) = ctx
+            .history
+            .lock()
+            .unwrap()
+            .pending_draft_question(&proposal.question_id, now_ms())?
+        else {
+            continue;
+        };
+        let full = format!(
+            "Proposed job `{}`\nRevision: `{}`\n\n{}",
+            candidate.name, candidate.snapshot_hash, candidate.contents
+        );
+        let contents_delivered = reply_to(ctx, &question.target, &full).await;
+        let delivered =
+            contents_delivered && reply_to(ctx, &question.target, &question.render_text()).await;
+        ctx.history.lock().unwrap().mark_question_delivery(
+            &proposal.question_id,
+            if delivered {
+                ApprovalDeliveryStatus::Delivered
+            } else {
+                ApprovalDeliveryStatus::Failed
+            },
+        )?;
+        if !delivered {
+            warn!("[{}] draft proposal delivery failed", job.thread);
+            anyhow::bail!("draft proposal delivery failed; retry before expiry");
+        }
+    }
+    Ok(())
 }
 
 async fn run_with_periodic_activity<O, A, AF>(
@@ -1455,6 +1701,7 @@ fn backend_request<'a>(
     session_id: &'a str,
     is_new: bool,
     work_dir: &'a str,
+    additional_write_dir: Option<&'a str>,
     instructions: &'a str,
     permission: crate::config::PermissionCapability,
     prompt: &'a str,
@@ -1463,6 +1710,7 @@ fn backend_request<'a>(
         session_id,
         is_new,
         work_dir,
+        additional_write_dir,
         instructions,
         permission,
         prompt,
@@ -1554,7 +1802,7 @@ pub(crate) mod tests {
     use crate::agent::{FakeRunCall, FakeRunner};
     use crate::channel::{normalize_handle, thread_handle};
     use crate::imessage::{Poller, Sender};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use uuid::Uuid;
 
@@ -1708,6 +1956,11 @@ pub(crate) mod tests {
             .unwrap();
         assert_eq!(inbound_id, 1);
         Ctx {
+            cfg: test_config(
+                &temp_path("setup-failure-state").to_string_lossy(),
+                &sessions_dir,
+                "",
+            ),
             store,
             history: Arc::new(Mutex::new(history)),
             ack,
@@ -1740,6 +1993,12 @@ pub(crate) mod tests {
             permission: PermissionProfile {
                 name: "restricted".to_string(),
                 capability: crate::config::PermissionCapability::ReadOnly,
+            },
+            approval_origin: AnswerOrigin {
+                channel: "imessage".to_string(),
+                thread_key: "imessage:self:me".to_string(),
+                sender_key: "me@icloud.com".to_string(),
+                chat_key: "me@icloud.com".to_string(),
             },
             text: "hello".to_string(),
         }
@@ -2434,6 +2693,7 @@ pub(crate) mod tests {
                 session_id: "fake-session".to_string(),
                 calls: calls.clone(),
                 before_return: None,
+                failure: None,
                 resume_missing_once: Some(missing),
             }),
         );
@@ -2506,6 +2766,7 @@ pub(crate) mod tests {
                 session_id: "codex-session".to_string(),
                 calls: codex_calls.clone(),
                 before_return: None,
+                failure: None,
                 resume_missing_once: None,
             }),
         );
@@ -2516,6 +2777,7 @@ pub(crate) mod tests {
                 session_id: "claude-session".to_string(),
                 calls: claude_calls.clone(),
                 before_return: None,
+                failure: None,
                 resume_missing_once: None,
             }),
         );
@@ -3187,6 +3449,326 @@ pub(crate) mod tests {
         let _ = std::fs::remove_dir_all(assistant_dir);
     }
 
+    #[tokio::test]
+    async fn route_agent_draft_requires_bound_approval_before_atomic_install() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("draft-e2e-sessions");
+        let assistant_dir = temp_path("draft-e2e-assistant");
+        let workdir = temp_path("draft-e2e-workdir");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        std::fs::create_dir_all(&workdir).unwrap();
+        let mut cfg = test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        );
+        cfg.permission_profile = "workspace".to_string();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut gateway = Gateway::new(cfg.clone()).unwrap();
+        let inbound = message(
+            1,
+            "+15551234567",
+            "+15551234567",
+            false,
+            "Draft a morning job",
+        );
+        let (thread, _) = gateway.channel.accept(&inbound).unwrap();
+        let draft_directory =
+            crate::drafts::origin_directory(&cfg, &approval_origin(&inbound, &thread)).unwrap();
+        let body = format!(
+            "+++\nversion = 1\npermission_profile = \"restricted\"\ntimeout = \"5s\"\nworkdir = {:?}\nbackend = \"codex\"\n+++\n\nPrepare a note.\n",
+            workdir.to_string_lossy()
+        );
+        let hook = Arc::new(move || {
+            std::fs::write(draft_directory.join("agent-note.md"), &body).unwrap();
+        });
+        gateway.ctx.runners = Arc::new(fake_runners_with_hook(calls.clone(), Some(hook)));
+
+        run_messages(&mut gateway, vec![inbound]).await;
+        assert!(!Path::new(&cfg.jobs_dir).join("agent-note.md").exists());
+        let replies = gateway.ctx.sent_replies.lock().unwrap().clone();
+        assert!(replies
+            .iter()
+            .any(|(_, text)| text.contains("Prepare a note.")));
+        let question_text = replies
+            .iter()
+            .find_map(|(_, text)| text.contains("Approve and install").then_some(text))
+            .unwrap();
+        let question_id = question_text
+            .split_whitespace()
+            .map(|part| part.trim_matches(|ch| ch == '`' || ch == ',' || ch == '.'))
+            .find(|part| uuid::Uuid::parse_str(part).is_ok())
+            .unwrap()
+            .to_string();
+
+        run_messages(
+            &mut gateway,
+            vec![message(
+                2,
+                "+15551234567",
+                "+15551234567",
+                false,
+                &format!("{question_id} 1"),
+            )],
+        )
+        .await;
+
+        assert!(Path::new(&cfg.jobs_dir).join("agent-note.md").is_file());
+        assert_eq!(calls.lock().unwrap().len(), 1);
+        let proposal = gateway
+            .ctx
+            .history
+            .lock()
+            .unwrap()
+            .draft_proposal(&question_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(proposal.status, "installed");
+        assert!(proposal.proposed_by.contains("sender=15551234567"));
+        assert!(proposal
+            .approved_by
+            .as_deref()
+            .unwrap()
+            .contains("sender=15551234567"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_origins_present_only_their_isolated_drafts() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("draft-concurrent-sessions");
+        let assistant_dir = temp_path("draft-concurrent-assistant");
+        let workdir = temp_path("draft-concurrent-workdir");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        std::fs::create_dir_all(&workdir).unwrap();
+        let mut cfg = test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        );
+        cfg.permission_profile = "workspace".to_string();
+        let gateway = Gateway::new(cfg.clone()).unwrap();
+        let first_origin = AnswerOrigin {
+            channel: "imessage".to_string(),
+            thread_key: "imessage:dm:111".to_string(),
+            sender_key: "111".to_string(),
+            chat_key: "111".to_string(),
+        };
+        let second_origin = AnswerOrigin {
+            channel: "imessage".to_string(),
+            thread_key: "imessage:dm:222".to_string(),
+            sender_key: "222".to_string(),
+            chat_key: "222".to_string(),
+        };
+        let first_dir = crate::drafts::origin_directory(&cfg, &first_origin).unwrap();
+        let second_dir = crate::drafts::origin_directory(&cfg, &second_origin).unwrap();
+        assert_ne!(first_dir, second_dir);
+        std::fs::write(
+            first_dir.join("first.md"),
+            draft_runbook(&workdir, "FIRST ONLY"),
+        )
+        .unwrap();
+        std::fs::write(
+            second_dir.join("second.md"),
+            draft_runbook(&workdir, "SECOND ONLY"),
+        )
+        .unwrap();
+        let first = draft_test_job(1, "111", first_origin);
+        let second = draft_test_job(2, "222", second_origin);
+
+        let (first_result, second_result) = tokio::join!(
+            present_drafts(&gateway.ctx, &first, &first_dir),
+            present_drafts(&gateway.ctx, &second, &second_dir),
+        );
+        first_result.unwrap();
+        second_result.unwrap();
+
+        let replies = gateway.ctx.sent_replies.lock().unwrap();
+        let first_replies = replies
+            .iter()
+            .filter(|(target, _)| target == "111")
+            .map(|(_, text)| text)
+            .collect::<Vec<_>>();
+        let second_replies = replies
+            .iter()
+            .filter(|(target, _)| target == "222")
+            .map(|(_, text)| text)
+            .collect::<Vec<_>>();
+        assert!(first_replies.iter().any(|text| text.contains("FIRST ONLY")));
+        assert!(!first_replies
+            .iter()
+            .any(|text| text.contains("SECOND ONLY")));
+        assert!(second_replies
+            .iter()
+            .any(|text| text.contains("SECOND ONLY")));
+        assert!(!second_replies
+            .iter()
+            .any(|text| text.contains("FIRST ONLY")));
+    }
+
+    #[tokio::test]
+    async fn failed_run_and_recovered_outbound_still_reconcile_origin_drafts() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("draft-failure-sessions");
+        let assistant_dir = temp_path("draft-failure-assistant");
+        let workdir = temp_path("draft-failure-workdir");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        std::fs::create_dir_all(&workdir).unwrap();
+        let mut cfg = test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        );
+        cfg.permission_profile = "workspace".to_string();
+        let mut gateway = Gateway::new(cfg.clone()).unwrap();
+        let failed_message = message(1, "+15551234567", "+15551234567", false, "draft then fail");
+        let (thread, _) = gateway.channel.accept(&failed_message).unwrap();
+        let directory =
+            crate::drafts::origin_directory(&cfg, &approval_origin(&failed_message, &thread))
+                .unwrap();
+        let failed_body = draft_runbook(&workdir, "CREATED BEFORE FAILURE");
+        let hook = Arc::new(move || {
+            std::fs::write(directory.join("failed-run.md"), &failed_body).unwrap();
+        });
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut runners = HashMap::new();
+        runners.insert(
+            AgentBackend::Codex,
+            Runner::Fake(FakeRunner {
+                backend: AgentBackend::Codex,
+                session_id: "failed-session".to_string(),
+                calls: calls.clone(),
+                before_return: Some(hook),
+                failure: Some("boom".to_string()),
+                resume_missing_once: None,
+            }),
+        );
+        gateway.ctx.runners = Arc::new(runners);
+
+        run_messages(&mut gateway, vec![failed_message]).await;
+        let replies = gateway.ctx.sent_replies.lock().unwrap().clone();
+        assert!(replies
+            .iter()
+            .any(|(_, text)| text.contains("CREATED BEFORE FAILURE")));
+        assert!(replies.iter().any(|(_, text)| text.contains("boom")));
+        assert_eq!(calls.lock().unwrap().len(), 1);
+
+        let recovered_message = message(2, "+15551234567", "+15551234567", false, "crash window");
+        let (recovered_thread, _) = gateway.channel.accept(&recovered_message).unwrap();
+        let recovered_dir = crate::drafts::origin_directory(
+            &cfg,
+            &approval_origin(&recovered_message, &recovered_thread),
+        )
+        .unwrap();
+        std::fs::write(
+            recovered_dir.join("recovered.md"),
+            draft_runbook(&workdir, "RECOVERED AFTER CRASH"),
+        )
+        .unwrap();
+        let inbound_id = gateway
+            .ctx
+            .history
+            .lock()
+            .unwrap()
+            .record_inbound(
+                recovered_message.channel,
+                &recovered_thread,
+                &recovered_message.event_id(),
+                recovered_message.text.trim(),
+            )
+            .unwrap();
+        gateway
+            .ctx
+            .history
+            .lock()
+            .unwrap()
+            .record_outbound(
+                inbound_id,
+                OutboundOrigin::Backend,
+                Some("codex"),
+                "stored before crash",
+            )
+            .unwrap();
+        run_messages(&mut gateway, vec![recovered_message]).await;
+        let replies = gateway.ctx.sent_replies.lock().unwrap();
+        assert!(replies
+            .iter()
+            .any(|(_, text)| text.contains("RECOVERED AFTER CRASH")));
+        assert_eq!(calls.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn failed_draft_delivery_retries_after_restart_before_expiry() {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path("draft-delivery-sessions");
+        let assistant_dir = temp_path("draft-delivery-assistant");
+        let workdir = temp_path("draft-delivery-workdir");
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        std::fs::create_dir_all(&workdir).unwrap();
+        let mut cfg = test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        );
+        cfg.permission_profile = "workspace".to_string();
+        let origin = AnswerOrigin {
+            channel: "imessage".to_string(),
+            thread_key: "imessage:dm:15551234567".to_string(),
+            sender_key: "15551234567".to_string(),
+            chat_key: "15551234567".to_string(),
+        };
+        let directory = crate::drafts::origin_directory(&cfg, &origin).unwrap();
+        std::fs::write(
+            directory.join("retry.md"),
+            draft_runbook(&workdir, "RETRY THIS OFFER"),
+        )
+        .unwrap();
+        let job = draft_test_job(1, "+15551234567", origin);
+        let gateway = Gateway::new(cfg.clone()).unwrap();
+        *gateway.ctx.send_failures_remaining.lock().unwrap() = DELIVERY_ATTEMPTS;
+
+        assert!(present_drafts(&gateway.ctx, &job, &directory)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("retry before expiry"));
+        drop(gateway);
+
+        let restarted = Gateway::new(cfg).unwrap();
+        present_drafts(&restarted.ctx, &job, &directory)
+            .await
+            .unwrap();
+        let replies = restarted.ctx.sent_replies.lock().unwrap();
+        assert!(replies
+            .iter()
+            .any(|(_, text)| text.contains("RETRY THIS OFFER")));
+        assert!(replies
+            .iter()
+            .any(|(_, text)| text.contains("Approve and install")));
+    }
+
+    fn draft_runbook(workdir: &Path, instruction: &str) -> String {
+        format!(
+            "+++\nversion = 1\npermission_profile = \"restricted\"\ntimeout = \"5s\"\nworkdir = {:?}\nbackend = \"codex\"\n+++\n\n{instruction}\n",
+            workdir.to_string_lossy()
+        )
+    }
+
+    fn draft_test_job(row_id: i64, target: &str, origin: AnswerOrigin) -> Job {
+        Job {
+            row_id,
+            inbound_id: row_id,
+            thread: origin.thread_key.clone(),
+            target: target.to_string(),
+            backend: AgentBackend::Codex,
+            permission: PermissionProfile {
+                name: "workspace".to_string(),
+                capability: crate::config::PermissionCapability::Workspace,
+            },
+            approval_origin: origin,
+            text: "draft".to_string(),
+        }
+    }
+
     fn test_config(state_path: &str, sessions_dir: &str, assistant_dir: &str) -> Config {
         Config {
             channel: "imessage".to_string(),
@@ -3207,6 +3789,7 @@ pub(crate) mod tests {
             job_permission_profiles: vec!["restricted".to_string()],
             permission_profiles: HashMap::new(),
             jobs_dir: format!("{state_path}.jobs"),
+            drafts_dir: format!("{state_path}.drafts"),
             jobs_agent: None,
             jobs_max_timeout: "30m".to_string(),
             jobs_run_dir: format!("{state_path}.run"),
@@ -3256,6 +3839,7 @@ pub(crate) mod tests {
                 session_id: "fake-session".to_string(),
                 calls,
                 before_return,
+                failure: None,
                 resume_missing_once: None,
             }),
         );

--- a/src/history.rs
+++ b/src/history.rs
@@ -11,7 +11,7 @@ use crate::approval::{
     NormalizedAnswer, Question, QuestionState,
 };
 
-const SCHEMA_VERSION: i64 = 4;
+const SCHEMA_VERSION: i64 = 5;
 const MAX_HISTORY_READ_BYTES: usize = 8 * 1024;
 const READ_TRUNCATED: &str = "\n[truncated by push while reading history]";
 
@@ -82,6 +82,18 @@ impl ConversationRole {
 pub struct ConversationMessage {
     pub role: ConversationRole,
     pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DraftProposal {
+    pub question_id: String,
+    pub name: String,
+    pub path: String,
+    pub snapshot_hash: String,
+    pub contents: String,
+    pub proposed_by: String,
+    pub approved_by: Option<String>,
+    pub status: String,
 }
 
 pub struct History {
@@ -285,6 +297,228 @@ impl History {
                 question.expires_at_ms,
             ],
         )?;
+        Ok(())
+    }
+
+    pub fn create_draft_question(
+        &mut self,
+        question: &Question,
+        proposal: &DraftProposal,
+        now_ms: i64,
+    ) -> Result<bool> {
+        question.validate()?;
+        if proposal.question_id != question.id {
+            bail!("draft proposal question id does not match approval question");
+        }
+        if question.expires_at_ms <= now_ms {
+            bail!("approval question expiry must be in the future");
+        }
+        let choices = serde_json::to_string(&question.choices)?;
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "INSERT INTO approval_questions (
+                id, channel, thread_key, sender_key, chat_key, target,
+                prompt, choices_json, expires_at_ms, status, delivery_status
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'pending', 'pending')",
+            params![
+                question.id,
+                question.channel,
+                question.thread_key,
+                question.sender_key,
+                question.chat_key,
+                question.target,
+                question.prompt,
+                choices,
+                question.expires_at_ms,
+            ],
+        )?;
+        let inserted = tx.execute(
+            "INSERT INTO job_draft_proposals (
+                question_id, name, path, snapshot_hash, contents, proposed_by,
+                proposed_channel, proposed_thread, proposed_sender, proposed_chat,
+                status, proposed_at_ms
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'pending', ?11)
+             ON CONFLICT(path, snapshot_hash) DO NOTHING",
+            params![
+                proposal.question_id,
+                proposal.name,
+                proposal.path,
+                proposal.snapshot_hash,
+                proposal.contents,
+                proposal.proposed_by,
+                question.channel,
+                question.thread_key,
+                question.sender_key,
+                question.chat_key,
+                now_ms,
+            ],
+        )?;
+        if inserted == 0 {
+            tx.rollback()?;
+            return Ok(false);
+        }
+        tx.commit()?;
+        Ok(true)
+    }
+
+    pub fn draft_proposal(&self, question_id: &str) -> Result<Option<DraftProposal>> {
+        self.conn
+            .query_row(
+                "SELECT question_id, name, path, snapshot_hash, contents, proposed_by, approved_by, status
+                 FROM job_draft_proposals WHERE question_id = ?1",
+                [question_id],
+                |row| {
+                    Ok(DraftProposal {
+                        question_id: row.get(0)?,
+                        name: row.get(1)?,
+                        path: row.get(2)?,
+                        snapshot_hash: row.get(3)?,
+                        contents: row.get(4)?,
+                        proposed_by: row.get(5)?,
+                        approved_by: row.get(6)?,
+                        status: row.get(7)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    pub fn draft_revision(
+        &self,
+        path: &Path,
+        snapshot_hash: &str,
+    ) -> Result<Option<DraftProposal>> {
+        self.conn
+            .query_row(
+                "SELECT question_id, name, path, snapshot_hash, contents, proposed_by,
+                        approved_by, status
+                 FROM job_draft_proposals WHERE path = ?1 AND snapshot_hash = ?2",
+                params![path.to_string_lossy(), snapshot_hash],
+                |row| {
+                    Ok(DraftProposal {
+                        question_id: row.get(0)?,
+                        name: row.get(1)?,
+                        path: row.get(2)?,
+                        snapshot_hash: row.get(3)?,
+                        contents: row.get(4)?,
+                        proposed_by: row.get(5)?,
+                        approved_by: row.get(6)?,
+                        status: row.get(7)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    pub fn pending_draft_question(
+        &self,
+        question_id: &str,
+        now_ms: i64,
+    ) -> Result<Option<Question>> {
+        self.conn
+            .query_row(
+                "SELECT channel, thread_key, sender_key, chat_key, target, prompt,
+                        choices_json, expires_at_ms
+                 FROM approval_questions
+                 WHERE id = ?1 AND status = 'pending' AND expires_at_ms > ?2
+                   AND delivery_status IN ('pending', 'failed')",
+                params![question_id, now_ms],
+                |row| {
+                    let choices: String = row.get(6)?;
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, String>(5)?,
+                        choices,
+                        row.get::<_, i64>(7)?,
+                    ))
+                },
+            )
+            .optional()?
+            .map(
+                |(
+                    channel,
+                    thread_key,
+                    sender_key,
+                    chat_key,
+                    target,
+                    prompt,
+                    choices,
+                    expires_at_ms,
+                )| {
+                    Ok(Question {
+                        id: question_id.to_string(),
+                        channel,
+                        thread_key,
+                        sender_key,
+                        chat_key,
+                        target,
+                        prompt,
+                        choices: serde_json::from_str(&choices)?,
+                        expires_at_ms,
+                    })
+                },
+            )
+            .transpose()
+    }
+
+    pub fn draft_answer(&self, question_id: &str) -> Result<Option<NormalizedAnswer>> {
+        let row = self
+            .conn
+            .query_row(
+                "SELECT choices_json, answer_index FROM approval_questions
+                 WHERE id = ?1 AND status = 'answered'",
+                [question_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .optional()?;
+        let Some((choices, selected_number)) = row else {
+            return Ok(None);
+        };
+        let choices: Vec<crate::approval::Choice> = serde_json::from_str(&choices)?;
+        let choice = choices
+            .get(selected_number.saturating_sub(1) as usize)
+            .context("stored draft approval answer index is invalid")?;
+        Ok(Some(NormalizedAnswer {
+            correlation_id: question_id.to_string(),
+            selected_number: selected_number as usize,
+            value: choice.value.clone(),
+        }))
+    }
+
+    pub fn finish_draft_decision(
+        &mut self,
+        question_id: &str,
+        status: &str,
+        approved_by: Option<&str>,
+        error: Option<&str>,
+        now_ms: i64,
+    ) -> Result<()> {
+        if !matches!(status, "installed" | "rejected" | "invalidated" | "failed") {
+            bail!("invalid draft proposal terminal status {status:?}");
+        }
+        let tx = self.conn.transaction()?;
+        let changed = tx.execute(
+            "UPDATE job_draft_proposals
+             SET status = ?2, approved_by = ?3, decision_at_ms = ?4, error = ?5
+             WHERE question_id = ?1 AND status = 'pending'",
+            params![question_id, status, approved_by, now_ms, error],
+        )?;
+        if changed != 1 {
+            bail!("pending draft proposal {question_id:?} does not exist");
+        }
+        tx.execute(
+            "UPDATE approval_questions
+             SET status = 'consumed', consumed_at_ms = ?2, updated_at_ms = ?2
+             WHERE id = ?1 AND status = 'answered'",
+            params![question_id, now_ms],
+        )?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -657,6 +891,33 @@ fn migrate(conn: &Connection) -> Result<()> {
              PRAGMA user_version = 4;",
         )?;
     }
+    if version <= 4 {
+        conn.execute_batch(
+            "CREATE TABLE job_draft_proposals (
+                 question_id TEXT PRIMARY KEY REFERENCES approval_questions(id),
+                 name TEXT NOT NULL,
+                 path TEXT NOT NULL,
+                 snapshot_hash TEXT NOT NULL,
+                 contents TEXT NOT NULL,
+                 proposed_by TEXT NOT NULL,
+                 proposed_channel TEXT NOT NULL,
+                 proposed_thread TEXT NOT NULL,
+                 proposed_sender TEXT NOT NULL,
+                 proposed_chat TEXT NOT NULL,
+                 approved_by TEXT,
+                 status TEXT NOT NULL CHECK(status IN (
+                     'pending', 'installed', 'rejected', 'invalidated', 'failed'
+                 )),
+                 proposed_at_ms INTEGER NOT NULL,
+                 decision_at_ms INTEGER,
+                 error TEXT,
+                 UNIQUE(path, snapshot_hash)
+             );
+             CREATE INDEX job_draft_proposals_status_idx
+                 ON job_draft_proposals(status, proposed_at_ms);
+             PRAGMA user_version = 5;",
+        )?;
+    }
     conn.execute_batch("COMMIT;")?;
     Ok(())
 }
@@ -781,7 +1042,7 @@ mod tests {
             .record_inbound("imessage", "imessage:self:me", "imessage:1", "hello")
             .unwrap();
         history.execute_batch_for_test(
-            "DROP TABLE job_runs; DROP TABLE approval_questions; PRAGMA user_version = 1;",
+            "DROP TABLE job_draft_proposals; DROP TABLE job_runs; DROP TABLE approval_questions; PRAGMA user_version = 1;",
         );
         drop(history);
 
@@ -805,7 +1066,9 @@ mod tests {
         let mut history = History::open(path.to_str().unwrap()).unwrap();
         let question = question(2_000);
         history.create_question(&question, 1_000).unwrap();
-        history.execute_batch_for_test("DROP TABLE job_runs; PRAGMA user_version = 2;");
+        history.execute_batch_for_test(
+            "DROP TABLE job_draft_proposals; DROP TABLE job_runs; PRAGMA user_version = 2;",
+        );
         drop(history);
 
         let mut reopened = History::open(path.to_str().unwrap()).unwrap();

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -163,7 +163,17 @@ fn load_file(cfg: &Config, name: &str, path: &Path) -> Result<Job> {
     let mut bytes = Vec::new();
     file.read_to_end(&mut bytes)
         .with_context(|| format!("read job {}", path.display()))?;
-    let text = std::str::from_utf8(&bytes).context("job must be valid UTF-8")?;
+    validate_contents(cfg, name, path, &bytes)
+}
+
+pub(crate) fn validate_contents(
+    cfg: &Config,
+    name: &str,
+    path: &Path,
+    bytes: &[u8],
+) -> Result<Job> {
+    validate_slug(name)?;
+    let text = std::str::from_utf8(bytes).context("job must be valid UTF-8")?;
     let (frontmatter, body) = split_runbook(text)?;
     let metadata: Frontmatter = toml::from_str(frontmatter).context("parse TOML frontmatter")?;
     if metadata.version != 1 {
@@ -189,7 +199,8 @@ fn load_file(cfg: &Config, name: &str, path: &Path) -> Result<Job> {
         .transpose()?
         .unwrap_or(cfg.jobs_backend()?);
     let workdir = canonical_workdir(&metadata.workdir)?;
-    let snapshot_hash = format!("{:x}", Sha256::digest(&bytes));
+    cfg.validate_job_workdir(&workdir, permission.capability)?;
+    let snapshot_hash = format!("{:x}", Sha256::digest(bytes));
     Ok(Job {
         name: name.to_string(),
         path: path.to_path_buf(),
@@ -241,7 +252,7 @@ fn job_name(path: &Path) -> Result<String> {
     Ok(name.to_string())
 }
 
-fn validate_slug(value: &str) -> Result<()> {
+pub(crate) fn validate_slug(value: &str) -> Result<()> {
     if value.is_empty()
         || value.starts_with('-')
         || value.ends_with('-')
@@ -1212,6 +1223,7 @@ async fn execute(cfg: &Config, job: &Job) -> std::result::Result<String, Executi
         session_id: &session_id,
         is_new: true,
         work_dir: &workdir,
+        additional_write_dir: None,
         instructions: &instructions,
         permission: job.permission.capability,
         prompt: &job.body,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod channel;
 mod claude;
 mod codex;
 mod config;
+mod drafts;
 mod gateway;
 mod history;
 mod imessage;
@@ -257,6 +258,7 @@ fn run_checks(cfg: &config::Config) -> CheckReport {
     check_config(cfg, &mut checks);
     check_state_dir(cfg, &mut checks);
     check_sessions_dir(cfg, &mut checks);
+    check_drafts_dir(cfg, &mut checks);
     check_audit_log_dir(cfg, &mut checks);
     check_history_database(cfg, &mut checks);
     match cfg.enabled_channel_kinds() {
@@ -326,6 +328,22 @@ fn check_sessions_dir(cfg: &config::Config, checks: &mut Vec<Check>) {
             format!(
                 "cannot create {}: {e}. Create it or choose a writable sessions_dir.",
                 cfg.sessions_dir
+            ),
+        )),
+    }
+}
+
+fn check_drafts_dir(cfg: &config::Config, checks: &mut Vec<Check>) {
+    match drafts::prepare(cfg) {
+        Ok(()) => checks.push(Check::pass(
+            "drafts directory",
+            format!("{} is writable and protected", cfg.drafts_dir),
+        )),
+        Err(error) => checks.push(Check::fail(
+            "drafts directory",
+            format!(
+                "cannot prepare {}: {error}. Create it with owner-only permissions or choose a writable drafts_dir.",
+                cfg.drafts_dir
             ),
         )),
     }
@@ -1255,6 +1273,7 @@ capability = "workspace"
             job_permission_profiles: vec!["restricted".to_string()],
             permission_profiles: std::collections::HashMap::new(),
             jobs_dir: "/fake/jobs".to_string(),
+            drafts_dir: "/fake/drafts".to_string(),
             jobs_agent: None,
             jobs_max_timeout: "30m".to_string(),
             jobs_run_dir: "/fake/run".to_string(),

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -85,6 +85,7 @@ impl ContractRequest {
             session_id: &self.session_id,
             is_new: self.is_new,
             work_dir: self.work_dir.to_str().unwrap(),
+            additional_write_dir: None,
             instructions: &self.instructions,
             permission: self.permission,
             prompt: &self.prompt,


### PR DESCRIPTION
## Summary

- add identity-isolated agent draft inboxes under `drafts_dir`
- grant only workspace routes their exact inbox as an extra writable root
- reject full-access routes and jobs plus Push-owned path overlap
- persist exact proposal bytes, revision, proposer, approver, and decision state
- present full validated drafts through bound `ask_user` approvals
- revalidate revisions and capability ceilings before atomic no-clobber install
- reconcile drafts after success, failure, timeout, delivery failure, and restart
- document the drafted-job security and recovery model

## Why

Issue #64 requires agents to propose jobs without activating schedules or granting themselves permissions. Approval must remain bound to the allowlisted identity and exact revision across concurrency and restart boundaries.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (187 unit tests and 3 integration tests)
- focused concurrent-origin isolation, failed-run, recovered-outbound, delivery-retry, revision-race, symlink, path-escape, permission-escalation, duplicate-approval, and replacement-safe cleanup tests
- `git diff --check`
- independent complete-diff review with all findings resolved and no remaining actionable findings

## Risks

This tightens unattended execution by rejecting full-access routes and jobs, because backend bypass modes cannot protect installed jobs, configuration, identity, or state. Existing configurations using full-access for those paths must choose a contained profile. Filesystem installation is staged inside `jobs_dir`, uses an atomic no-clobber link, and has restart reconciliation coverage.

## Related issue

Closes #64.
