### PR TITLE
docs: capitalize Push product name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# push
+# Push
 
-push is a tiny personal assistant gateway. You text it, it sends the message to
+Push is a tiny personal assistant gateway. You text it, it sends the message to
 a configured coding-agent runtime, then it sends the answer back.
 
 The product is the gateway: messaging, allowlists, routing, assistant identity,
@@ -10,7 +10,7 @@ Claude Code and Codex are the first two backends.
 ## How it works
 
 ```text
-iMessage or Telegram -> push gateway -> Claude Code or Codex -> same-channel reply
+iMessage or Telegram -> Push gateway -> Claude Code or Codex -> same-channel reply
 ```
 
 1. Poll `~/Library/Messages/chat.db` or the Telegram Bot API for new messages.
@@ -30,11 +30,11 @@ Coding agents are becoming commodity runtimes. Claude Code, Codex, Cursor, AMP,
 Pi-style agents, and independent agents all compete on the same layer: tool use,
 repo edits, command execution, MCP, plugins, model choice, and coding workflow.
 
-push does not try to win that layer. It treats those agents as workers behind a
+Push does not try to win that layer. It treats those agents as workers behind a
 small contract: given this user message and assistant context, produce the reply
 or task result that should be sent back.
 
-push owns the personal assistant layer:
+Push owns the personal assistant layer:
 
 - Message ingress and egress.
 - Sender allowlists and reply loop prevention.
@@ -44,7 +44,7 @@ push owns the personal assistant layer:
 
 The framing is personal assistant first, coding agent second. The backend may be
 Claude Code today and Codex tomorrow, but the assistant identity, memory, and
-messaging relationship stay with push.
+messaging relationship stay with Push.
 
 See [docs/strategy.md](docs/strategy.md) for the full direction.
 
@@ -112,25 +112,25 @@ back through the same channel and conversation.
 channel's requirements. Telegram-only use does not need Messages, `chat.db`, or
 `osascript`.
 
-To run push continuously, see [Running push as a Service](docs/services.md) for
+To run Push continuously, see [Running Push as a Service](docs/services.md) for
 macOS `launchd`, Linux `systemd` where supported, logs, restart behavior, and
 headless security notes.
 
 ## iMessage Support
 
-push supports one-to-one iMessage conversations: self-chat and allowlisted
+Push supports one-to-one iMessage conversations: self-chat and allowlisted
 direct messages. Group chats are not supported in v1 and are ignored.
 
 The iMessage channel reads `~/Library/Messages/chat.db` directly, so the process
 needs Full Disk Access on macOS. It assumes the recent macOS Messages schema with
 `message`, `handle`, `chat`, `chat_message_join`, and `chat_handle_join` tables;
 `push doctor` and the runtime report database access or query failures. Tapbacks,
-system rows, blank messages, messages from non-allowlisted senders, and push's
+system rows, blank messages, messages from non-allowlisted senders, and Push's
 own marked replies are ignored. Phone numbers are matched after removing
 formatting, and email handles are matched case-insensitively.
 
 `state.json` stores the last completed Messages row and backend sessions. On
-restart, push resumes after the last completed row and keeps existing backend
+restart, Push resumes after the last completed row and keeps existing backend
 sessions when the selected backend has not changed.
 
 `push.db` is the canonical conversation journal. It stores accepted inbound
@@ -164,7 +164,7 @@ audit state without entering the conversation transcript used for rehydration.
 
 ## Telegram Support
 
-Telegram uses Bot API long polling, so push opens no public port and needs no
+Telegram uses Bot API long polling, so Push opens no public port and needs no
 webhook server. Private chats are supported first. Group chats, forum topics,
 and non-text updates are ignored before they can reach the agent. Replies go to
 the chat that originated the accepted message. Replies up to Telegram's 32,768
@@ -330,7 +330,7 @@ Backend translation is intentionally conservative:
 - `workspace`: Claude gets read and file-edit tools but no Bash because Claude
   Code has no equivalent to Codex filesystem sandboxing; Codex uses
   `workspace-write` with approvals disabled.
-- `full-access`: maps to backend bypass modes, but push rejects it for
+- `full-access`: maps to backend bypass modes, but Push rejects it for
   unattended routes and jobs because it cannot protect installed jobs,
   configuration, or state from direct writes.
 
@@ -435,18 +435,18 @@ before installing from the stored bytes with an atomic no-clobber operation.
 Any edit after presentation invalidates the approval. Rejection leaves the file
 inactive in `drafts_dir`; duplicate answers cannot install twice.
 
-push reads TOML only. Convert any earlier `config.json` file to `config.toml`
+Push reads TOML only. Convert any earlier `config.json` file to `config.toml`
 before upgrading. The old JSON filename remains gitignored to reduce the risk
 of committing a config that contains credentials.
 
 ## Assistant Identity and Migration
 
-`SOUL.md` is the only assistant identity source. By default push reads
+`SOUL.md` is the only assistant identity source. By default Push reads
 `~/.push/SOUL.md`; set `assistant_dir` to keep the file elsewhere. Push reads
 the file for every run, appends its own invariant instructions in memory, and
 never creates or rewrites `SOUL.md`.
 
-If `SOUL.md` is missing, backend runs continue with only push's invariants and
+If `SOUL.md` is missing, backend runs continue with only Push's invariants and
 no custom identity. Copy any identity, preferences, or stable context that you
 want to preserve from the old `[assistant]`, `User.md`, and `Memory.md` inputs
 into `SOUL.md`. Old context files are not loaded, and a remaining `[assistant]`
@@ -470,7 +470,7 @@ enforcement differs and an allowed sender controls the request.
 
 ## Audit Log
 
-push writes a structured JSONL audit log to `audit_log_path`, which defaults to
+Push writes a structured JSONL audit log to `audit_log_path`, which defaults to
 `~/.push/audit.jsonl`. Each line is one event, such as `message_accepted`,
 `message_ignored`, `backend_run_started`, `backend_run_failed`, `reply_sent`, or
 `message_completed`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
-# push Architecture
+# Push Architecture
 
-push is one local Rust process. It polls one or more configured iMessage and
+Push is one local Rust process. It polls one or more configured iMessage and
 Telegram channels, filters messages,
 loads the assistant identity, runs a configured agent backend, and sends the
 final reply.
@@ -17,7 +17,7 @@ The gateway owns the personal assistant state. The backend owns execution.
 
 ### 1. Gateway First
 
-push is a messaging gateway for a personal assistant. It should stay small and
+Push is a messaging gateway for a personal assistant. It should stay small and
 own the durable pieces:
 
 - channels
@@ -46,7 +46,7 @@ Those belong to the selected backend.
 
 ### 3. Polling Only
 
-push polls channel state and shells out to local agent commands. It opens no
+Push polls channel state and shells out to local agent commands. It opens no
 server port and accepts no inbound network connection. Telegram uses outbound
 HTTPS long polling.
 
@@ -61,7 +61,7 @@ flowchart LR
     user -->|private chat| tg[Telegram Bot API]
     db -->|poll| push
     tg -->|long poll| push
-    subgraph push[push gateway]
+    subgraph push[Push gateway]
         poller[Channel poller] --> gateway[Gateway loop]
         gateway --> worker[Per-thread worker]
         store[(state.json)] <--> gateway
@@ -147,7 +147,7 @@ rehydration. Audit metadata records the rehydrated message count.
 
 ### Claude Code Adapter
 
-Claude Code lets push choose the session id.
+Claude Code lets Push choose the session id.
 
 - New conversation: `claude -p --session-id <uuid>`
 - Existing conversation: `claude -p --resume <uuid>`
@@ -191,7 +191,7 @@ stores that id for future turns.
 field named `uuid` also remains for compatibility, but it
 now means "backend session id".
 
-If the configured backend changes for a thread, push starts a fresh backend
+If the configured backend changes for a thread, Push starts a fresh backend
 session instead of trying to resume the old runtime's session.
 
 With advanced `channels = ["imessage", "telegram"]` configuration, one
@@ -270,7 +270,7 @@ content logging.
 
 ## Assistant Identity
 
-push loads only `SOUL.md` from `assistant_dir`, which defaults to `~/.push`.
+Push loads only `SOUL.md` from `assistant_dir`, which defaults to `~/.push`.
 The gateway appends invariants in memory without changing the file, then injects
 the result at instruction priority. Missing `SOUL.md` means no custom identity;
 backend runs continue with the gateway invariants. The backend still owns how

--- a/docs/core-system/design.md
+++ b/docs/core-system/design.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-push is a local personal-assistant gateway. It owns channels, identity,
+Push is a local personal-assistant gateway. It owns channels, identity,
 conversation history, routing, permissions, scheduling, and delivery while
 delegating reasoning and tool use to disposable agent runtimes such as Claude
 Code and Codex. The first durable assistant model has two parts: a user-owned
@@ -18,7 +18,7 @@ outside the first implementation.
 ## Goals
 
 - Keep one assistant identity across channels and agent backends.
-- Make push, rather than a backend vendor, the owner of conversation history.
+- Make Push, rather than a backend vendor, the owner of conversation history.
 - Keep identity legible and directly editable in one Markdown file.
 - Preserve existing backend sessions as a fast path without depending on them
   for durable history.
@@ -34,12 +34,12 @@ outside the first implementation.
 - Make agent filesystem isolation part of this change. Agent writes to assistant
   files are forbidden by contract; enforceable isolation follows with
   permission profiles.
-- Build a custom agent loop, tool runner, plugin system, or MCP layer in push.
+- Build a custom agent loop, tool runner, plugin system, or MCP layer in Push.
 - Define scheduled jobs, approval flows, or autonomous memory write-back here.
 
 ## Constraints
 
-- push remains one local Rust process with no inbound server port.
+- Push remains one local Rust process with no inbound server port.
 - Telegram and iMessage conversations must remain channel-qualified.
 - Claude Code and Codex retain different session and instruction mechanisms.
 - A failed history write must not result in an unrecorded request being sent to
@@ -78,7 +78,7 @@ of assistant identity. The default assistant directory becomes `~/.push`. The
 file contains personality, communication style, principles, and stable
 behavioural boundaries. Identity does not live in TOML fields.
 
-At runtime, push composes the file with a gateway-owned footer rather than
+At runtime, Push composes the file with a gateway-owned footer rather than
 modifying it on disk:
 
 ```text
@@ -94,7 +94,7 @@ the composed text as appended system instructions. Codex receives it as
 developer instructions. This is the only intended backend-specific handling
 for identity injection.
 
-push owns the footer so customising `SOUL.md` cannot accidentally disconnect
+Push owns the footer so customising `SOUL.md` cannot accidentally disconnect
 the assistant from durable memory. The footer tells backends not to modify
 assistant files, but this is guidance rather than a filesystem security
 boundary under the current permission modes. Enforceable read-only access
@@ -132,14 +132,14 @@ The exact schema is an implementation decision, but these invariants are not:
 - Backend replies, local command replies, and user-visible error replies are
   stored with their origin.
 - An assistant response is stored after the backend returns a valid reply and
-  before push attempts delivery.
+  before Push attempts delivery.
 - Delivery status is recorded separately from response generation so a retry
   does not invent a second assistant turn.
 - Existing `state.json` cursor and backend-session behaviour remains unchanged
   in this phase. Moving gateway state into SQLite is a separate decision.
 
-On a normal turn, push resumes the existing backend session and sends only the
-new request. When a backend session is missing, cleared, or replaced, push may
+On a normal turn, Push resumes the existing backend session and sends only the
+new request. When a backend session is missing, cleared, or replaced, Push may
 rehydrate a new session from recent canonical history. Rehydration policy is a
 performance decision and is not required for the initial history store.
 
@@ -180,7 +180,7 @@ execution loops remain backend-owned.
 ### `User.md` plus `Memory.md` injected on every turn
 
 This is legible but mixes user facts, assistant identity, and memory policy. It
-also leaves push without a complete history from which memory can be audited or
+also leaves Push without a complete history from which memory can be audited or
 rebuilt. A single `SOUL.md` gives identity one clear owner.
 
 ### Append every exchange to `JOURNAL.md`

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,8 +1,8 @@
-# push v1 PRD
+# Push v1 PRD
 
 ## Summary
 
-push is a small Rust binary that turns coding-agent runtimes into a personal
+Push is a small Rust binary that turns coding-agent runtimes into a personal
 assistant you can text.
 
 It polls iMessage, filters allowed senders, loads user-owned assistant context,
@@ -55,9 +55,9 @@ Hermes and similar projects build more of the runtime: memory databases,
 summarizers, skills, subagents, schedulers, provider abstractions, and custom
 agent behavior.
 
-push takes a narrower bet:
+Push takes a narrower bet:
 
-| Area | Hermes-style product | push |
+| Area | Hermes-style product | Push |
 |---|---|---|
 | Runtime | Built into the product | External backend |
 | Tools | Product-owned | Backend-owned |
@@ -69,13 +69,13 @@ push takes a narrower bet:
 ## Core User Flow
 
 1. User sends a text.
-2. push reads the new row from `chat.db`.
-3. push filters by allowlist and reply marker.
-4. push loads assistant context.
-5. push resolves the thread's backend session.
-6. push runs Claude Code or Codex.
-7. push sends the final reply back over iMessage.
-8. push stores the latest message row and backend session state.
+2. Push reads the new row from `chat.db`.
+3. Push filters by allowlist and reply marker.
+4. Push loads assistant context.
+5. Push resolves the thread's backend session.
+6. Push runs Claude Code or Codex.
+7. Push sends the final reply back over iMessage.
+8. Push stores the latest message row and backend session state.
 
 ## Components
 
@@ -161,7 +161,7 @@ user prompt.
 | `audit_log_content` | Whether audit events include message and reply text. |
 | `database_path` | Canonical SQLite history path; defaults to `~/.push/push.db`. |
 | `assistant_dir` | Directory with `SOUL.md`; defaults to `~/.push`. |
-| `reply_marker` | Footer used to skip push's own replies. |
+| `reply_marker` | Footer used to skip Push's own replies. |
 
 ## Control Commands
 
@@ -172,8 +172,8 @@ user prompt.
 
 - A configured self-chat message gets a reply.
 - Non-allowlisted senders are ignored.
-- push does not answer messages containing the reply marker.
-- push only advances `last_row_id` after a message is ignored or completed.
+- Push does not answer messages containing the reply marker.
+- Push only advances `last_row_id` after a message is ignored or completed.
 - `/clear` starts a fresh backend session.
 - Claude backend can create and resume a session.
 - Codex backend can create a session, store the Codex thread id, and resume it.

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,4 +1,4 @@
-# Running push as a Service
+# Running Push as a Service
 
 This guide covers running `push` continuously under a process manager.
 
@@ -121,7 +121,7 @@ Create `~/.config/systemd/user/push.service`. You can start from
 
 ```ini
 [Unit]
-Description=push personal assistant gateway
+Description=Push personal assistant gateway
 After=network-online.target
 Wants=network-online.target
 
@@ -182,7 +182,7 @@ allowlisted channel identity. Pending questions survive service restart.
 
 ## Restart Behavior
 
-`push` only advances the selected channel cursor after a message is ignored or
+Push only advances the selected channel cursor after a message is ignored or
 completed. If the process stops during an in-flight backend run, that message
 can be retried after restart. This avoids silently losing accepted messages,
 but it can repeat backend work or send a duplicate reply if the backend

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -1,4 +1,4 @@
-# push Strategy
+# Push Strategy
 
 ## The Bet
 
@@ -9,15 +9,15 @@ open-source agents are all racing to own the same capabilities: reasoning,
 coding, file edits, shell commands, MCP, plugins, permissions, repo context, and
 task execution.
 
-push should not compete there.
+Push should not compete there.
 
-push should own the durable personal assistant layer: messages, identity,
+Push should own the durable personal assistant layer: messages, identity,
 memory, user preferences, business context, routing, and state. The agent
 runtime should be replaceable.
 
 ## Product Thesis
 
-push is a personal assistant gateway, not an agent runtime.
+Push is a personal assistant gateway, not an agent runtime.
 
 The gateway answers these questions:
 
@@ -34,7 +34,7 @@ The backend agent answers a smaller question:
   response should be sent back?
 
 That contract keeps the hard and fast-moving agent work inside products with
-large teams behind them, while push owns the layer that makes the interaction a
+large teams behind them, while Push owns the layer that makes the interaction a
 personal assistant.
 
 ## What Personal Assistant Means
@@ -51,7 +51,7 @@ A personal assistant needs:
 - A stable identity across backend changes.
 - Permission and routing rules that match the user's life.
 
-For now, push stores assistant identity in one user-owned `SOUL.md`. That is
+For now, Push stores assistant identity in one user-owned `SOUL.md`. That is
 small, legible, and stable across backends.
 
 ## What The Gateway Owns
@@ -100,7 +100,7 @@ Claude Code and Codex already fit this shape:
 
 - Claude Code accepts a gateway-generated session id with `--session-id` and
   resumes with `--resume`.
-- Codex creates its own thread id through `codex exec`; push stores it and later
+- Codex creates its own thread id through `codex exec`; Push stores it and later
   resumes with `codex exec resume`.
 
 The state store must therefore track backend-owned session ids, not just
@@ -114,14 +114,14 @@ Hermes is powerful because it builds a full agent runtime and memory system. The
 cost is complexity and a second agent layer between the user and the underlying
 model or tool runtime.
 
-push takes the opposite bet. It delegates agent quality to first-party or
+Push takes the opposite bet. It delegates agent quality to first-party or
 specialized coding agents and focuses on the personal gateway layer.
 
-This means push can be smaller and more durable:
+This means Push can be smaller and more durable:
 
 - When Claude Code improves, the Claude backend improves.
 - When Codex improves, the Codex backend improves.
-- When another agent becomes better, push can add an adapter instead of
+- When another agent becomes better, Push can add an adapter instead of
   rewriting the product.
 
 ## Current Direction

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -1,6 +1,6 @@
 # Telegram Setup and Security
 
-push supports Telegram private chats through Bot API long polling. It makes
+Push supports Telegram private chats through Bot API long polling. It makes
 outbound HTTPS requests only. You do not need to expose a webhook or public
 server port. Telegram documents the polling contract in the official
 [Bot API reference](https://core.telegram.org/bots/api#getupdates).
@@ -16,12 +16,12 @@ server port. Telegram documents the polling contract in the official
    `getUpdates` response or a trusted id lookup bot. Do not allowlist a Telegram
    username because usernames can change.
 
-If the bot previously used a webhook, remove it before starting push because
-Telegram does not allow `getUpdates` while a webhook is active. The first push
+If the bot previously used a webhook, remove it before starting Push because
+Telegram does not allow `getUpdates` while a webhook is active. The first Push
 start discards pending updates, so send a new message after the gateway reports
 that it is running.
 
-Export the token in the environment that starts push:
+Export the token in the environment that starts Push:
 
 ```sh
 export TELEGRAM_BOT_TOKEN='replace-with-the-token-from-BotFather'
@@ -45,7 +45,7 @@ The token environment variable defaults to `TELEGRAM_BOT_TOKEN`. Set
 `telegram.bot_token_env` only when you need a different variable name.
 `telegram.bot_token` is supported for constrained deployments, but the
 environment-variable form is safer because it keeps the credential out of the
-config file. push never prints the token. Run:
+config file. Push never prints the token. Run:
 
 ```sh
 push doctor --config /absolute/path/to/config.toml
@@ -83,7 +83,7 @@ state.
 `state.json` stores independent `imessage` and `telegram` cursors. `push.db`
 stores channel-qualified canonical conversations, so Telegram and iMessage
 history cannot collide. On the first
-Telegram start, push asks Telegram for the newest pending update and records its
+Telegram start, Push asks Telegram for the newest pending update and records its
 id without running it. This explicit backlog skip prevents old bot messages
 from unexpectedly starting agent work. Later accepted and ignored updates
 advance only the Telegram cursor. Restarts continue from the next update id.


### PR DESCRIPTION
## Summary

- capitalize the Push product name across README and documentation prose
- preserve lowercase technical literals such as the `push` executable, paths, database names, service identifiers, repository URLs, and Mermaid node IDs

## Why

The product name should be presented consistently as "Push" in user-facing documentation.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (190 tests passed)
- `git diff --check`
- exhaustive `rg` review of remaining lowercase `push` references
- independent subagent review: no actionable findings

## Risks

Low. Documentation-only capitalization changes. Technical identifiers were intentionally left unchanged.

## Related issue

None.