### PR TITLE
fix: reject stale job_permission_profiles and shield the config file from job workdirs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -827,4 +827,19 @@ mod tests {
             .to_string()
             .contains("config file must not be inside sessions_dir"));
     }
+
+    #[test]
+    fn job_workdir_must_not_contain_the_loaded_config_file() {
+        let mut cfg = config();
+        let workdir = crate::test_support::temp_dir("config-shield-workdir");
+        cfg.config_path = workdir.join("config.toml").to_string_lossy().to_string();
+
+        let error = cfg.validate_job_workdir(&workdir).unwrap_err();
+        assert!(error.to_string().contains("config file"));
+
+        let sibling = crate::test_support::temp_dir("config-shield-sibling");
+        assert!(cfg.validate_job_workdir(&sibling).is_ok());
+        let _ = std::fs::remove_dir_all(workdir);
+        let _ = std::fs::remove_dir_all(sibling);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,6 +499,39 @@ tools = ["Read", "Grep"]
     }
 
     #[test]
+    fn config_rejects_removed_job_permission_profiles_key() {
+        let path = temp_path("job-permission-profiles-config");
+        std::fs::write(
+            &path,
+            r#"self_handles = ["me@icloud.com"]
+job_permission_profiles = ["restricted"]
+"#,
+        )
+        .unwrap();
+
+        let error = Config::load(path.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("job_permission_profiles"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn loaded_config_file_is_shielded_from_job_workdirs() {
+        let dir = temp_dir("config-shield-load");
+        let path = dir.join("config.toml");
+        std::fs::write(&path, "self_handles = [\"me@icloud.com\"]\n").unwrap();
+
+        let cfg = Config::load(path.to_str().unwrap()).unwrap();
+
+        assert!(cfg
+            .validate_job_workdir(&dir)
+            .unwrap_err()
+            .to_string()
+            .contains("config file"));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
     fn multi_channel_config_is_opt_in_and_defers_primary_resolution() {
         let path = temp_path("multi-channel-config");
         std::fs::write(


### PR DESCRIPTION
## Summary

Two fixes on top of #81 (jobs inherit backend permissions):

- A config that still sets the removed `job_permission_profiles` key now fails to load with an actionable message instead of being silently ignored.
- `Config::load` records the canonical path of the loaded config file, and `validate_job_workdir` rejects any job workdir that contains it. The config file now sits alongside the other Push-owned paths that jobs must not touch.

Adds tests for both: load-time rejection of the stale key, direct `validate_job_workdir` rejection, and an end-to-end check through `Config::load`.

## Why

After #81, jobs run with the backend's own permission configuration and may write. The job workdir check protected every Push-owned path except the config file itself, so a job rooted at the config's directory could rewrite Push's own configuration. Separately, operators upgrading past #81 would have their old `job_permission_profiles` allow-list silently dropped rather than being told to remove it.

## Test plan

- `cargo test`: 189 + 3 integration tests pass.
- `cargo clippy --all-targets`: no warnings.
- `cargo fmt`: clean.

## Risks

- `validate_job_workdir` now also rejects workdirs containing the config file; any existing runbook whose workdir contains `config.toml` will stop validating. That is the intended behavior change.
- Stacked on `jobs-inherit-backend-permissions`; merge #81 first. GitHub will retarget this PR to `main` when the base branch is deleted.

## Related issue

None.