### PR TITLE
test: cover job_permission_profiles rejection and config file shielding

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -827,4 +827,19 @@ mod tests {
             .to_string()
             .contains("config file must not be inside sessions_dir"));
     }
+
+    #[test]
+    fn job_workdir_must_not_contain_the_loaded_config_file() {
+        let mut cfg = config();
+        let workdir = crate::test_support::temp_dir("config-shield-workdir");
+        cfg.config_path = workdir.join("config.toml").to_string_lossy().to_string();
+
+        let error = cfg.validate_job_workdir(&workdir).unwrap_err();
+        assert!(error.to_string().contains("config file"));
+
+        let sibling = crate::test_support::temp_dir("config-shield-sibling");
+        assert!(cfg.validate_job_workdir(&sibling).is_ok());
+        let _ = std::fs::remove_dir_all(workdir);
+        let _ = std::fs::remove_dir_all(sibling);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,6 +499,39 @@ tools = ["Read", "Grep"]
     }
 
     #[test]
+    fn config_rejects_removed_job_permission_profiles_key() {
+        let path = temp_path("job-permission-profiles-config");
+        std::fs::write(
+            &path,
+            r#"self_handles = ["me@icloud.com"]
+job_permission_profiles = ["restricted"]
+"#,
+        )
+        .unwrap();
+
+        let error = Config::load(path.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("job_permission_profiles"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn loaded_config_file_is_shielded_from_job_workdirs() {
+        let dir = temp_dir("config-shield-load");
+        let path = dir.join("config.toml");
+        std::fs::write(&path, "self_handles = [\"me@icloud.com\"]\n").unwrap();
+
+        let cfg = Config::load(path.to_str().unwrap()).unwrap();
+
+        assert!(cfg
+            .validate_job_workdir(&dir)
+            .unwrap_err()
+            .to_string()
+            .contains("config file"));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
     fn multi_channel_config_is_opt_in_and_defers_primary_resolution() {
         let path = temp_path("multi-channel-config");
         std::fs::write(


### PR DESCRIPTION
## Summary

Adds the test coverage for the two review fixes merged in #81. The tests were written alongside the fixes but were lost to a concurrent edit of `src/config.rs` before the final amend, so main carries the fix code without its tests.

- `config.rs`: a job workdir containing the loaded config file is rejected; a sibling directory passes.
- `main.rs`: `Config::load` rejects a config that still sets `job_permission_profiles`, end to end.

## Why

Keep the #81 security checks pinned by tests.

## Test plan

`cargo test`: 189 unit + 3 integration tests pass locally.

## Risks

Test-only change.

## Related issue

None.