### PR TITLE
feat: make the inherit permission profile selectable for chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,8 +365,9 @@ remain accepted.
 
 Every route selects a named Push permission profile. The default is the built-in
 `restricted` profile. Built-ins are `restricted` (`read-only` capability),
-`workspace`, and the deliberately explicit `full-access`. Custom profiles can
-only select one of those capabilities; they cannot inject raw backend flags.
+`workspace`, `inherit`, and the deliberately explicit `full-access`. Custom
+profiles can only select one of those capabilities; they cannot inject raw
+backend flags.
 
 Backend translation is intentionally conservative:
 
@@ -375,16 +376,19 @@ Backend translation is intentionally conservative:
 - `workspace`: Claude gets read and file-edit tools but no Bash because Claude
   Code has no equivalent to Codex filesystem sandboxing; Codex uses
   `workspace-write` with approvals disabled.
+- `inherit`: Push enforces nothing and defers to the backend's own permission
+  configuration. Claude Code runs headless with the operator's settings
+  (permission mode, allow and deny rules), so tools such as Bash work only when
+  those settings pre-approve them, because a headless run cannot prompt. Codex
+  runs without a `--sandbox` flag, so its configured default sandbox applies.
+  Set `permission_profile = "inherit"` to make this the default for chat.
 - `full-access`: maps to backend bypass modes, but Push rejects it for
-  unattended routes because it cannot protect installed jobs, configuration,
-  or state from direct writes.
+  unattended routes because it overrides even the operator's own backend
+  settings and cannot protect installed jobs, configuration, or state.
 
-Jobs do not select a profile. A job runs with the backend's own permission
-configuration: Claude Code uses the operator's settings (permission mode, allow
-and deny rules), and Codex uses its configured default sandbox. Push passes no
-tool restrictions to job runs, so what a job may do is decided entirely by the
-backend configuration the operator already maintains. Because jobs may
-therefore write, every job work directory must stay clear of Push-owned paths.
+Jobs do not select a profile. A job always runs with the `inherit` behavior
+described above. Because `inherit` may write, every job work directory must
+stay clear of Push-owned paths, including the loaded config file.
 Unknown route profiles fail startup.
 
 Legacy raw settings such as `claude_permission_mode`, `claude_tools`,
@@ -457,11 +461,11 @@ result, including after restart, and never reruns the backend.
 
 ## Agent-Drafted Jobs
 
-A route using the `workspace` profile can propose a job by writing one complete
-runbook to the identity-specific inbox Push provides beneath `drafts_dir`, which
-defaults to `~/.push/drafts`. Push gives the backend only that opaque inbox as
-its extra writable root, so concurrent senders and topics cannot claim each
-other's files. `restricted` routes
+A route using the `workspace` or `inherit` profile can propose a job by writing
+one complete runbook to the identity-specific inbox Push provides beneath
+`drafts_dir`, which defaults to `~/.push/drafts`. Push gives the backend that
+opaque inbox as its extra writable root, so concurrent senders and topics
+cannot claim each other's files. `restricted` routes
 remain read-only, and `full-access` routes are rejected because their
 backend bypass modes cannot enforce this boundary.
 
@@ -512,7 +516,9 @@ as able to instruct the agent.
 
 The default `restricted` profile does not grant write or shell tools. Broader
 profiles should still be treated as powerful automation because backend
-enforcement differs and an allowed sender controls the request.
+enforcement differs and an allowed sender controls the request. With `inherit`,
+everything the backend's own configuration allows, including shell access, is
+one text message away, so pair it with a tight sender allowlist.
 
 ## Audit Log
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -2,6 +2,10 @@
 channel = "telegram"
 agent = "codex"
 
+# Chat is read-only by default. Uncomment to defer entirely to your own
+# backend settings (Claude Code allow rules, Codex sandbox), including shell.
+# permission_profile = "inherit"
+
 [telegram]
 # Replace this once with your numeric Telegram user ID.
 allow_user_ids = [123456789]

--- a/src/config.rs
+++ b/src/config.rs
@@ -279,6 +279,7 @@ impl Config {
         let capability = match name {
             "restricted" => PermissionCapability::ReadOnly,
             "workspace" => PermissionCapability::Workspace,
+            "inherit" => PermissionCapability::Inherit,
             "full-access" => PermissionCapability::FullAccess,
             custom => self
                 .permission_profiles
@@ -365,7 +366,10 @@ impl Config {
             if name.trim().is_empty() {
                 bail!("permission profile names cannot be empty");
             }
-            if matches!(name.as_str(), "restricted" | "workspace" | "full-access") {
+            if matches!(
+                name.as_str(),
+                "restricted" | "workspace" | "inherit" | "full-access"
+            ) {
                 bail!("built-in permission profile {name:?} cannot be redefined");
             }
             profile
@@ -577,8 +581,8 @@ pub enum PermissionCapability {
     ReadOnly,
     Workspace,
     /// Defer to the backend's own permission configuration. Push passes no
-    /// tool allow or deny lists; the operator's backend settings decide.
-    /// Not selectable from config (`parse` rejects it); only jobs use it.
+    /// permission mode, tool lists, or sandbox flags; the operator's backend
+    /// settings decide what the agent may do. Jobs always run with this.
     Inherit,
     FullAccess,
 }
@@ -588,9 +592,10 @@ impl PermissionCapability {
         match value {
             "read-only" => Ok(Self::ReadOnly),
             "workspace" => Ok(Self::Workspace),
+            "inherit" => Ok(Self::Inherit),
             "full-access" => Ok(Self::FullAccess),
             other => bail!(
-                "invalid permission capability {other:?}; expected read-only, workspace, or full-access"
+                "invalid permission capability {other:?}; expected read-only, workspace, inherit, or full-access"
             ),
         }
     }

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -33,18 +33,24 @@ pub(super) async fn run(ctx: Ctx, mut rx: mpsc::Receiver<Job>) {
 }
 
 pub(super) async fn handle(ctx: &Ctx, job: Job) {
-    let draft_directory =
-        if job.permission.capability == crate::config::PermissionCapability::Workspace {
-            match crate::drafts::origin_directory(&ctx.cfg, &job.approval_origin) {
-                Ok(directory) => Some(directory),
-                Err(error) => {
-                    error!("[{}] draft boundary error: {error:#}", job.thread);
-                    return;
-                }
+    use crate::config::PermissionCapability;
+    // Threads whose capability allows writes get the draft boundary, so they
+    // can propose recurring jobs for approval.
+    let can_write = matches!(
+        job.permission.capability,
+        PermissionCapability::Workspace | PermissionCapability::Inherit
+    );
+    let draft_directory = if can_write {
+        match crate::drafts::origin_directory(&ctx.cfg, &job.approval_origin) {
+            Ok(directory) => Some(directory),
+            Err(error) => {
+                error!("[{}] draft boundary error: {error:#}", job.thread);
+                return;
             }
-        } else {
-            None
-        };
+        }
+    } else {
+        None
+    };
     let existing_outbound = { ctx.history.lock().unwrap().outbound_for(job.inbound_id) };
     match existing_outbound {
         Ok(Some(outbound)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,6 +499,63 @@ tools = ["Read", "Grep"]
     }
 
     #[test]
+    fn inherit_profile_is_selectable_for_default_and_routes() {
+        let path = temp_path("inherit-profile-config");
+        std::fs::write(
+            &path,
+            r#"self_handles = ["me@icloud.com"]
+permission_profile = "inherit"
+
+[permission_profiles.trusted]
+capability = "inherit"
+
+[[routes]]
+thread = "imessage:self:me@icloud.com"
+agent = "codex"
+permission_profile = "trusted"
+"#,
+        )
+        .unwrap();
+
+        let cfg = Config::load(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            cfg.route_for_message("imessage", "imessage:dm:someone")
+                .unwrap()
+                .permission
+                .capability,
+            config::PermissionCapability::Inherit
+        );
+        assert_eq!(
+            cfg.route_for_message("imessage", "imessage:self:me@icloud.com")
+                .unwrap()
+                .permission
+                .capability,
+            config::PermissionCapability::Inherit
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn built_in_inherit_profile_cannot_be_redefined() {
+        let path = temp_path("inherit-redefined-config");
+        std::fs::write(
+            &path,
+            r#"self_handles = ["me@icloud.com"]
+
+[permission_profiles.inherit]
+capability = "read-only"
+"#,
+        )
+        .unwrap();
+
+        let error = Config::load(path.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("cannot be redefined"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn config_rejects_removed_job_permission_profiles_key() {
         let path = temp_path("job-permission-profiles-config");
         std::fs::write(


### PR DESCRIPTION
## Summary

- `inherit` is now a built-in permission profile and a parseable capability (`capability = "inherit"` in custom profiles). Setting `permission_profile = "inherit"` (or using it on a route) makes chat defer entirely to the backend's own permission configuration, exactly as jobs already do: Claude runs headless under the operator's Claude Code settings, Codex runs with its configured default sandbox, and Push passes no permission mode, tool lists, or sandbox flags.
- `inherit` threads get the identity-scoped draft inbox, so they can propose recurring jobs for approval like `workspace` threads.
- `full-access` remains rejected for routes: unlike `inherit`, it overrides even the operator's own backend settings.
- README and `config.toml.example` document the new profile and its security posture. The shipped default stays `restricted`.

## Why

Chat routes could not run shell or other backend tools at all: `restricted` and `workspace` deny Bash by design, and `full-access` is rejected at config load. The only unrestricted capability, `inherit`, existed but was jobs-only. Operators who want their assistant to do real work over chat can now opt in, with enforcement delegated to the backend settings they already maintain.

## Test plan

- `cargo test`: 191 + 3 integration tests pass, including new tests that `inherit` resolves as the default profile and on routes, and that the built-in name cannot be redefined.
- `cargo clippy --all-targets`: no warnings.
- `cargo fmt`: clean.

## Risks

- Opting in to `inherit` puts everything the local backend config allows one text message away; the README security section now says to pair it with a tight sender allowlist. Default behavior is unchanged.
- Inherit chat threads receive the drafts inbox as an extra `--add-dir`; the draft approval boundary and Push-owned path checks still apply.

## Related issue

None.