### PR TITLE
fix(gateway): complete rows after draft boundary failures

### DIFF
--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -477,6 +477,78 @@ async fn sandbox_setup_failure_completes_in_flight_row_and_advances_cursor() {
 }
 
 #[tokio::test]
+async fn draft_boundary_failure_completes_in_flight_row_and_advances_cursor() {
+    let state_path = temp_state_path();
+    let store = Arc::new(Mutex::new(Store::open(&state_path).unwrap()));
+    let drafts_blocker = temp_path("drafts-blocker");
+    std::fs::write(&drafts_blocker, "not a directory").unwrap();
+    let ack = Arc::new(Mutex::new(AckState::default()));
+    {
+        let mut ack = ack.lock().unwrap();
+        ack.in_flight.insert(10);
+        ack.completed.insert(11);
+    }
+    let mut ctx = setup_failure_ctx(
+        store.clone(),
+        ack.clone(),
+        temp_path("sessions").to_string_lossy().to_string(),
+    );
+    ctx.cfg.drafts_dir = drafts_blocker.to_string_lossy().to_string();
+    let mut job = setup_failure_job(10);
+    job.permission.capability = crate::config::PermissionCapability::Workspace;
+
+    handle(&ctx, job).await;
+
+    assert_eq!(
+        ctx.setup_failure_replies.lock().unwrap().as_slice(),
+        [SANDBOX_SETUP_FAILURE]
+    );
+    assert_eq!(store.lock().unwrap().last_row(), 11);
+    let ack = ack.lock().unwrap();
+    assert!(ack.in_flight.is_empty());
+    assert!(ack.completed.is_empty());
+
+    let _ = std::fs::remove_file(state_path);
+    let _ = std::fs::remove_file(drafts_blocker);
+}
+
+#[tokio::test]
+async fn draft_boundary_failure_delivers_existing_outbound_without_misreporting_setup() {
+    let state_path = temp_state_path();
+    let store = Arc::new(Mutex::new(Store::open(&state_path).unwrap()));
+    let drafts_blocker = temp_path("drafts-recovery-blocker");
+    std::fs::write(&drafts_blocker, "not a directory").unwrap();
+    let ack = Arc::new(Mutex::new(AckState::default()));
+    ack.lock().unwrap().in_flight.insert(10);
+    let mut ctx = setup_failure_ctx(
+        store.clone(),
+        ack.clone(),
+        temp_path("recovery-sessions").to_string_lossy().to_string(),
+    );
+    ctx.cfg.drafts_dir = drafts_blocker.to_string_lossy().to_string();
+    ctx.history
+        .lock()
+        .unwrap()
+        .record_outbound(1, OutboundOrigin::Backend, Some("claude"), "stored reply")
+        .unwrap();
+    let mut job = setup_failure_job(10);
+    job.permission.capability = crate::config::PermissionCapability::Workspace;
+
+    handle(&ctx, job).await;
+
+    assert!(ctx.setup_failure_replies.lock().unwrap().is_empty());
+    assert_eq!(
+        ctx.sent_replies.lock().unwrap().as_slice(),
+        [("me@icloud.com".to_string(), "stored reply".to_string())]
+    );
+    assert_eq!(store.lock().unwrap().last_row(), 10);
+    assert!(ack.lock().unwrap().in_flight.is_empty());
+
+    let _ = std::fs::remove_file(state_path);
+    let _ = std::fs::remove_file(drafts_blocker);
+}
+
+#[tokio::test]
 async fn soul_read_failure_stops_backend_dispatch_and_completes_row() {
     let state_path = temp_state_path();
     let store = Arc::new(Mutex::new(Store::open(&state_path).unwrap()));

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -34,6 +34,13 @@ pub(super) async fn run(ctx: Ctx, mut rx: mpsc::Receiver<Job>) {
 
 pub(super) async fn handle(ctx: &Ctx, job: Job) {
     use crate::config::PermissionCapability;
+    let existing_outbound = match ctx.history.lock().unwrap().outbound_for(job.inbound_id) {
+        Ok(outbound) => outbound,
+        Err(error) => {
+            history_error(ctx, &job, "read outbound", error);
+            return;
+        }
+    };
     // Threads whose capability allows writes get the draft boundary, so they
     // can propose recurring jobs for approval.
     let can_write = matches!(
@@ -45,39 +52,43 @@ pub(super) async fn handle(ctx: &Ctx, job: Job) {
             Ok(directory) => Some(directory),
             Err(error) => {
                 error!("[{}] draft boundary error: {error:#}", job.thread);
+                if let Some(outbound) = &existing_outbound {
+                    report_delivery(
+                        ctx,
+                        &job,
+                        deliver_stored(ctx, &job, outbound).await,
+                        &outbound.content,
+                        "recovered_outbound",
+                        "recover outbound",
+                    );
+                } else {
+                    complete_setup_failure(ctx, &job, SANDBOX_SETUP_FAILURE).await;
+                }
                 return;
             }
         }
     } else {
         None
     };
-    let existing_outbound = { ctx.history.lock().unwrap().outbound_for(job.inbound_id) };
-    match existing_outbound {
-        Ok(Some(outbound)) => {
-            if let Some(directory) = &draft_directory {
-                if let Err(error) = present_drafts(ctx, &job, directory).await {
-                    error!(
-                        "[{}] recovered draft presentation failed: {error:#}",
-                        job.thread
-                    );
-                    return;
-                }
+    if let Some(outbound) = existing_outbound {
+        if let Some(directory) = &draft_directory {
+            if let Err(error) = present_drafts(ctx, &job, directory).await {
+                error!(
+                    "[{}] recovered draft presentation failed: {error:#}",
+                    job.thread
+                );
+                return;
             }
-            report_delivery(
-                ctx,
-                &job,
-                deliver_stored(ctx, &job, &outbound).await,
-                &outbound.content,
-                "recovered_outbound",
-                "recover outbound",
-            );
-            return;
         }
-        Ok(None) => {}
-        Err(error) => {
-            history_error(ctx, &job, "read outbound", error);
-            return;
-        }
+        report_delivery(
+            ctx,
+            &job,
+            deliver_stored(ctx, &job, &outbound).await,
+            &outbound.content,
+            "recovered_outbound",
+            "recover outbound",
+        );
+        return;
     }
 
     if let Some(reply) = command(ctx, &job) {


### PR DESCRIPTION
## Summary

- Read any existing canonical outbound before preparing the per-origin draft boundary.
- Treat a fresh draft-boundary failure as a terminal setup failure, notify the user, and complete the accepted row.
- On retry, deliver the actual stored outbound instead of misreporting the setup notice.
- Add regression coverage for both fresh-message and existing-outbound recovery paths.

## Why

A targeted reproduction against `origin/main` at `ece41b8` proved that `worker::handle` returned immediately when `drafts::origin_directory` failed at runtime. `Gateway::route` had already inserted that row into `AckState::in_flight`, and no completion path removed it. Because `AckState::advance_to` stops at the first in-flight row, one invalid drafts path could pin the channel cursor and block later messages.

This was introduced by the July 12 agent-drafted jobs path and expanded to `inherit` chat routes in commit `1f6bc1d`. The fix is justified because the failure is deterministic, user-visible, and affects continued message processing rather than only diagnostics.

## Test plan

- Before the fix: `cargo test --locked gateway::tests::draft_boundary_failure_completes_in_flight_row_and_advances_cursor -- --exact --nocapture` failed because no setup notice was recorded and the row was not completed.
- `cargo test --locked gateway::tests::draft_boundary_failure_ -- --nocapture` passed: 2 focused regression tests.
- `cargo test --locked` passed: 193 unit tests and 3 integration tests.
- `cargo clippy --all-targets --all-features --locked -- -D warnings` passed.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- Independent subagent review found one existing-outbound retry issue; it was fixed and the updated diff had no remaining actionable findings.

## Risks

The behavior changes only when a write-capable chat cannot prepare its configured draft boundary. Fresh messages receive the existing sandbox setup notice and advance safely. Retries with a stored reply deliver that reply and advance without claiming the setup notice was sent. No public API or persistent data shape changes.

## Related issue

None.