### PR TITLE
feat: add Pi coding agent backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![Docs](https://img.shields.io/badge/docs-read-12756f)](https://owainlewis.github.io/push/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-111417)](LICENSE)
 
-Push turns Claude Code or Codex into an always-on personal assistant. Run one
-small process on your own machine, message it over iMessage or Telegram, and
-schedule work with plain Markdown runbooks.
+Push turns Claude Code, Codex, or Pi into an always-on personal assistant. Run
+one small process on your own machine, message it over iMessage or Telegram,
+and schedule work with plain Markdown runbooks.
 
 It can review repositories before you wake up, watch pull requests, prepare a
 daily brief, or pick up a conversation from your phone. You own one portable,
@@ -24,8 +24,9 @@ Your coding agent owns the intelligence and tools.
 
 - **An assistant that is actually available.** Push runs continuously under
   `launchd` or `systemd`, not only while a terminal window is open.
-- **The agents you already use.** Keep Claude Code or Codex, including their
-  model access, tools, MCP servers, skills, login, and backend configuration.
+- **The agents you already use.** Keep Claude Code, Codex, or Pi, including
+  their model access, tools, MCP servers, skills, login, and backend
+  configuration.
 - **Conversations from your phone.** Use private iMessage or Telegram chats.
   Each thread keeps its own backend session and canonical history.
 - **Work that starts without you.** A five-field cron trigger can run a
@@ -41,7 +42,7 @@ Your coding agent owns the intelligence and tools.
 
 ```text
 you by iMessage or Telegram ─┐
-                            ├─> Push ─> Claude Code or Codex ─> reply to you
+                            ├─> Push ─> Claude Code, Codex, or Pi ─> reply to you
 cron-triggered Markdown job ┘
 ```
 
@@ -56,12 +57,12 @@ Push keeps conversations, run history, schedules, and delivery routes durable.
 
 [Hermes Agent](https://hermes-agent.nousresearch.com/docs/) is a broad,
 batteries-included autonomous agent platform. Push is a smaller orchestration
-layer for people who already want Claude Code or Codex to do the work.
+layer for people who already want Claude Code, Codex, or Pi to do the work.
 
 | | Push | Hermes Agent |
 | --- | --- | --- |
 | Product shape | Small gateway and scheduler around external coding agents | Full autonomous agent runtime and platform |
-| Agent runtime | Claude Code or Codex | Hermes's integrated agent and tool system |
+| Agent runtime | Claude Code, Codex, or Pi | Hermes's integrated agent and tool system |
 | Main focus | A durable 24/7 assistant over private chat and Markdown jobs | A broad agent environment with many tools, channels, skills, and deployment modes |
 | Tools and context | Come from your existing backend configuration | Managed as part of the Hermes ecosystem |
 | State | Local TOML, Markdown, JSON, and SQLite owned by Push | Managed by the Hermes runtime |
@@ -75,7 +76,7 @@ and the rest of your day.
 ## What works today
 
 - iMessage on macOS and Telegram private chats on macOS or Linux
-- Claude Code and Codex backends, selectable by channel or conversation
+- Claude Code, Codex, and Pi backends, selectable by channel or conversation
 - One Git-versioned assistant repository containing `SOUL.md`, `context/`, and
   approved `jobs/`
 - Durable conversation history and backend session recovery
@@ -102,6 +103,13 @@ Linux. Other Rust-supported architectures can [build from source](docs/getting-s
 Then follow the [quickstart](https://owainlewis.github.io/push/getting-started/)
 to create your assistant repository, choose a channel, configure a backend,
 run `push doctor`, and keep the gateway online.
+
+To use [Pi](https://pi.dev/), install it, complete provider authentication for
+the same service user that runs Push, and set `agent = "pi"`. `pi_bin` defaults
+to `pi`. Push stores Pi's reported session ID and resumes that exact session on
+later turns; `/clear` starts a new one. Pi has tool allowlists but no native
+sandbox or permission prompts, so read the documented permission limits before
+allowing writes or shell access.
 
 ## Documentation
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -3,8 +3,13 @@ channel = "telegram"
 agent = "codex"
 assistant_root = "~/Code/assistant"
 
+# Pi is also supported. Install and authenticate it first, then use:
+# agent = "pi"
+# pi_bin = "pi"
+
 # Chat is read-only by default. Uncomment to defer entirely to your own
-# backend settings (Claude Code allow rules, Codex sandbox), including shell.
+# backend settings (Claude Code allow rules, Codex sandbox, or Pi tool config),
+# including shell.
 # permission_profile = "inherit"
 
 [telegram]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,8 +37,8 @@ own the durable pieces:
 
 ### 2. Runtime Disposable
 
-Agent runtimes are replaceable. Claude Code and Codex are the first adapters.
-More can be added without changing the messaging core.
+Agent runtimes are replaceable. Claude Code, Codex, and Pi are the current
+adapters. More can be added without changing the messaging core.
 
 The gateway should not build:
 
@@ -77,8 +77,10 @@ flowchart LR
     end
     adapter -->|claude -p| claude[Claude Code]
     adapter -->|codex exec| codex[Codex]
+    adapter -->|pi --print| pi[Pi]
     claude --> adapter
     codex --> adapter
+    pi --> adapter
     adapter --> sender[Sender]
     sender -->|osascript| db
     sender -->|sendMessage| tg
@@ -172,6 +174,19 @@ Codex creates its own thread id.
 
 The adapter reads Codex JSONL events to capture `thread.started.thread_id` and
 stores that id for future turns.
+
+### Pi Adapter
+
+Pi creates its own session id and reports it in the first JSON event.
+
+- New conversation: `pi --print --mode json ...`
+- Existing conversation: `pi --print --mode json --session <session_id> ...`
+- Instructions: `--append-system-prompt <SOUL.md + resolved assistant paths + gateway policy>`
+- Work dir: per-thread session directory
+
+The adapter reads the session header and final assistant `message_end` event.
+Pi tool allowlists implement Push permission profiles, but Pi has no native
+filesystem sandbox or permission prompts.
 
 ## State Model
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,9 +38,26 @@ assistant_root = "~/Code/assistant"
 allow_user_ids = [123456789]
 ```
 
-`channel` is the easiest single-provider setup. `agent` is `claude` or
-`codex`. Chat uses the built-in `restricted` permission profile unless you
+`channel` is the easiest single-provider setup. `agent` is `claude`, `codex`,
+or `pi`. Chat uses the built-in `restricted` permission profile unless you
 select another profile.
+
+### Pi setup
+
+Install Pi from [pi.dev](https://pi.dev/) and configure a model provider or
+complete its authentication as the same user that runs Push. Confirm `pi
+--version` works in the service environment, then select it:
+
+```toml
+agent = "pi"
+pi_bin = "pi"
+```
+
+Push runs `pi --print --mode json`, stores the session ID from Pi's JSON event
+stream, and resumes it with `--session`. Clearing a conversation discards that
+mapping, so the next turn creates a fresh Pi session. Push appends `SOUL.md` as
+system instructions, separate from the user message. Pi is not required unless
+the default backend, an enabled route, or `jobs_agent` selects it.
 
 ## Channels
 
@@ -165,6 +182,7 @@ flags. See [permissions and security](security.md) for exact backend mappings.
 | `claude_bin` | `"claude"` | Claude Code executable |
 | `codex_bin` | `"codex"` | Codex executable |
 | `codex_model` | unset | Optional Codex model override |
+| `pi_bin` | `"pi"` | Pi coding agent executable |
 | `reply_marker` | `"\n\n-- sent by push"` | iMessage loop-prevention marker |
 
 ### Local state

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,7 +31,7 @@ cargo test --locked
 | Channel-neutral boundary | `src/channel.rs` |
 | iMessage and Telegram adapters | `src/imessage/`, `src/telegram.rs` |
 | Gateway, queues, workers, delivery | `src/gateway/` |
-| Claude Code and Codex adapters | `src/claude.rs`, `src/codex.rs` |
+| Claude Code, Codex, and Pi adapters | `src/claude.rs`, `src/codex.rs`, `src/pi.rs` |
 | Canonical SQLite history | `src/history.rs` |
 | Jobs, scheduling, locks, run ledger | `src/jobs.rs` |
 | Agent-authored draft approval | `src/drafts.rs`, `src/approval.rs` |

--- a/docs/core-system/design.md
+++ b/docs/core-system/design.md
@@ -39,7 +39,7 @@ history in SQLite outside that repository.
 
 - Push remains one local Rust process with no inbound server port.
 - Telegram and iMessage conversations must remain channel-qualified.
-- Claude Code and Codex retain different session and instruction mechanisms.
+- Claude Code, Codex, and Pi retain different session and instruction mechanisms.
 - A failed history write must not result in an unrecorded request being sent to
   an agent.
 - A failed future reconciliation run must not block replies.
@@ -61,7 +61,7 @@ security, delivery              user-owned and Git-versioned   skills, MCP, auth
 The gateway owns durable runtime state. The user owns the assistant repository.
 Agent runtimes own execution. A
 backend session is a cache of conversational context, not the source of truth.
-Losing a Claude or Codex session must not lose the conversation record.
+Losing a Claude Code, Codex, or Pi session must not lose the conversation record.
 
 ### Identity
 
@@ -86,8 +86,8 @@ Do not modify SOUL.md or installed jobs directly.
 Propose job changes through Push's approval workflow.
 ```
 
-Claude receives the composed text as appended system instructions. Codex
-receives it as developer instructions. Push never writes resolved machine paths
+Claude Code and Pi receive the composed text as appended system instructions.
+Codex receives it as developer instructions. Push never writes resolved machine paths
 into `SOUL.md` and does not inject all context files into every prompt. The
 backend decides which files to inspect. Conversation routes receive `context/`
 as an additional workspace subject to their permission profile; `SOUL.md` and

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,8 +10,8 @@ You need:
 
 - Apple Silicon macOS or x86_64 Linux for the current prebuilt release
 - macOS for iMessage, or macOS/Linux for Telegram
-- Claude Code or Codex installed, authenticated, and runnable by the same user
-  that will run Push
+- Claude Code, Codex, or Pi installed, authenticated, and runnable by the same
+  user that will run Push
 - `curl` and `tar` for the release installer
 
 Push uses the backend's existing login, settings, tools, MCP servers, skills,
@@ -30,6 +30,12 @@ Confirm the selected command works before starting Push:
 
     ```sh
     claude --version
+    ```
+
+=== "Pi"
+
+    ```sh
+    pi --version
     ```
 
 ## 2. Install Push
@@ -113,7 +119,8 @@ time and never writes machine-specific paths into the repository.
     Read the [iMessage guide](channels/imessage.md) for database permissions
     and filtering behavior.
 
-Replace `codex` with `claude` if Claude Code is your backend.
+Replace `codex` with `claude` for Claude Code or `pi` for Pi. Pi must already
+have a configured model provider or authenticated account for the service user.
 
 If you replace the config file created by `push init`, keep its
 `assistant_root` setting. Running the same init command again is safe for a

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ hide:
 
 # Put your coding agent on call.
 
-Push turns Claude Code or Codex into a personal assistant you can message and
+Push turns Claude Code, Codex, or Pi into a personal assistant you can message and
 schedule. It runs on your machine, keeps durable state, and sends results back
 to iMessage or Telegram.
 
@@ -70,7 +70,7 @@ message or cron trigger
         ↓
 Push: filter → route → persist → schedule → deliver
         ↓
-Claude Code or Codex: reason → use tools → produce result
+Claude Code, Codex, or Pi: reason → use tools → produce result
 ```
 
 You own one Git-versioned assistant repository containing identity, context,

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -33,7 +33,7 @@ Frontmatter fields:
 | `version` | yes | Format version, currently `1` |
 | `timeout` | yes | Positive duration no greater than `jobs_max_timeout` |
 | `workdir` | yes | Existing working directory for the backend |
-| `backend` | no | `claude` or `codex`; defaults to `jobs_agent`, then root `agent` |
+| `backend` | no | `claude`, `codex`, or `pi`; defaults to `jobs_agent`, then root `agent` |
 | `triggers` | no | One or more cron trigger tables |
 
 Unknown fields are errors. A job work directory may not overlap the assistant

--- a/docs/jobs/design.md
+++ b/docs/jobs/design.md
@@ -42,7 +42,7 @@ an agent runtime.
 - Push has one long-running gateway process with no inbound server port.
   Commands may run as short-lived local processes against the same SQLite
   store.
-- Claude Code and Codex have different permission controls, but a job selects
+- Claude Code, Codex, and Pi have different permission controls, but a job selects
   only a named Push permission profile.
 - Scheduled work can have external side effects, so duplicate execution is more
   dangerous than skipping a missed run.
@@ -68,7 +68,7 @@ Markdown instruction body. Version 1 supports these fields:
 - `permission_profile`: required named profile from Push configuration.
 - `timeout`: required positive duration, capped by the configured job maximum.
 - `workdir`: required fixed directory, expanded and canonicalised at validation.
-- `backend`: optional `claude` or `codex` override; otherwise use the configured
+- `backend`: optional `claude`, `codex`, or `pi` override; otherwise use the configured
   jobs default.
 - `triggers`: optional list of separately identified trigger definitions.
 
@@ -165,7 +165,7 @@ snapshot hash of the validated job, trigger information, scheduled time,
 backend, permission profile, timeout, and canonical work directory. Editing the
 job affects later runs but not an already claimed run.
 
-Each run starts a fresh Claude or Codex session. Push supplies the composed
+Each run starts a fresh Claude Code, Codex, or Pi session. Push supplies the composed
 `SOUL.md`, resolved assistant paths, and gateway policy at instruction priority
 and the job body as the current request. Jobs receive neither backend
 conversation history nor canonical chat history. Their backend session ids are

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -9,7 +9,7 @@ It polls iMessage, filters allowed senders, loads user-owned assistant context,
 runs a configured backend, and sends the backend's final reply back over
 iMessage.
 
-The first supported backends are Claude Code and Codex.
+The supported backends are Claude Code, Codex, and Pi.
 
 ## Product Goal
 
@@ -66,7 +66,7 @@ Push takes a narrower bet:
 | Memory | Opaque or generated store | Plain markdown first |
 | Gateway | One part of the product | The product |
 | Backend choice | Abstracted provider/runtime | Adapter to real CLIs |
-| First backends | Product-specific | Claude Code and Codex |
+| Backends | Product-specific | Claude Code, Codex, and Pi |
 
 ## Core User Flow
 
@@ -75,7 +75,7 @@ Push takes a narrower bet:
 3. Push filters by allowlist and reply marker.
 4. Push loads assistant context.
 5. Push resolves the thread's backend session.
-6. Push runs Claude Code or Codex.
+6. Push runs Claude Code, Codex, or Pi.
 7. Push sends the final reply back over iMessage.
 8. Push stores the latest message row and backend session state.
 
@@ -134,7 +134,7 @@ user prompt.
 
 | Field | Meaning |
 |---|---|
-| `agent` | `claude` or `codex`. |
+| `agent` | `claude`, `codex`, or `pi`. |
 | `routes` | Exact thread to backend overrides. |
 | `permission_profile` | Default named profile; defaults to `restricted`. |
 | `channels` | Optional advanced list of reply channels to poll concurrently; otherwise `channel` is used unchanged. |
@@ -157,6 +157,7 @@ user prompt.
 | `claude_bin` | Claude Code binary. |
 | `codex_bin` | Codex binary. |
 | `codex_model` | Optional Codex model override. |
+| `pi_bin` | Pi coding agent binary. |
 | `sessions_dir` | Per-thread working dirs. |
 | `state_path` | JSON state path. |
 | `audit_log_path` | Local JSONL audit log path. |
@@ -178,6 +179,7 @@ user prompt.
 - `/clear` starts a fresh backend session.
 - Claude backend can create and resume a session.
 - Codex backend can create a session, store the Codex thread id, and resume it.
+- Pi backend can create a session, store the Pi session id, and resume it.
 - Workspace routes can propose a validated job draft, but only an exact-revision
   approval from the bound allowlisted identity can install it.
 - Fresh or lost backend sessions receive bounded recent canonical history;

--- a/docs/security.md
+++ b/docs/security.md
@@ -21,15 +21,22 @@ compromised allowed sender as access to the assistant.
 
 ## Chat permission profiles
 
-| Profile | Claude Code | Codex | Intended use |
-| --- | --- | --- | --- |
-| `restricted` | Read, Grep, and Glob; Bash and write tools denied | read-only sandbox, approvals disabled | Default inspection and conversation |
-| `workspace` | Read and file-edit tools; Bash omitted | workspace-write sandbox, approvals disabled | Contained repository edits and job drafts |
-| `inherit` | No Push mode or tool filters | No Push sandbox override | Defer to the operator's backend configuration |
-| `full-access` | Backend bypass mode | Backend bypass mode | Rejected for unattended chat routes |
+| Profile | Claude Code | Codex | Pi | Intended use |
+| --- | --- | --- | --- | --- |
+| `restricted` | Read, Grep, and Glob; Bash and write tools denied | read-only sandbox, approvals disabled | `read,grep,find,ls` allowlist | Default inspection and conversation |
+| `workspace` | Read and file-edit tools; Bash omitted | workspace-write sandbox, approvals disabled | `read,edit,write,grep,find,ls` allowlist; no Bash | Repository edits and job drafts |
+| `inherit` | No Push mode or tool filters | No Push sandbox override | No Push tool allowlist | Defer to the operator's backend configuration |
+| `full-access` | Backend bypass mode | Backend bypass mode | Explicit allowlist including Bash | Rejected for unattended chat routes |
 
 Claude Code does not expose a Codex-equivalent filesystem sandbox. Its
 `workspace` mapping allows file tools but deliberately omits shell access.
+Pi also has no native sandbox or permission prompts. Its tool allowlist can
+remove mutating tools or Bash, but it cannot confine file tools to the session
+workspace. `workspace` prevents direct shell access but Pi's read, edit, and
+write tools can still address paths allowed by the operating-system user.
+`inherit` may enable built-in or extension tools from Pi's configuration.
+`full-access` explicitly enables all built-in tools, including unrestricted
+Bash, and therefore remains unsuitable for unattended chat routes.
 
 These profiles control the local filesystem and process capabilities that Push
 passes to the backend. They do not rewrite the backend's own integration
@@ -49,7 +56,7 @@ Custom profiles only alias a capability:
 capability = "workspace"
 ```
 
-Push rejects raw Claude or Codex permission flags in TOML so a route cannot
+Push rejects raw backend permission flags in TOML so a route cannot
 quietly bypass the shared local policy model.
 
 ## Job permissions

--- a/docs/services.md
+++ b/docs/services.md
@@ -29,7 +29,7 @@ Use absolute paths in service files. The service user needs:
   `assistant_root/jobs/`
 - write access to `assistant_root/context/` for workspace or inherited routes,
   and to `assistant_root/jobs/` only for approved job installation
-- access to `claude` or `codex` on `PATH`
+- access to the selected `claude`, `codex`, or `pi` executable on `PATH`
 - backend login, tokens, settings, MCP config, and project credentials
 - for iMessage on macOS, Full Disk Access and `osascript`
 - for Telegram, `TELEGRAM_BOT_TOKEN` in the service environment and network

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -106,12 +106,14 @@ output:
   backend session id if created by the runtime
 ```
 
-Claude Code and Codex already fit this shape:
+Claude Code, Codex, and Pi fit this shape:
 
 - Claude Code accepts a gateway-generated session id with `--session-id` and
   resumes with `--resume`.
 - Codex creates its own thread id through `codex exec`; Push stores it and later
   resumes with `codex exec resume`.
+- Pi reports a session id in JSON mode; Push stores it and resumes with
+  `--session`.
 
 The state store must therefore track backend-owned session ids, not just
 gateway-owned UUIDs.
@@ -131,6 +133,7 @@ This means Push can be smaller and more durable:
 
 - When Claude Code improves, the Claude backend improves.
 - When Codex improves, the Codex backend improves.
+- When Pi improves, the Pi backend improves.
 - When another agent becomes better, Push can add an adapter instead of
   rewriting the product.
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use crate::config::{AgentBackend, Config, PermissionCapability};
-use crate::{claude, codex};
+use crate::{claude, codex, pi};
 
 /// One headless agent turn.
 pub struct Request<'a> {
@@ -37,6 +37,7 @@ pub enum RunError {
 pub enum Runner {
     Claude(claude::Runner),
     Codex(codex::Runner),
+    Pi(pi::Runner),
     #[cfg(test)]
     Fake(FakeRunner),
 }
@@ -72,6 +73,9 @@ impl Runner {
                 bin: cfg.codex_bin.clone(),
                 model: cfg.codex_model.clone(),
             }),
+            AgentBackend::Pi => Runner::Pi(pi::Runner {
+                bin: cfg.pi_bin.clone(),
+            }),
         }
     }
 
@@ -79,6 +83,7 @@ impl Runner {
         match self {
             Runner::Claude(_) => AgentBackend::Claude,
             Runner::Codex(_) => AgentBackend::Codex,
+            Runner::Pi(_) => AgentBackend::Pi,
             #[cfg(test)]
             Runner::Fake(r) => r.backend,
         }
@@ -88,6 +93,7 @@ impl Runner {
         match self {
             Runner::Claude(_) => "Claude",
             Runner::Codex(_) => "Codex",
+            Runner::Pi(_) => "Pi",
             #[cfg(test)]
             Runner::Fake(_) => "Fake",
         }
@@ -97,6 +103,7 @@ impl Runner {
         match self {
             Runner::Claude(_) => Uuid::new_v4().to_string(),
             Runner::Codex(_) => String::new(),
+            Runner::Pi(_) => String::new(),
             #[cfg(test)]
             Runner::Fake(_) => String::new(),
         }
@@ -110,6 +117,7 @@ impl Runner {
         match self {
             Runner::Claude(r) => r.run(req, timeout).await,
             Runner::Codex(r) => r.run(req, timeout).await,
+            Runner::Pi(r) => r.run(req, timeout).await,
             #[cfg(test)]
             Runner::Fake(r) => r.run(req, timeout).await,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,8 @@ pub struct Config {
     pub codex_bin: String,
     #[serde(default)]
     pub codex_model: Option<String>,
+    #[serde(default = "default_pi_bin")]
+    pub pi_bin: String,
     #[serde(default = "default_sessions_dir")]
     pub sessions_dir: String,
     #[serde(default = "default_state_path")]
@@ -378,15 +380,23 @@ impl Config {
         }) {
             backends.insert(AgentBackend::parse(&route.agent)?);
         }
+        if let Some(jobs_agent) = self.jobs_agent.as_deref() {
+            backends.insert(AgentBackend::parse(jobs_agent).context("invalid jobs_agent")?);
+        }
 
         let mut bins = Vec::new();
         for backend in backends {
-            bins.push(match backend {
-                AgentBackend::Claude => self.claude_bin.as_str(),
-                AgentBackend::Codex => self.codex_bin.as_str(),
-            });
+            bins.push(self.agent_bin(backend));
         }
         Ok(bins)
+    }
+
+    pub fn agent_bin(&self, backend: AgentBackend) -> &str {
+        match backend {
+            AgentBackend::Claude => self.claude_bin.as_str(),
+            AgentBackend::Codex => self.codex_bin.as_str(),
+            AgentBackend::Pi => self.pi_bin.as_str(),
+        }
     }
 
     fn validate(&self) -> Result<()> {
@@ -799,6 +809,7 @@ impl ChannelKind {
 pub enum AgentBackend {
     Claude,
     Codex,
+    Pi,
 }
 
 impl AgentBackend {
@@ -806,7 +817,8 @@ impl AgentBackend {
         match s {
             "claude" => Ok(AgentBackend::Claude),
             "codex" => Ok(AgentBackend::Codex),
-            other => bail!("invalid agent {other:?}; expected \"claude\" or \"codex\""),
+            "pi" => Ok(AgentBackend::Pi),
+            other => bail!("invalid agent {other:?}; expected \"claude\", \"codex\", or \"pi\""),
         }
     }
 
@@ -814,6 +826,7 @@ impl AgentBackend {
         match self {
             AgentBackend::Claude => "claude",
             AgentBackend::Codex => "codex",
+            AgentBackend::Pi => "pi",
         }
     }
 }
@@ -841,6 +854,9 @@ fn default_claude_bin() -> String {
 }
 fn default_codex_bin() -> String {
     "codex".to_string()
+}
+fn default_pi_bin() -> String {
+    "pi".to_string()
 }
 fn default_permission_profile() -> String {
     "restricted".to_string()
@@ -914,6 +930,7 @@ mod tests {
             claude_bin: "claude".to_string(),
             codex_bin: "codex".to_string(),
             codex_model: None,
+            pi_bin: "pi".to_string(),
             sessions_dir: root.join("sessions").to_string_lossy().to_string(),
             state_path: root.join("state.json").to_string_lossy().to_string(),
             audit_log_path: root.join("audit.jsonl").to_string_lossy().to_string(),
@@ -923,6 +940,58 @@ mod tests {
             assistant_dir: root.to_string_lossy().to_string(),
             reply_marker: String::new(),
         }
+    }
+
+    #[test]
+    fn pi_parses_and_is_selectable_for_default_routes_and_jobs() {
+        let mut cfg = config();
+        cfg.agent = "pi".to_string();
+        cfg.jobs_agent = Some("pi".to_string());
+        cfg.routes = vec![RouteRule {
+            thread: Some("imessage:chat:pi".to_string()),
+            channel: Some("imessage".to_string()),
+            agent: "pi".to_string(),
+            permission_profile: Some("restricted".to_string()),
+        }];
+
+        assert_eq!(AgentBackend::parse("pi").unwrap(), AgentBackend::Pi);
+        assert_eq!(AgentBackend::Pi.as_str(), "pi");
+        assert_eq!(cfg.agent_backend().unwrap(), AgentBackend::Pi);
+        assert_eq!(cfg.jobs_backend().unwrap(), AgentBackend::Pi);
+        assert_eq!(
+            cfg.route_for_message("imessage", "imessage:chat:pi")
+                .unwrap()
+                .backend,
+            AgentBackend::Pi
+        );
+        assert_eq!(cfg.required_agent_bins().unwrap(), vec!["pi"]);
+    }
+
+    #[test]
+    fn pi_binary_defaults_to_pi_when_loading_toml() {
+        let cfg: Config = toml::from_str("agent = 'pi'").unwrap();
+
+        assert_eq!(cfg.agent_backend().unwrap(), AgentBackend::Pi);
+        assert_eq!(cfg.pi_bin, "pi");
+    }
+
+    #[test]
+    fn pi_binary_is_only_required_when_selected() {
+        let mut cfg = config();
+        assert_eq!(cfg.required_agent_bins().unwrap(), vec!["codex"]);
+
+        cfg.routes.push(RouteRule {
+            thread: None,
+            channel: Some("telegram".to_string()),
+            agent: "pi".to_string(),
+            permission_profile: None,
+        });
+        assert_eq!(cfg.required_agent_bins().unwrap(), vec!["codex"]);
+
+        cfg.jobs_agent = Some("pi".to_string());
+        let mut bins = cfg.required_agent_bins().unwrap();
+        bins.sort_unstable();
+        assert_eq!(bins, vec!["codex", "pi"]);
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Result};
 
-use crate::{config, drafts, history};
+use crate::{config, drafts, history, jobs};
 
 /// Fails fast with actionable messages when the environment is not ready.
 pub fn preflight(cfg: &config::Config) -> Result<()> {
@@ -234,6 +234,9 @@ fn check_bins_with(
             return;
         }
     };
+    if let Ok(catalog) = jobs::Catalog::load(cfg) {
+        bins.extend(catalog.jobs.values().map(|job| cfg.agent_bin(job.backend)));
+    }
     if cfg
         .enabled_channel_kinds()
         .is_ok_and(|channels| channels.contains(&config::ChannelKind::IMessage))
@@ -444,6 +447,51 @@ claude_tools = []
         }));
         assert!(checks.iter().any(|check| {
             check.name == "binary osascript" && matches!(check.status, CheckStatus::Fail)
+        }));
+    }
+
+    #[test]
+    fn binary_checks_use_configured_pi_binary_when_pi_is_active() {
+        let mut cfg = test_config();
+        cfg.agent = "pi".to_string();
+        cfg.pi_bin = "/custom/pi".to_string();
+        let mut checks = Vec::new();
+
+        check_bins_with(&cfg, &mut checks, |bin| {
+            (bin == "/custom/pi" || bin == "osascript").then(|| PathBuf::from(bin))
+        });
+
+        assert!(checks.iter().any(|check| {
+            check.name == "binary /custom/pi" && matches!(check.status, CheckStatus::Pass)
+        }));
+        assert!(!checks
+            .iter()
+            .any(|check| check.name == "binary /fake/codex"));
+    }
+
+    #[test]
+    fn binary_checks_include_pi_selected_by_an_installed_job() {
+        let mut cfg = test_config();
+        let jobs_dir = temp_dir("doctor-pi-job");
+        let workdir = temp_dir("doctor-pi-job-work");
+        cfg.jobs_dir = jobs_dir.to_string_lossy().to_string();
+        cfg.pi_bin = "/custom/pi".to_string();
+        std::fs::write(
+            jobs_dir.join("pi-job.md"),
+            format!(
+                "+++\nversion = 1\ntimeout = \"5s\"\nworkdir = {:?}\nbackend = \"pi\"\n+++\nRun Pi.\n",
+                workdir.to_string_lossy()
+            ),
+        )
+        .unwrap();
+        let mut checks = Vec::new();
+
+        check_bins_with(&cfg, &mut checks, |bin| {
+            (bin == "/fake/codex" || bin == "osascript").then(|| PathBuf::from(bin))
+        });
+
+        assert!(checks.iter().any(|check| {
+            check.name == "binary /custom/pi" && matches!(check.status, CheckStatus::Fail)
         }));
     }
 

--- a/src/drafts.rs
+++ b/src/drafts.rs
@@ -448,6 +448,7 @@ mod tests {
                 claude_bin: "claude".to_string(),
                 codex_bin: "codex".to_string(),
                 codex_model: None,
+                pi_bin: "pi".to_string(),
                 sessions_dir: root.join("sessions").to_string_lossy().to_string(),
                 state_path: root.join("state.json").to_string_lossy().to_string(),
                 audit_log_path: root.join("audit.jsonl").to_string_lossy().to_string(),

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -803,7 +803,7 @@ fn complete_row(store: &Arc<Mutex<Store>>, ack: &Arc<Mutex<AckState>>, channel: 
 }
 
 fn runners(cfg: &Config) -> HashMap<AgentBackend, Runner> {
-    [AgentBackend::Claude, AgentBackend::Codex]
+    [AgentBackend::Claude, AgentBackend::Codex, AgentBackend::Pi]
         .into_iter()
         .map(|backend| (backend, Runner::for_backend(backend, cfg)))
         .collect()

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -2101,6 +2101,7 @@ fn test_config(state_path: &str, sessions_dir: &str, assistant_dir: &str) -> Con
         claude_bin: "claude".to_string(),
         codex_bin: "codex".to_string(),
         codex_model: None,
+        pi_bin: "pi".to_string(),
         sessions_dir: sessions_dir.to_string(),
         state_path: state_path.to_string(),
         audit_log_path: format!("{state_path}.audit.jsonl"),

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -1393,6 +1393,27 @@ mod tests {
     }
 
     #[test]
+    fn job_backend_override_accepts_pi() {
+        let jobs_dir = temp_dir("jobs-pi-backend");
+        let workdir = temp_dir("jobs-pi-work");
+        let database = temp_path("jobs-pi-db");
+        let run_dir = temp_dir("jobs-pi-run");
+        write_job(
+            &jobs_dir,
+            "pi-job",
+            &format!(
+                "+++\nversion = 1\nbackend = \"pi\"\ntimeout = \"5s\"\nworkdir = {:?}\n+++\nbody",
+                workdir.to_string_lossy()
+            ),
+        );
+        let cfg = cfg(&jobs_dir, &database, &run_dir);
+
+        let catalog = Catalog::load(&cfg).unwrap();
+
+        assert_eq!(catalog.jobs["pi-job"].backend, AgentBackend::Pi);
+    }
+
+    #[test]
     fn cron_validation_rejects_malformed_fields_and_ranges() {
         for schedule in [
             "nonsense * * * *",
@@ -2154,7 +2175,7 @@ printf '%s\n' '{{"type":"thread.started","thread_id":"fresh-thread"}}'
 
         assert_eq!(first.1, "manual result");
         assert_eq!(second.1, "manual result");
-        let args = std::fs::read_to_string(args_path).unwrap();
+        let args = std::fs::read_to_string(&args_path).unwrap();
         assert_eq!(args.lines().filter(|line| *line == "exec").count(), 2);
         assert!(!args.lines().any(|line| line == "resume"));
         let rows = Ledger::open(&cfg.database_path)
@@ -2247,5 +2268,38 @@ printf '%s\n' ok > {}
         assert!(args.lines().any(|line| line == "--session-id"));
         assert!(!args.lines().any(|line| line == "--resume"));
         assert!(args.lines().any(|line| line == "Inspect this directory."));
+    }
+
+    #[tokio::test]
+    async fn backend_override_runs_pi_with_a_fresh_session() {
+        let jobs_dir = temp_dir("jobs-pi");
+        let workdir = temp_dir("jobs-pi-work");
+        let database = temp_path("jobs-pi-db");
+        let run_dir = temp_dir("jobs-pi-run");
+        let args_path = temp_path("jobs-pi-args");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\ncat > {}.stdin\nprintf '%s\\n' '{{\"type\":\"session\",\"id\":\"pi-job-session\"}}'\nprintf '%s\\n' '{{\"type\":\"message_end\",\"message\":{{\"role\":\"assistant\",\"content\":[{{\"type\":\"text\",\"text\":\"pi result\"}}],\"stopReason\":\"stop\"}}}}'\n",
+            sh_arg(&args_path),
+            sh_arg(&args_path)
+        );
+        let cli = FakeCli::new("pi", &script);
+        let runbook = valid_job(&workdir).replace("backend = \"codex\"", "backend = \"pi\"");
+        write_job(&jobs_dir, "pi-job", &runbook);
+        let mut cfg = cfg(&jobs_dir, &database, &run_dir);
+        cfg.pi_bin = cli.bin();
+
+        let output = run_manual(&cfg, Catalog::load_named(&cfg, "pi-job").unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(output.1, "pi result");
+        let args = std::fs::read_to_string(&args_path).unwrap();
+        assert!(args.lines().any(|line| line == "--mode"));
+        assert!(args.lines().any(|line| line == "json"));
+        assert!(!args.lines().any(|line| line == "--session"));
+        assert_eq!(
+            std::fs::read_to_string(format!("{}.stdin", args_path.to_string_lossy())).unwrap(),
+            "\nInspect this directory.\n"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod gateway;
 mod history;
 mod imessage;
 mod jobs;
+mod pi;
 mod rehydration;
 mod soul;
 mod store;

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -1,0 +1,551 @@
+//! Runs the Pi coding agent headlessly for a single message.
+
+use std::time::Duration;
+use std::{io, process::Stdio};
+
+use serde_json::Value;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+use crate::agent::{Request, RunError, RunOutput};
+use crate::config::PermissionCapability;
+
+/// Runner invokes `pi` in non-interactive JSON event mode.
+pub struct Runner {
+    pub bin: String,
+}
+
+impl Runner {
+    /// Executes one turn and returns Pi's final reply plus its stable session id.
+    pub async fn run(&self, req: Request<'_>, timeout: Duration) -> Result<RunOutput, RunError> {
+        let attempt = crate::agent::output_with_retry(|| {
+            let mut cmd = self.command(&req);
+            let prompt = req.prompt.as_bytes().to_vec();
+            async move {
+                let mut child = cmd.spawn()?;
+                let mut stdin = child.stdin.take().ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "pi stdin unavailable")
+                })?;
+                let write_result = stdin.write_all(&prompt).await;
+                drop(stdin);
+                let output = child.wait_with_output().await?;
+                if output.status.success() {
+                    write_result?;
+                }
+                Ok(output)
+            }
+        });
+        let out = match tokio::time::timeout(timeout, attempt).await {
+            Err(_) => return Err(RunError::Timeout),
+            Ok(Err(error)) => return Err(RunError::Failed(format!("run pi: {error}"))),
+            Ok(Ok(output)) => output,
+        };
+
+        let parsed = parse_jsonl(&out.stdout);
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if !req.is_new && missing_resume_error(&stderr) {
+                return Err(RunError::SessionMissing(
+                    "Pi could not find the saved session; Push will rebuild it from conversation history"
+                        .to_string(),
+                ));
+            }
+            return Err(RunError::Failed(exit_diagnostic(
+                out.status.code(),
+                parsed.as_ref().err().map(String::as_str),
+            )));
+        }
+
+        let parsed = parsed.map_err(RunError::Failed)?;
+        if req.is_new && parsed.session_id.is_none() {
+            return Err(RunError::Failed(
+                "pi did not report a session id".to_string(),
+            ));
+        }
+        if parsed.assistant_failed {
+            return Err(RunError::Failed(
+                "Pi assistant request failed; check Pi provider and authentication settings"
+                    .to_string(),
+            ));
+        }
+        let reply = parsed.reply.unwrap_or_default();
+        if reply.trim().is_empty() {
+            return Err(RunError::Failed(
+                "pi exited without a final assistant reply".to_string(),
+            ));
+        }
+
+        Ok(RunOutput {
+            reply: reply.trim().to_string(),
+            session_id: req.is_new.then_some(parsed.session_id).flatten(),
+        })
+    }
+
+    fn command(&self, req: &Request<'_>) -> Command {
+        let mut cmd = Command::new(&self.bin);
+        cmd.arg("--print").arg("--mode").arg("json");
+        if !req.instructions.trim().is_empty() {
+            cmd.arg("--append-system-prompt")
+                .arg(req.instructions.trim());
+        }
+        if let Some(tools) = tools(req.permission) {
+            cmd.arg("--tools").arg(tools);
+        }
+        if !req.is_new {
+            cmd.arg("--session").arg(req.session_id);
+        }
+        cmd.current_dir(req.work_dir);
+        cmd.kill_on_drop(true);
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        cmd
+    }
+}
+
+#[derive(Default)]
+struct ParsedOutput {
+    session_id: Option<String>,
+    reply: Option<String>,
+    assistant_failed: bool,
+}
+
+fn parse_jsonl(stdout: &[u8]) -> Result<ParsedOutput, String> {
+    let stdout = std::str::from_utf8(stdout)
+        .map_err(|_| "pi returned malformed JSON output (invalid UTF-8)".to_string())?;
+    let mut parsed = ParsedOutput::default();
+    for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
+        let event: Value = serde_json::from_str(line)
+            .map_err(|_| "pi returned malformed JSON output".to_string())?;
+        match event.get("type").and_then(Value::as_str) {
+            Some("session") => {
+                parsed.session_id = event
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .map(str::to_string);
+            }
+            Some("message_end") => {
+                let Some(message) = event.get("message") else {
+                    continue;
+                };
+                if message.get("role").and_then(Value::as_str) != Some("assistant") {
+                    continue;
+                }
+                if matches!(
+                    message.get("stopReason").and_then(Value::as_str),
+                    Some("error" | "aborted")
+                ) {
+                    parsed.reply = None;
+                    parsed.assistant_failed = true;
+                    continue;
+                }
+                let text = message
+                    .get("content")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .filter(|part| part.get("type").and_then(Value::as_str) == Some("text"))
+                    .filter_map(|part| part.get("text").and_then(Value::as_str))
+                    .collect::<Vec<_>>()
+                    .join("");
+                parsed.reply = Some(text);
+                parsed.assistant_failed = false;
+            }
+            _ => {}
+        }
+    }
+    Ok(parsed)
+}
+
+fn exit_diagnostic(status: Option<i32>, parse_error: Option<&str>) -> String {
+    if let Some(error) = parse_error {
+        error.to_string()
+    } else {
+        match status {
+            Some(code) => format!(
+                "Pi exited with status {code}; run Pi directly as the service user to check provider and authentication settings"
+            ),
+            None => "Pi was terminated; run Pi directly as the service user to check provider and authentication settings"
+                .to_string(),
+        }
+    }
+}
+
+fn missing_resume_error(message: &str) -> bool {
+    message
+        .to_ascii_lowercase()
+        .contains("no session found matching")
+}
+
+const READ_ONLY_TOOLS: &str = "read,grep,find,ls";
+const WORKSPACE_TOOLS: &str = "read,edit,write,grep,find,ls";
+const FULL_ACCESS_TOOLS: &str = "read,bash,edit,write,grep,find,ls";
+
+fn tools(capability: PermissionCapability) -> Option<&'static str> {
+    match capability {
+        PermissionCapability::ReadOnly => Some(READ_ONLY_TOOLS),
+        PermissionCapability::Workspace => Some(WORKSPACE_TOOLS),
+        PermissionCapability::Inherit => None,
+        PermissionCapability::FullAccess => Some(FULL_ACCESS_TOOLS),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{
+        assert_runner_contract, sh_arg, temp_dir, temp_path, ContractCase, ContractRequest,
+        ContractRunner, FakeCli, RunnerContract,
+    };
+
+    impl ContractRunner for Runner {
+        fn run<'a>(
+            &'a self,
+            req: Request<'a>,
+            timeout: Duration,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<RunOutput, RunError>> + 'a>>
+        {
+            Box::pin(self.run(req, timeout))
+        }
+    }
+
+    #[tokio::test]
+    async fn satisfies_runner_contract() {
+        assert_runner_contract(RunnerContract {
+            name: "Pi",
+            new_session: contract_new_session,
+            resumed_session: contract_resumed_session,
+            failed_run: contract_failed_run,
+            timeout_run: contract_timeout_run,
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn creates_session_and_separates_instructions_from_prompt() {
+        let args_path = temp_path("pi-new-args");
+        let work_dir = temp_dir("pi-new-work");
+        let cli = FakeCli::new("pi", &success_script(&args_path, "pi-session", "hello"));
+        let runner = Runner { bin: cli.bin() };
+
+        let output = runner
+            .run(
+                Request {
+                    session_id: "",
+                    is_new: true,
+                    work_dir: work_dir.to_str().unwrap(),
+                    additional_dirs: &[],
+                    instructions: "SOUL instructions",
+                    permission: PermissionCapability::Workspace,
+                    prompt: "user message",
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output.reply, "hello");
+        assert_eq!(output.session_id.as_deref(), Some("pi-session"));
+        let args = read_args(&args_path);
+        assert_arg_pair(&args, "--mode", "json");
+        assert_arg_pair(&args, "--append-system-prompt", "SOUL instructions");
+        assert_arg_pair(&args, "--tools", WORKSPACE_TOOLS);
+        assert!(!args.contains(&"--session".to_string()));
+        assert_eq!(read_prompt(&args_path), "user message");
+        assert!(!args.contains(&"user message".to_string()));
+    }
+
+    #[tokio::test]
+    async fn sends_option_and_file_like_prompts_verbatim_over_stdin() {
+        for prompt in [
+            "@/private/file",
+            "--provider attacker",
+            "-p",
+            "line one\nline two",
+        ] {
+            let args_path = temp_path("pi-verbatim-prompt-args");
+            let work_dir = temp_dir("pi-verbatim-prompt-work");
+            let cli = FakeCli::new("pi", &success_script(&args_path, "pi-session", "reply"));
+            let runner = Runner { bin: cli.bin() };
+
+            runner
+                .run(
+                    Request {
+                        prompt,
+                        ..request(work_dir.to_str().unwrap(), true)
+                    },
+                    Duration::from_secs(5),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(read_prompt(&args_path), prompt);
+            assert!(!read_args(&args_path).iter().any(|arg| arg == prompt));
+        }
+    }
+
+    #[tokio::test]
+    async fn resumes_exact_session() {
+        let args_path = temp_path("pi-resume-args");
+        let work_dir = temp_dir("pi-resume-work");
+        let cli = FakeCli::new("pi", &success_script(&args_path, "pi-session", "again"));
+        let runner = Runner { bin: cli.bin() };
+
+        let output = runner
+            .run(
+                Request {
+                    session_id: "pi-session",
+                    is_new: false,
+                    work_dir: work_dir.to_str().unwrap(),
+                    additional_dirs: &[],
+                    instructions: "SOUL instructions",
+                    permission: PermissionCapability::ReadOnly,
+                    prompt: "continue",
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output.reply, "again");
+        assert_eq!(output.session_id, None);
+        let args = read_args(&args_path);
+        assert_arg_pair(&args, "--session", "pi-session");
+        assert_arg_pair(&args, "--tools", READ_ONLY_TOOLS);
+    }
+
+    #[tokio::test]
+    async fn missing_resume_is_typed_for_rehydration() {
+        let work_dir = temp_dir("pi-missing-work");
+        let cli = FakeCli::new(
+            "pi",
+            "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' \"No session found matching 'missing'\" >&2\nexit 1\n",
+        );
+        let runner = Runner { bin: cli.bin() };
+        let error = runner
+            .run(
+                request(work_dir.to_str().unwrap(), false),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, RunError::SessionMissing(_)));
+    }
+
+    #[tokio::test]
+    async fn immediate_missing_resume_with_large_prompt_is_typed_for_rehydration() {
+        let work_dir = temp_dir("pi-immediate-missing-work");
+        let cli = FakeCli::new(
+            "pi",
+            "#!/bin/sh\nprintf '%s\\n' \"No session found matching 'missing'\" >&2\nexit 1\n",
+        );
+        let runner = Runner { bin: cli.bin() };
+        let prompt = "x".repeat(1024 * 1024);
+
+        let error = runner
+            .run(
+                Request {
+                    prompt: &prompt,
+                    ..request(work_dir.to_str().unwrap(), false)
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RunError::SessionMissing(_)));
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_and_empty_output() {
+        for (script, expected) in [
+            (
+                "#!/bin/sh\ncat >/dev/null\nprintf 'not-json\\n'\n",
+                "malformed JSON",
+            ),
+            (
+                "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '{\"type\":\"session\",\"id\":\"id\"}'\n",
+                "without a final assistant reply",
+            ),
+        ] {
+            let work_dir = temp_dir("pi-bad-output");
+            let cli = FakeCli::new("pi", script);
+            let runner = Runner { bin: cli.bin() };
+            let error = runner
+                .run(
+                    request(work_dir.to_str().unwrap(), true),
+                    Duration::from_secs(5),
+                )
+                .await
+                .unwrap_err();
+            assert!(failed_message(error).contains(expected));
+        }
+    }
+
+    #[tokio::test]
+    async fn reports_non_zero_exit_without_forwarding_stderr_secrets() {
+        let work_dir = temp_dir("pi-failed-work");
+        let secret = "stored-extension-token-123456";
+        let cli = FakeCli::new(
+            "pi",
+            &format!(
+                "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' 'provider failed with {secret}' >&2\nexit 2\n"
+            ),
+        );
+        let runner = Runner { bin: cli.bin() };
+        let error = runner
+            .run(
+                request(work_dir.to_str().unwrap(), true),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap_err();
+        let message = failed_message(error);
+        assert!(message.contains("status 2"));
+        assert!(!message.contains(secret));
+    }
+
+    #[tokio::test]
+    async fn successful_auto_retry_uses_the_later_assistant_reply() {
+        let work_dir = temp_dir("pi-retry-work");
+        let script = "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '{\"type\":\"session\",\"id\":\"retry-session\"}'\nprintf '%s\\n' '{\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"content\":[],\"stopReason\":\"error\",\"errorMessage\":\"secret first failure\"}}'\nprintf '%s\\n' '{\"type\":\"auto_retry_start\",\"attempt\":1}'\nprintf '%s\\n' '{\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"recovered\"}],\"stopReason\":\"stop\"}}'\n";
+        let cli = FakeCli::new("pi", script);
+        let runner = Runner { bin: cli.bin() };
+
+        let output = runner
+            .run(
+                request(work_dir.to_str().unwrap(), true),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output.reply, "recovered");
+    }
+
+    #[test]
+    fn maps_all_permission_profiles_conservatively() {
+        assert_eq!(tools(PermissionCapability::ReadOnly), Some(READ_ONLY_TOOLS));
+        assert_eq!(
+            tools(PermissionCapability::Workspace),
+            Some(WORKSPACE_TOOLS)
+        );
+        assert_eq!(tools(PermissionCapability::Inherit), None);
+        assert_eq!(
+            tools(PermissionCapability::FullAccess),
+            Some(FULL_ACCESS_TOOLS)
+        );
+        assert!(!WORKSPACE_TOOLS.split(',').any(|tool| tool == "bash"));
+    }
+
+    fn success_script(args_path: &std::path::Path, session: &str, reply: &str) -> String {
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\ncat > {}.stdin\nprintf '%s\\n' '{{\"type\":\"session\",\"id\":\"{session}\"}}'\nprintf '%s\\n' '{{\"type\":\"message_end\",\"message\":{{\"role\":\"assistant\",\"content\":[{{\"type\":\"text\",\"text\":\"{reply}\"}}],\"stopReason\":\"stop\"}}}}'\n",
+            sh_arg(args_path),
+            sh_arg(args_path)
+        )
+    }
+
+    fn request(work_dir: &str, is_new: bool) -> Request<'_> {
+        Request {
+            session_id: if is_new { "" } else { "existing-session" },
+            is_new,
+            work_dir,
+            additional_dirs: &[],
+            instructions: "",
+            permission: PermissionCapability::ReadOnly,
+            prompt: "hello",
+        }
+    }
+
+    fn read_args(path: &std::path::Path) -> Vec<String> {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn read_prompt(path: &std::path::Path) -> String {
+        std::fs::read_to_string(format!("{}.stdin", path.to_string_lossy())).unwrap()
+    }
+
+    fn assert_arg_pair(args: &[String], flag: &str, value: &str) {
+        let index = args.iter().position(|arg| arg == flag).unwrap();
+        assert_eq!(args.get(index + 1).map(String::as_str), Some(value));
+    }
+
+    fn failed_message(error: RunError) -> String {
+        match error {
+            RunError::Failed(message) => message,
+            other => panic!("expected failed error, got {other:?}"),
+        }
+    }
+
+    fn contract_new_session() -> ContractCase {
+        contract_success(true)
+    }
+
+    fn contract_resumed_session() -> ContractCase {
+        contract_success(false)
+    }
+
+    fn contract_success(is_new: bool) -> ContractCase {
+        let work_dir = temp_dir("pi-contract-success");
+        let cli = FakeCli::new(
+            "pi",
+            &success_script(&temp_path("pi-contract-args"), "pi-session", "reply"),
+        );
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(Runner { bin }),
+            request: contract_request(work_dir, is_new),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn contract_failed_run() -> ContractCase {
+        let work_dir = temp_dir("pi-contract-fail");
+        let cli = FakeCli::new(
+            "pi",
+            "#!/bin/sh\ncat >/dev/null\nprintf 'failed\\n' >&2\nexit 1\n",
+        );
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(Runner { bin }),
+            request: contract_request(work_dir, true),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn contract_timeout_run() -> ContractCase {
+        let work_dir = temp_dir("pi-contract-timeout");
+        let cli = FakeCli::new("pi", "#!/bin/sh\ncat >/dev/null\nsleep 2\n");
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(Runner { bin }),
+            request: contract_request(work_dir, true),
+            timeout: Duration::from_millis(10),
+        }
+    }
+
+    fn contract_request(work_dir: std::path::PathBuf, is_new: bool) -> ContractRequest {
+        ContractRequest {
+            session_id: if is_new {
+                String::new()
+            } else {
+                "existing-session".to_string()
+            },
+            is_new,
+            work_dir,
+            instructions: String::new(),
+            permission: PermissionCapability::ReadOnly,
+            prompt: "hello".to_string(),
+        }
+    }
+}

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -70,6 +70,7 @@ pub fn test_config() -> crate::config::Config {
         claude_bin: "/fake/claude".to_string(),
         codex_bin: "/fake/codex".to_string(),
         codex_model: None,
+        pi_bin: "/fake/pi".to_string(),
         sessions_dir: "/fake/sessions".to_string(),
         state_path: "/fake/state.json".to_string(),
         audit_log_path: "/fake/audit.jsonl".to_string(),


### PR DESCRIPTION
## Summary

- add Pi as a third agent backend for default, route, and job selection
- run Pi non-interactively through its JSON event stream, persist and resume exact session IDs, and classify missing sessions for canonical-history recovery
- map Push permission capabilities to conservative Pi tool allowlists and keep SOUL instructions separate from stdin user content
- include default, enabled-route, jobs-default, and installed-runbook Pi selections in binary preflight
- document Pi setup, authentication, sessions, configuration, and permission limits across README, config examples, and reference docs

## Why

Issue #88 requires Pi support without changing Push's channel, history, recovery, or delivery contracts. The adapter follows Pi 0.78 and current official CLI behavior for JSON events, `--session`, `--append-system-prompt`, stdin prompts, and `--tools`.

## Test plan

- `cargo fmt --all --check` passed
- `cargo clippy --locked --all-targets -- -D warnings` passed
- `cargo build --locked` passed
- `cargo test --locked` passed: 232 unit tests, 2 init CLI tests, 3 manual job crash tests
- installed `pi 0.78.0` verified: CLI flags and missing-session exit/message
- focused tests cover parsing, command construction, stdin option/file-like prompts, new/resumed sessions, SOUL separation, permission mapping, missing-session rehydration including early pipe closure, successful auto-retry, malformed/empty/non-zero/timeout/spawn-safe errors, routing, preflight, job override execution, and the shared runner contract
- fresh subagent review completed; all findings were fixed and final review reported no actionable findings

## Risks

Pi provides tool allowlists but no native sandbox or permission prompts. The docs call out that `workspace` omits Bash but cannot confine Pi file tools to the session directory, while `inherit` defers to operator configuration and `full-access` explicitly enables Bash.

Raw Pi stderr and assistant error text are not forwarded, preventing stored credentials or extension output from leaking into replies or audit logs.

## Related issue

Closes #88
