### PR TITLE
fix: replace installed binary atomically

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,17 @@ case "$os:$arch" in
 esac
 
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
+staged=""
+cleanup() {
+  rm -rf "$tmp"
+  if [ -n "$staged" ]; then
+    rm -f "$staged"
+  fi
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 api="https://api.github.com/repos/$repo/releases/latest"
 asset_url="$(
@@ -80,14 +90,24 @@ echo "Verified SHA-256 checksum"
 tar -xzf "$tmp/push.tar.gz" -C "$tmp"
 
 mkdir -p "$bin_dir"
-find "$tmp" -type f -name push -perm -111 -exec cp {} "$bin_dir/push" \;
-chmod +x "$bin_dir/push"
+source="$(find "$tmp" -type f -name push -perm -111 | head -n 1)"
+if [ -z "$source" ]; then
+  echo "push install: release archive does not contain an executable" >&2
+  exit 1
+fi
+
+staged="$(mktemp "$bin_dir/.push.install.XXXXXX")"
+cp "$source" "$staged"
+chmod 755 "$staged"
 
 if [ "$os" = "Darwin" ] && command -v xattr >/dev/null 2>&1; then
-  if xattr -p com.apple.provenance "$bin_dir/push" >/dev/null 2>&1; then
-    xattr -d com.apple.provenance "$bin_dir/push"
+  if xattr -p com.apple.provenance "$staged" >/dev/null 2>&1; then
+    xattr -d com.apple.provenance "$staged"
   fi
 fi
+
+mv -f "$staged" "$bin_dir/push"
+staged=""
 
 echo "Installed push to $bin_dir/push"
 case ":$PATH:" in

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -65,6 +65,10 @@ EOF
 
 cat > "$fake_bin/xattr" <<'EOF'
 #!/bin/sh
+if [ "${XATTR_SIGNAL_PARENT:-}" = "1" ] && [ "$1" = "-p" ]; then
+  kill -TERM "$PPID"
+  exit 0
+fi
 printf '%s\n' "$*" >> "$XATTR_LOG"
 EOF
 
@@ -84,6 +88,7 @@ run_installer() {
   FIXTURE_ARCHIVE="$fixture_dir/push.tar.gz" \
   FIXTURE_CHECKSUM="$checksum" \
   XATTR_LOG="$xattr_log" \
+  XATTR_SIGNAL_PARENT="${XATTR_SIGNAL_PARENT:-}" \
   BIN_DIR="$bin_dir" \
   PATH="$fake_bin:$PATH" \
     sh "$repo_root/install.sh"
@@ -91,22 +96,47 @@ run_installer() {
 
 macos_bin="$test_root/macos-bin"
 macos_xattr="$test_root/macos-xattr.log"
+mkdir -p "$macos_bin"
+printf 'blocked old binary\n' > "$macos_bin/push"
+chmod +x "$macos_bin/push"
+old_inode="$(ls -di "$macos_bin/push" | awk '{ print $1 }')"
 run_installer \
   Darwin arm64 aarch64-apple-darwin \
   "$fixture_dir/push.tar.gz.sha256" "$macos_bin" "$macos_xattr"
 test -x "$macos_bin/push"
-grep -F -- "-d com.apple.provenance $macos_bin/push" "$macos_xattr"
+new_inode="$(ls -di "$macos_bin/push" | awk '{ print $1 }')"
+test "$new_inode" != "$old_inode"
+grep -F -- "-d com.apple.provenance $macos_bin/.push.install." "$macos_xattr"
+test -z "$(find "$macos_bin" -name '.push.install.*' -print -quit)"
 
 bad_bin="$test_root/bad-bin"
 bad_xattr="$test_root/bad-xattr.log"
+mkdir -p "$bad_bin"
+printf 'working old binary\n' > "$bad_bin/push"
+chmod +x "$bad_bin/push"
 if run_installer \
   Darwin arm64 aarch64-apple-darwin \
   "$fixture_dir/bad.sha256" "$bad_bin" "$bad_xattr"; then
   echo "installer accepted a mismatched checksum" >&2
   exit 1
 fi
-test ! -e "$bad_bin/push"
+grep -F 'working old binary' "$bad_bin/push"
 test ! -e "$bad_xattr"
+
+interrupt_bin="$test_root/interrupt-bin"
+interrupt_xattr="$test_root/interrupt-xattr.log"
+mkdir -p "$interrupt_bin"
+printf 'working old binary\n' > "$interrupt_bin/push"
+chmod +x "$interrupt_bin/push"
+set +e
+XATTR_SIGNAL_PARENT=1 run_installer \
+  Darwin arm64 aarch64-apple-darwin \
+  "$fixture_dir/push.tar.gz.sha256" "$interrupt_bin" "$interrupt_xattr"
+interrupt_status=$?
+set -e
+test "$interrupt_status" -eq 143
+grep -F 'working old binary' "$interrupt_bin/push"
+test -z "$(find "$interrupt_bin" -name '.push.install.*' -print -quit)"
 
 linux_bin="$test_root/linux-bin"
 linux_xattr="$test_root/linux-xattr.log"


### PR DESCRIPTION
## Summary

- stage the verified release binary in the destination directory
- clear macOS provenance on the staged file
- atomically rename the new inode over an existing installation
- clean staged files on failure, HUP, INT, or TERM
- cover replacement, checksum failure, interruption, cleanup, and Linux behavior

## Why

Copying a release over an existing `~/.local/bin/push` updates the old inode in place. macOS can retain the old inode's rejected security-policy state, so a verified reinstall is still killed. Deleting the binary first creates a new inode and succeeds. Staging and renaming provides the same new-inode behavior without deleting a working installation before the replacement is ready.

## Test plan

- `sh -n install.sh`
- `dash -n install.sh`
- `bash -n tests/install.sh`
- `bash tests/install.sh`
- real v0.1.0 replacement in a disposable directory under `~/.local/bin`: inode changed and Push reached config loading instead of `SIGKILL`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`
- `git diff --check`
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (237 tests passed)
- independent subagent review with no remaining findings

## Risks

The installer now uses `mktemp` and `mv` in the destination directory. This preserves atomic replacement on the same filesystem. A handled signal before the rename leaves the old binary intact and removes the staged file.

## Related issue

None.
