### PR TITLE
fix: guide first-run configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,11 +53,35 @@ async fn main() -> Result<()> {
         Command::Doctor => doctor::doctor(&args.config_path),
         Command::Job(command) => run_job_command(&args.config_path, command).await,
         Command::Run => {
-            let cfg = config::Config::load(&args.config_path).context("config")?;
+            let cfg = load_run_config(&args.config_path)?;
             doctor::preflight(&cfg).context("preflight")?;
             report_invalid_jobs(&cfg)?;
             gateway::GatewayGroup::new(cfg).context("init")?.run().await
         }
+    }
+}
+
+fn load_run_config(path: &str) -> Result<config::Config> {
+    if matches!(
+        std::fs::symlink_metadata(path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound
+    ) {
+        let path_arg = shell_quote(path);
+        bail!(
+            "configuration not found at {path}\n\nCreate it with:\n  push init --config {path_arg}\n\nThen configure a channel and run `push doctor --config {path_arg}`."
+        );
+    }
+    config::Config::load(path).context("config")
+}
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || b"_@%+=:,./-".contains(&byte))
+    {
+        value.to_owned()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
     }
 }
 

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -66,6 +66,64 @@ fn init_expands_home_in_requested_path() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+#[test]
+fn run_without_default_config_reports_first_run_guidance() {
+    let root = temp_dir("missing-default-config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_push"))
+        .current_dir(&root)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("configuration not found at config.toml"));
+    assert!(stderr.contains("push init --config config.toml"));
+    assert!(stderr.contains("Then configure a channel"));
+    assert!(!stderr.contains("Caused by:"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn run_with_missing_custom_config_reports_selected_path() {
+    let root = temp_dir("missing-custom-config");
+    let config = root.join("custom config's.toml");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_push"))
+        .args(["--config", config.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let quoted_path = format!("'{}'", config.display().to_string().replace('\'', "'\\''"));
+    let expected = format!("push init --config {quoted_path}");
+    assert!(stderr.contains(&expected));
+    assert!(!stderr.contains("read config"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn run_with_dangling_config_symlink_preserves_load_error() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_dir("dangling-config-symlink");
+    let config = root.join("config.toml");
+    symlink(root.join("missing-target.toml"), &config).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_push"))
+        .args(["--config", config.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("read config"));
+    assert!(!stderr.contains("Create it with:"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
 fn temp_dir(name: &str) -> std::path::PathBuf {
     let path = std::env::temp_dir().join(format!("push-init-cli-{name}-{}", Uuid::new_v4()));
     std::fs::create_dir_all(&path).unwrap();


### PR DESCRIPTION
## Summary

- replace the raw missing-config error with actionable `push init` guidance
- preserve existing errors for invalid configs and dangling symlinks
- shell-quote custom paths in copyable commands

## Why

A fresh install currently exits with a low-level file error when `config.toml` does not exist. The CLI should tell a new user how to initialize it.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked`
- `bash tests/install.sh`
- `mkdocs build --strict`
- manual run from an empty temporary directory

## Risks

Low. The new behavior is limited to an absent config path; other load failures retain their existing error chain.

## Related issue

None.