### PR TITLE
chore: prepare v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "push"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "push"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A tiny messaging gateway that turns coding agents into a personal assistant you text."


### PR DESCRIPTION
## Summary

- bump the package version from 0.1.0 to 0.2.0
- keep Cargo.lock release metadata in sync

## Why

Prepare the first usable public release after the installer and first-run fixes.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked --release`
- `cargo test --locked`
- verify `cargo metadata --locked --no-deps` reports 0.2.0

## Risks

Low. This changes package metadata only.

## Related issue

None.