### PR TITLE
fix: use stable default config path

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -93,7 +93,7 @@ Grant Full Disk Access to the exact terminal or service host, restart that
 process, and rerun:
 
 ```sh
-push doctor --config ~/.config/push/config.toml
+push doctor
 ```
 
 ### Messages are ignored

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,11 +1,11 @@
 # Configuration
 
-Push reads TOML from `config.toml` by default. Pass `--config <path>` to every
-gateway, doctor, or job command when the file lives elsewhere.
+Push reads TOML from `~/.push/config.toml` by default. Pass `--config <path>`
+to use a different file for a gateway, doctor, init, or job command.
 
 ```sh
-push doctor --config ~/.config/push/config.toml
-push --config ~/.config/push/config.toml
+push doctor
+push
 ```
 
 Paths beginning with `~` are expanded. Invalid values, unknown fields inside
@@ -16,7 +16,7 @@ Create the one assistant repository and persist its root before editing the
 rest of the config:
 
 ```sh
-push init ~/Code/assistant --config ~/.config/push/config.toml
+push init ~/Code/assistant
 ```
 
 Push derives `SOUL.md`, `context/`, and `jobs/` from `assistant_root`. At run

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,8 +69,7 @@ install -m 755 target/release/push ~/.local/bin/push
 ## 3. Create your assistant repository
 
 ```sh
-mkdir -p ~/.config/push
-push init ~/Code/assistant --config ~/.config/push/config.toml
+push init ~/Code/assistant
 ```
 
 Push creates one Git-versioned repository containing `SOUL.md`, `AGENTS.md`,
@@ -84,7 +83,7 @@ time and never writes machine-specific paths into the repository.
 === "Telegram"
 
     Create a bot with Telegram's `@BotFather`, send it one message, and find
-    your stable numeric user ID. Then create `~/.config/push/config.toml`:
+    your stable numeric user ID. Then edit `~/.push/config.toml`:
 
     ```toml
     channel = "telegram"
@@ -107,7 +106,7 @@ time and never writes machine-specific paths into the repository.
 === "iMessage"
 
     Give the terminal or service host Full Disk Access in macOS System
-    Settings, then create `~/.config/push/config.toml`:
+    Settings, then edit `~/.push/config.toml`:
 
     ```toml
     channel = "imessage"
@@ -134,8 +133,8 @@ user files.
 ## 5. Validate and run
 
 ```sh
-push doctor --config ~/.config/push/config.toml
-push --config ~/.config/push/config.toml
+push doctor
+push
 ```
 
 Send a new message after the gateway starts. Telegram deliberately discards

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -42,9 +42,9 @@ root, Push config, sessions, state, database, audit, drafts, or lock paths.
 ## Validate and inspect jobs
 
 ```sh
-push job validate --config ~/.config/push/config.toml
-push job list --config ~/.config/push/config.toml
-push job show repo-review --config ~/.config/push/config.toml
+push job validate
+push job list
+push job show repo-review
 ```
 
 Validation reports every valid and invalid file. An invalid job is disabled
@@ -53,8 +53,8 @@ individually and does not stop messaging or other valid jobs.
 ## Run a job manually
 
 ```sh
-push job run repo-review --config ~/.config/push/config.toml
-push job runs repo-review --config ~/.config/push/config.toml
+push job run repo-review
+push job runs repo-review
 ```
 
 A manual run executes in the invoking CLI process and prints its result there.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,7 +2,7 @@
 
 Push has one gateway command, one diagnostic command, and a small set of job
 commands. All commands accept `--config <path>` anywhere in the argument list.
-The default is `config.toml` in the current directory.
+The default is `~/.push/config.toml`.
 
 | Command | Purpose |
 | --- | --- |
@@ -18,12 +18,12 @@ The default is `config.toml` in the current directory.
 Examples:
 
 ```sh
-push init ~/Code/assistant --config ~/.config/push/config.toml
-push doctor --config ~/.config/push/config.toml
-push --config ~/.config/push/config.toml
-push job validate --config ~/.config/push/config.toml
-push --config ~/.config/push/config.toml job run repo-review
-push job runs repo-review --config ~/.config/push/config.toml
+push init ~/Code/assistant
+push doctor
+push
+push job validate
+push job run repo-review
+push job runs repo-review
 ```
 
 Unknown commands and missing values fail with the accepted command forms. The

--- a/docs/services.md
+++ b/docs/services.md
@@ -12,10 +12,9 @@ Build or install `push`, then run doctor from the same user account that will
 own the service:
 
 ```sh
-mkdir -p ~/.config/push ~/.push
-# Copy config.toml.example to ~/.config/push/config.toml and edit channel settings.
-push init ~/Code/assistant --config ~/.config/push/config.toml
-push doctor --config /Users/YOU/.config/push/config.toml
+push init ~/Code/assistant
+# Edit ~/.push/config.toml with your channel settings.
+push doctor
 ```
 
 Use absolute paths in service files. The service user needs:
@@ -70,7 +69,7 @@ and replace `YOU` with your macOS user name:
   <array>
     <string>/Users/YOU/.local/bin/push</string>
     <string>--config</string>
-    <string>/Users/YOU/.config/push/config.toml</string>
+    <string>/Users/YOU/.push/config.toml</string>
   </array>
 
   <key>WorkingDirectory</key>
@@ -135,7 +134,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=%h/.local/bin/push --config %h/.config/push/config.toml
+ExecStart=%h/.local/bin/push --config %h/.push/config.toml
 WorkingDirectory=%h/.push
 Restart=on-failure
 RestartSec=10

--- a/examples/launchd/com.owainlewis.push.plist
+++ b/examples/launchd/com.owainlewis.push.plist
@@ -10,7 +10,7 @@
   <array>
     <string>/Users/YOU/.local/bin/push</string>
     <string>--config</string>
-    <string>/Users/YOU/.config/push/config.toml</string>
+    <string>/Users/YOU/.push/config.toml</string>
   </array>
 
   <key>WorkingDirectory</key>

--- a/examples/systemd/push.service
+++ b/examples/systemd/push.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=%h/.local/bin/push --config %h/.config/push/config.toml
+ExecStart=%h/.local/bin/push --config %h/.push/config.toml
 WorkingDirectory=%h/.push
 Restart=on-failure
 RestartSec=10

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,9 @@ pub struct Config {
 impl Config {
     /// Load, expand `~` in path fields, and validate the config at `path`.
     pub fn load(path: &str) -> Result<Config> {
-        let raw = std::fs::read_to_string(path).with_context(|| format!("read config {path}"))?;
+        let expanded_path = expand_home(path);
+        let raw = std::fs::read_to_string(&expanded_path)
+            .with_context(|| format!("read config {expanded_path}"))?;
         let mut value: toml::Value = toml::from_str(&raw).context("parse TOML config")?;
         let root = value
             .as_table_mut()
@@ -151,8 +153,8 @@ impl Config {
             ],
         )?;
         let mut c: Config = value.try_into().context("parse TOML config")?;
-        let config_path =
-            std::fs::canonicalize(path).with_context(|| format!("resolve config {path}"))?;
+        let config_path = std::fs::canonicalize(&expanded_path)
+            .with_context(|| format!("resolve config {expanded_path}"))?;
         c.db_path = expand_home(&c.db_path);
         c.sessions_dir = expand_home(&c.sessions_dir);
         c.state_path = expand_home(&c.state_path);

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -25,13 +25,13 @@ pub fn doctor(config_path: &str) -> Result<()> {
     let cfg = match config::Config::load(config_path) {
         Ok(cfg) => cfg,
         Err(e) => {
+            let message = crate::missing_config_message(config_path).unwrap_or_else(|| {
+                format!(
+                    "cannot load {config_path}: {e}. Create the file from config.toml.example or fix the invalid value."
+                )
+            });
             let report = CheckReport {
-                checks: vec![Check::fail(
-                    "config",
-                    format!(
-                        "cannot load {config_path}: {e}. Create the file from config.toml.example or fix the invalid value."
-                    ),
-                )],
+                checks: vec![Check::fail("config", message)],
             };
             print!("{report}");
             bail!("doctor found 1 failed check");

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ mod util;
 
 use anyhow::{bail, Context, Result};
 
+const DEFAULT_CONFIG_PATH: &str = "~/.push/config.toml";
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt().with_target(false).init();
@@ -46,8 +48,13 @@ async fn main() -> Result<()> {
             println!("\nNext:");
             println!("  $EDITOR {}/SOUL.md", result.root.display());
             println!("  $EDITOR {}/context/README.md", result.root.display());
-            println!("  push doctor --config {}", result.config_path.display());
-            println!("  push --config {}", result.config_path.display());
+            if args.config_path == DEFAULT_CONFIG_PATH {
+                println!("  push doctor");
+                println!("  push");
+            } else {
+                println!("  push doctor --config {}", result.config_path.display());
+                println!("  push --config {}", result.config_path.display());
+            }
             Ok(())
         }
         Command::Doctor => doctor::doctor(&args.config_path),
@@ -62,16 +69,29 @@ async fn main() -> Result<()> {
 }
 
 fn load_run_config(path: &str) -> Result<config::Config> {
-    if matches!(
-        std::fs::symlink_metadata(path),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound
-    ) {
-        let path_arg = shell_quote(path);
-        bail!(
-            "configuration not found at {path}\n\nCreate it with:\n  push init --config {path_arg}\n\nThen configure a channel and run `push doctor --config {path_arg}`."
-        );
+    if let Some(message) = missing_config_message(path) {
+        bail!(message);
     }
     config::Config::load(path).context("config")
+}
+
+fn missing_config_message(path: &str) -> Option<String> {
+    let expanded_path = util::expand_home(path);
+    if !matches!(
+        std::fs::symlink_metadata(&expanded_path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound
+    ) {
+        return None;
+    }
+    if path == DEFAULT_CONFIG_PATH {
+        return Some(format!(
+            "configuration not found at {path}\n\nCreate it with:\n  push init\n\nThen configure a channel and run `push doctor`."
+        ));
+    }
+    let path_arg = shell_quote(path);
+    Some(format!(
+        "configuration not found at {path}\n\nCreate it with:\n  push init --config {path_arg}\n\nThen configure a channel and run `push doctor --config {path_arg}`."
+    ))
 }
 
 fn shell_quote(value: &str) -> String {
@@ -110,7 +130,7 @@ enum JobCommand {
 
 impl Args {
     fn parse(args: Vec<String>) -> Result<Self> {
-        let mut config_path = "config.toml".to_string();
+        let mut config_path = DEFAULT_CONFIG_PATH.to_string();
         let mut positional = Vec::new();
         let mut i = 0;
         while i < args.len() {
@@ -151,7 +171,7 @@ impl Args {
 }
 
 async fn run_job_command(config_path: &str, command: JobCommand) -> Result<()> {
-    let cfg = config::Config::load(config_path).context("config")?;
+    let cfg = load_run_config(config_path)?;
     match command {
         JobCommand::Validate => {
             let catalog = jobs::Catalog::load(&cfg)?;
@@ -367,12 +387,12 @@ mod tests {
     }
 
     #[test]
-    fn defaults_to_toml_config_path() {
+    fn defaults_to_user_config_path() {
         assert_eq!(
             Args::parse(Vec::new()).unwrap(),
             Args {
                 command: Command::Run,
-                config_path: "config.toml".to_string(),
+                config_path: DEFAULT_CONFIG_PATH.to_string(),
             }
         );
     }

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -5,9 +5,14 @@ use uuid::Uuid;
 #[test]
 fn init_without_path_creates_assistant_in_current_directory() {
     let root = temp_dir("default");
+    let home = root.join("home");
+    let workdir = root.join("workdir");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&workdir).unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_push"))
         .arg("init")
-        .current_dir(&root)
+        .current_dir(&workdir)
+        .env("HOME", &home)
         .output()
         .unwrap();
 
@@ -16,12 +21,14 @@ fn init_without_path_creates_assistant_in_current_directory() {
         "{}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let assistant = root.join("assistant");
+    let assistant = workdir.join("assistant");
     assert!(assistant.join("SOUL.md").is_file());
     assert!(assistant.join("context/README.md").is_file());
     assert!(assistant.join("jobs").is_dir());
     assert!(assistant.join(".git").exists());
-    let config = std::fs::read_to_string(root.join("config.toml")).unwrap();
+    let config_path = home.join(".push/config.toml");
+    let config = std::fs::read_to_string(&config_path).unwrap();
+    assert!(!workdir.join("config.toml").exists());
     assert!(config.contains(
         &assistant
             .canonicalize()
@@ -31,6 +38,7 @@ fn init_without_path_creates_assistant_in_current_directory() {
     ));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("push doctor"));
+    assert!(!stdout.contains("push doctor --config"));
     assert!(stdout.contains("SOUL.md"));
     let _ = std::fs::remove_dir_all(root);
 }
@@ -69,18 +77,77 @@ fn init_expands_home_in_requested_path() {
 #[test]
 fn run_without_default_config_reports_first_run_guidance() {
     let root = temp_dir("missing-default-config");
+    let home = root.join("home");
+    std::fs::create_dir_all(&home).unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_push"))
         .current_dir(&root)
+        .env("HOME", &home)
         .output()
         .unwrap();
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("configuration not found at config.toml"));
-    assert!(stderr.contains("push init --config config.toml"));
+    assert!(stderr.contains("configuration not found at ~/.push/config.toml"));
+    assert!(stderr.contains("Create it with:\n  push init"));
+    assert!(!stderr.contains("push init --config"));
     assert!(stderr.contains("Then configure a channel"));
     assert!(!stderr.contains("Caused by:"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn run_reads_existing_default_config_from_home() {
+    let root = temp_dir("existing-default-config");
+    let home = root.join("home");
+    let config_dir = home.join(".push");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(config_dir.join("config.toml"), "invalid = [").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_push"))
+        .current_dir(&root)
+        .env("HOME", &home)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("parse TOML"));
+    assert!(!stderr.contains("configuration not found"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn doctor_without_default_config_reports_init_guidance() {
+    assert_missing_default_config_guidance(&["doctor"]);
+}
+
+#[test]
+fn job_without_default_config_reports_init_guidance() {
+    assert_missing_default_config_guidance(&["job", "list"]);
+}
+
+fn assert_missing_default_config_guidance(args: &[&str]) {
+    let root = temp_dir("missing-default-config-command");
+    let home = root.join("home");
+    std::fs::create_dir_all(&home).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_push"))
+        .args(args)
+        .current_dir(&root)
+        .env("HOME", &home)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(combined.contains("configuration not found at ~/.push/config.toml"));
+    assert!(combined.contains("Create it with:\n  push init"));
+    assert!(!combined.contains("config.toml.example"));
     let _ = std::fs::remove_dir_all(root);
 }
 


### PR DESCRIPTION
## Summary

- make `~/.push/config.toml` the default for init, gateway, doctor, and job commands
- make `push init` create the default config without requiring `--config`
- expand `~` in config filenames and keep explicit `--config` overrides
- align first-run guidance, docs, and service examples

## Why

The previous default wrote `config.toml` into whichever directory launched `push init`, making fresh installs hard to locate and later commands dependent on their working directory.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked`
- `bash tests/install.sh`
- `mkdocs build --strict`
- disposable HOME smoke test from unrelated working directories

## Risks

The default path changes from `./config.toml` to `~/.push/config.toml`. Project-local configs remain supported with `--config`.

## Related issue

None.