### PR TITLE
fix: make init Telegram-first

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,9 +19,12 @@ rest of the config:
 push init ~/Code/assistant
 ```
 
-Push derives `SOUL.md`, `context/`, and `jobs/` from `assistant_root`. At run
-time it appends their resolved absolute locations to the user-owned `SOUL.md`
-instructions in memory. It does not write machine paths into the repository.
+For a new file, init writes a Telegram and Codex starting point with an empty
+`telegram.allow_user_ids` list. Replace it with your numeric Telegram user ID
+before running Push. Push derives `SOUL.md`, `context/`, and `jobs/` from
+`assistant_root`. At run time it appends their resolved absolute locations to
+the user-owned `SOUL.md` instructions in memory. It does not write machine
+paths into the repository.
 
 Root configuration, route, primary-delivery, and custom-profile tables do not
 yet reject every unknown key. Use the documented names, then run `push doctor`;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,9 +74,11 @@ push init ~/Code/assistant
 
 Push creates one Git-versioned repository containing `SOUL.md`, `AGENTS.md`,
 `README.md`, `context/`, and an empty `jobs/`. It records the canonical root in
-the selected config file. Edit `SOUL.md` to define identity and operating style,
-then add durable user context under `context/`. Push reads these files at run
-time and never writes machine-specific paths into the repository.
+the selected config file. A new config starts with Telegram, Codex, and an empty
+`telegram.allow_user_ids` list that you must fill in. Edit `SOUL.md` to define
+identity and operating style, then add durable user context under `context/`.
+Push reads these files at run time and never writes machine-specific paths into
+the repository.
 
 ## 4. Configure a channel
 

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -47,6 +47,15 @@ Store durable facts and working context here when they should be available acros
 Good examples include preferences, active projects, people, recurring processes, and reference notes. Keep secrets out of this repository. Start with small, focused Markdown files and update or remove stale information.
 "#;
 
+const DEFAULT_CONFIG: &str = r#"# Telegram quick start. Export TELEGRAM_BOT_TOKEN before running Push.
+channel = "telegram"
+agent = "codex"
+
+[telegram]
+# Replace this with your numeric Telegram user ID.
+allow_user_ids = []
+"#;
+
 #[derive(Debug)]
 pub struct InitResult {
     pub root: PathBuf,
@@ -90,6 +99,7 @@ pub fn init(requested_path: &str, config_path: &str) -> Result<InitResult> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ConfigState {
+    MissingFile,
     MissingRoot,
     MatchingRoot,
 }
@@ -99,7 +109,7 @@ fn inspect_config(config_path: &Path, target: &Path) -> Result<ConfigState> {
         Ok(raw) => raw,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             validate_runtime_boundary(None, target)?;
-            return Ok(ConfigState::MissingRoot);
+            return Ok(ConfigState::MissingFile);
         }
         Err(error) => {
             return Err(error).with_context(|| format!("read config {}", config_path.display()))
@@ -408,7 +418,12 @@ fn persist_root(config_path: &Path, root: &Path, state: ConfigState) -> Result<(
     };
     let existing = match fs::read_to_string(config_path) {
         Ok(existing) => existing,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error)
+            if error.kind() == std::io::ErrorKind::NotFound
+                && state == ConfigState::MissingFile =>
+        {
+            DEFAULT_CONFIG.to_string()
+        }
         Err(error) => {
             return Err(error).with_context(|| format!("read config {}", config_path.display()))
         }
@@ -713,6 +728,8 @@ mod tests {
         let raw = fs::read_to_string(&config).unwrap();
         assert!(raw.starts_with("channel = 'telegram'\n"));
         assert!(raw.contains("assistant_root = \".\""));
+        assert!(!raw.contains("agent = \"codex\""));
+        assert!(!raw.contains("allow_user_ids"));
         assert!(target.join("SOUL.md").is_file());
         let _ = fs::remove_dir_all(target);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,14 +46,18 @@ async fn main() -> Result<()> {
                 println!("Initialized Git repository.");
             }
             println!("\nNext:");
-            println!("  $EDITOR {}/SOUL.md", result.root.display());
-            println!("  $EDITOR {}/context/README.md", result.root.display());
+            println!("  Review or configure the channel and its allowlist:");
+            println!("    $EDITOR {}", result.config_path.display());
+            println!("  Customize the assistant:");
+            println!("    $EDITOR {}/SOUL.md", result.root.display());
+            println!("    $EDITOR {}/context/README.md", result.root.display());
+            println!("  Validate and run:");
             if args.config_path == DEFAULT_CONFIG_PATH {
-                println!("  push doctor");
-                println!("  push");
+                println!("    push doctor");
+                println!("    push");
             } else {
-                println!("  push doctor --config {}", result.config_path.display());
-                println!("  push --config {}", result.config_path.display());
+                println!("    push doctor --config {}", result.config_path.display());
+                println!("    push --config {}", result.config_path.display());
             }
             Ok(())
         }
@@ -72,7 +76,8 @@ fn load_run_config(path: &str) -> Result<config::Config> {
     if let Some(message) = missing_config_message(path) {
         bail!(message);
     }
-    config::Config::load(path).context("config")
+    let expanded_path = util::expand_home(path);
+    config::Config::load(path).with_context(|| format!("load config {expanded_path}"))
 }
 
 fn missing_config_message(path: &str) -> Option<String> {

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -29,6 +29,11 @@ fn init_without_path_creates_assistant_in_current_directory() {
     let config_path = home.join(".push/config.toml");
     let config = std::fs::read_to_string(&config_path).unwrap();
     assert!(!workdir.join("config.toml").exists());
+    assert!(config.contains("channel = \"telegram\""));
+    assert!(config.contains("agent = \"codex\""));
+    assert!(config.contains("[telegram]"));
+    assert!(config.contains("allow_user_ids = []"));
+    assert!(config.contains("TELEGRAM_BOT_TOKEN"));
     assert!(config.contains(
         &assistant
             .canonicalize()
@@ -37,9 +42,28 @@ fn init_without_path_creates_assistant_in_current_directory() {
             .to_string()
     ));
     let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Review or configure the channel and its allowlist:"));
     assert!(stdout.contains("push doctor"));
     assert!(!stdout.contains("push doctor --config"));
+    assert!(stdout.contains(&format!("$EDITOR {}", config_path.display())));
+    assert!(
+        stdout
+            .find(&format!("$EDITOR {}", config_path.display()))
+            .unwrap()
+            < stdout.find("push doctor").unwrap()
+    );
     assert!(stdout.contains("SOUL.md"));
+
+    let run_output = Command::new(env!("CARGO_BIN_EXE_push"))
+        .current_dir(&workdir)
+        .env("HOME", &home)
+        .output()
+        .unwrap();
+    assert!(!run_output.status.success());
+    let run_stderr = String::from_utf8_lossy(&run_output.stderr);
+    assert!(run_stderr.contains(&format!("load config {}", config_path.display())));
+    assert!(run_stderr.contains("set telegram.allow_user_ids or telegram.allow_chat_ids"));
+    assert!(!run_stderr.contains("imessage"));
     let _ = std::fs::remove_dir_all(root);
 }
 


### PR DESCRIPTION
## Summary

- initialize new configs with Telegram and Codex defaults
- leave the Telegram allowlist empty and document the required user ID and token environment variable
- direct users to edit the generated config before doctor and run
- name the exact config path when validation fails
- preserve existing config files without injecting new defaults

## Why

A new config contained only `assistant_root`, so Push silently selected iMessage and failed with an unhelpful `Error: config` message. Fresh setup should be explicit, Telegram-first, and actionable without inventing a trusted identity.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked`
- `bash tests/install.sh`
- `mkdocs build --strict`
- disposable HOME smoke test covering init and incomplete-config failure

## Risks

Low. Telegram and Codex defaults are written only when the config file does not exist. Existing files are preserved. New users must still enter their own Telegram user ID and export `TELEGRAM_BOT_TOKEN`.

## Related issue

None.