### PR TITLE
chore: prepare v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "push"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "push"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "A tiny messaging gateway that turns coding agents into a personal assistant you text."


### PR DESCRIPTION
## Summary

- bump the package version from 0.2.0 to 0.3.0
- keep Cargo.lock release metadata in sync

## Why

Publish the stable home config path, Telegram-first init, clearer setup guidance, and graceful config errors.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked --release`
- `cargo test --locked`
- `bash tests/install.sh`
- `mkdocs build --strict`
- verify locked Cargo metadata reports 0.3.0

## Risks

Low. This PR changes package metadata only; the release will be smoke-tested from the public installer before handoff.

## Related issue

None.