### PR TITLE
feat(config): defer permissions to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ Your coding agent owns the intelligence and tools.
   Markdown job and send the stored result back to your primary chat.
 - **State you own.** `SOUL.md`, durable context, and installed jobs live in
   one assistant repository. History is local SQLite and configuration is TOML.
-- **A small local control layer.** Sender allowlists and permission profiles
-  constrain chat access and local execution. Backend tools such as Codex MCP
-  servers keep the permissions defined in the backend. Telegram uses outbound
-  long polling and opens no port.
+- **A small local control layer.** Sender allowlists constrain chat access.
+  Agent permissions, tools, and MCP servers stay in the agent configuration.
+  Telegram uses outbound long polling and opens no port.
 
 ## The model
 
@@ -80,7 +79,7 @@ and the rest of your day.
 - One Git-versioned assistant repository containing `SOUL.md`, `context/`, and
   approved `jobs/`
 - Durable conversation history and backend session recovery
-- Named read-only, workspace, and backend-inherited permission profiles
+- Agent-owned permissions with no gateway sandbox or tool overrides
 - Manual and scheduled Markdown jobs with a durable run ledger
 - Agent-drafted jobs that require approval of the exact revision in chat
 - Local structured audit logs with message content redacted by default
@@ -107,9 +106,8 @@ run `push doctor`, and keep the gateway online.
 To use [Pi](https://pi.dev/), install it, complete provider authentication for
 the same service user that runs Push, and set `agent = "pi"`. `pi_bin` defaults
 to `pi`. Push stores Pi's reported session ID and resumes that exact session on
-later turns; `/clear` starts a new one. Pi has tool allowlists but no native
-sandbox or permission prompts, so read the documented permission limits before
-allowing writes or shell access.
+later turns; `/clear` starts a new one. Push passes no tool override to Pi, so
+review Pi's own configuration before allowing unattended access.
 
 ## Documentation
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,4 +1,4 @@
-# Telegram quick start. The bot token comes from TELEGRAM_BOT_TOKEN.
+# Telegram quick start.
 channel = "telegram"
 agent = "codex"
 assistant_root = "~/Code/assistant"
@@ -7,11 +7,8 @@ assistant_root = "~/Code/assistant"
 # agent = "pi"
 # pi_bin = "pi"
 
-# Chat is read-only by default. Uncomment to defer entirely to your own
-# backend settings (Claude Code allow rules, Codex sandbox, or Pi tool config),
-# including shell.
-# permission_profile = "inherit"
-
 [telegram]
+# Paste the token from BotFather here. Keep this file private.
+bot_token = "replace-with-the-token-from-BotFather"
 # Replace this once with your numeric Telegram user ID.
 allow_user_ids = [123456789]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,6 @@ Request {
     session_id,
     is_new,
     work_dir,
-    additional_dirs,
     instructions,
     prompt,
 }
@@ -185,8 +184,8 @@ Pi creates its own session id and reports it in the first JSON event.
 - Work dir: per-thread session directory
 
 The adapter reads the session header and final assistant `message_end` event.
-Pi tool allowlists implement Push permission profiles, but Pi has no native
-filesystem sandbox or permission prompts.
+Push passes no tool override to Pi. Pi has no native filesystem sandbox or
+interactive permission prompts, so its own configuration is the boundary.
 
 ## State Model
 
@@ -271,15 +270,14 @@ state and consume an answered value once; crossing the expiry first records an
 expired terminal state, so later cancellation cannot overwrite the timeout.
 
 Agent-written job proposals live separately under origin-specific inboxes in
-`drafts_dir`. Route backends receive only their exact inbox as an additional
-writable root under contained permission profiles; full-access routes are
-rejected because they cannot enforce that boundary. Push snapshots
+`drafts_dir`. Push creates the exact inbox and includes its path in the route's
+instructions. The selected agent's configuration decides whether it is writable. Push snapshots
 and validates a changed regular file, stores its exact bytes, hash, proposer,
 and bound approval question in SQLite, then sends the full proposal to the
 originating channel. Reconciliation also runs after backend failure or timeout
 and before replaying a persisted outbound reply, so a crash cannot orphan an
 unrecorded revision. Approval rechecks the path, symlink status, revision, job
-schema, protected work directory, and configured permission ceiling. A valid
+schema and protected work directory. A valid
 stored revision is staged inside the derived assistant `jobs/` directory and
 installed with an atomic
 no-clobber link. Rejection and revision mismatch never activate the draft, and
@@ -305,9 +303,8 @@ assistant, context, and jobs paths. The footer directs the backend to begin
 with `context/README.md` when useful, protect `SOUL.md` and installed jobs, and
 use the job draft approval flow. Push does not write the footer to the
 repository or inject all context files into each prompt. The selected backend
-and permission profile decide what to inspect. Conversation runs receive
-`context/` as an additional workspace; installed jobs are not added as a
-writable root.
+and its configuration decide what to inspect. Instructions include the absolute
+`context/` path; Push does not add it as a writable root.
 
 Sessions, databases, drafts, audit logs, delivery state, locks, config secrets,
 and other runtime state stay outside the Git-versioned assistant repository.
@@ -328,15 +325,9 @@ the trust boundary. iMessage uses `imessage.self_handles` and
 `imessage.allow_from`; Telegram uses stable numeric `telegram.allow_user_ids`
 and `telegram.allow_chat_ids`.
 
-Routes select a named Push permission profile. `restricted` is the default.
-Push rejects `full-access` for routes because backend bypass modes cannot
-protect Push-owned files. Claude receives a fixed tool allowlist and denies
-Bash; Codex receives `read-only` or `workspace-write`. Claude does not provide
-a Codex-equivalent filesystem sandbox, so its `workspace` mapping permits file
-tools but deliberately omits shell access. Custom profiles select a capability,
-not raw backend flags. Jobs always inherit the backend's own permission
-configuration and must use a work directory that does not overlap Push-owned
-state or configuration.
+Push does not override sandbox, approval, permission-mode, or tool-list settings.
+Chats and jobs use the selected agent's own configuration and must use work
+directories that do not overlap Push-owned state or configuration.
 
 ## Extension Points
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -44,8 +44,7 @@ matched after formatting is removed. Email addresses are matched without case
 sensitivity.
 
 Treat every allowed handle as an operator of the configured backend. A sender
-can ask the agent to use any capability allowed by the selected permission
-profile.
+can ask the agent to use any capability allowed by that agent's configuration.
 
 ## What Push ignores
 
@@ -68,11 +67,9 @@ Self-chat keys use `imessage:self:<handle>`. Allowed direct-message keys use
 [[routes]]
 thread = "imessage:self:you@icloud.com"
 agent = "claude"
-permission_profile = "workspace"
 ```
 
-See [configuration](../configuration.md#routing) for precedence and permission
-selection.
+See [configuration](../configuration.md#routing) for route precedence.
 
 ## Restart behavior
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ push
 ```
 
 Paths beginning with `~` are expanded. Invalid values, unknown fields inside
-provider sections, unsafe path overlap, and removed legacy permission settings
+provider sections, unsafe path overlap, and removed gateway permission settings
 fail configuration load with an actionable error.
 
 Create the one assistant repository and persist its root before editing the
@@ -19,14 +19,14 @@ rest of the config:
 push init ~/Code/assistant
 ```
 
-For a new file, init writes a Telegram and Codex starting point with an empty
-`telegram.allow_user_ids` list. Replace it with your numeric Telegram user ID
-before running Push. Push derives `SOUL.md`, `context/`, and `jobs/` from
+For a new file, init writes a private, owner-only Telegram and Codex starting
+point with empty `telegram.bot_token` and `telegram.allow_user_ids` values.
+Fill both in before running Push. Push derives `SOUL.md`, `context/`, and `jobs/` from
 `assistant_root`. At run time it appends their resolved absolute locations to
 the user-owned `SOUL.md` instructions in memory. It does not write machine
 paths into the repository.
 
-Root configuration, route, primary-delivery, and custom-profile tables do not
+Root configuration, route, and primary-delivery tables do not
 yet reject every unknown key. Use the documented names, then run `push doctor`;
 do not assume a silent key changed runtime behavior.
 
@@ -38,12 +38,13 @@ agent = "codex"
 assistant_root = "~/Code/assistant"
 
 [telegram]
+bot_token = "token-from-BotFather"
 allow_user_ids = [123456789]
 ```
 
 `channel` is the easiest single-provider setup. `agent` is `claude`, `codex`,
-or `pi`. Chat uses the built-in `restricted` permission profile unless you
-select another profile.
+or `pi`. Push does not set sandbox, approval, permission-mode, or tool flags.
+Configure those in the selected agent.
 
 ### Pi setup
 
@@ -80,14 +81,15 @@ enabled. See the [iMessage guide](channels/imessage.md).
 
 ```toml
 [telegram]
-bot_token_env = "TELEGRAM_BOT_TOKEN"
+bot_token = "token-from-BotFather"
 allow_user_ids = [123456789]
 allow_chat_ids = []
 ```
 
-At least one stable numeric user or chat ID is required. Prefer the token
-environment variable over `bot_token` in the file. See the [Telegram
-guide](telegram.md).
+At least one stable numeric user or chat ID is required. Keep the config file
+private. `push init` creates new config files with mode `0600` on Unix. The
+`bot_token_env` setting remains available when an environment variable is a
+better fit. See the [Telegram guide](telegram.md).
 
 ### Run both providers
 
@@ -101,6 +103,7 @@ agent = "codex"
 self_handles = ["you@icloud.com"]
 
 [telegram]
+bot_token = "token-from-BotFather"
 allow_user_ids = [123456789]
 
 [primary_delivery]
@@ -118,21 +121,16 @@ Telegram topic targets use `"<chat-id>:<topic-id>"`.
 
 ## Routing
 
-Routes can override the backend and permission profile for a channel or exact
-thread:
+Routes can override the backend for a channel or exact thread:
 
 ```toml
-permission_profile = "restricted"
-
 [[routes]]
 channel = "telegram"
 agent = "codex"
-permission_profile = "restricted"
 
 [[routes]]
 thread = "telegram:dm:123456789"
 agent = "claude"
-permission_profile = "workspace"
 ```
 
 Precedence is:
@@ -140,7 +138,7 @@ Precedence is:
 1. exact thread or topic route
 2. parent Telegram private-chat route for a topic
 3. channel route
-4. root `agent` and `permission_profile`
+4. root `agent`
 
 Thread keys are:
 
@@ -149,26 +147,12 @@ Thread keys are:
 - `telegram:dm:<chat-id>`
 - `telegram:dm:<chat-id>:topic:<topic-id>`
 
-## Permission profiles
+## Agent permissions
 
-Built-in profiles are `restricted`, `workspace`, `inherit`, and
-`full-access`. `full-access` is deliberately rejected for chat routes because
-its backend bypass mode cannot protect Push-owned files.
-
-Create a named alias when the name explains intent:
-
-```toml
-[permission_profiles.research]
-capability = "read-only"
-
-[[routes]]
-channel = "telegram"
-agent = "codex"
-permission_profile = "research"
-```
-
-Custom profiles select only a capability. They cannot inject raw backend
-flags. See [permissions and security](security.md) for exact backend mappings.
+Permissions belong to the agent, not the gateway. Push invokes Claude Code,
+Codex, and Pi without overriding their sandbox, approval mode, or tool lists.
+This keeps interactive and gateway behavior aligned. Configure permissions in
+the selected agent and review [permissions and security](security.md).
 
 ## Settings reference
 
@@ -179,7 +163,6 @@ flags. See [permissions and security](security.md) for exact backend mappings.
 | `channel` | `"imessage"` | Single enabled provider when `channels` is empty |
 | `channels` | `[]` | Concurrent enabled providers |
 | `agent` | `"claude"` | Default backend |
-| `permission_profile` | `"restricted"` | Default chat permission profile |
 | `poll_interval` | `"3s"` | Delay between channel polls |
 | `run_timeout` | `"120s"` | Maximum chat backend run time |
 | `claude_bin` | `"claude"` | Claude Code executable |
@@ -220,7 +203,6 @@ repository.
 channels = ["imessage", "telegram"]
 agent = "codex"
 assistant_root = "~/Code/assistant"
-permission_profile = "restricted"
 poll_interval = "3s"
 run_timeout = "120s"
 
@@ -229,25 +211,22 @@ self_handles = ["you@icloud.com"]
 allow_from = []
 
 [telegram]
-bot_token_env = "TELEGRAM_BOT_TOKEN"
+bot_token = "token-from-BotFather"
 allow_user_ids = [123456789]
 
 [primary_delivery]
 channel = "telegram"
 target = "123456789"
 
-[permission_profiles.trusted-workspace]
-capability = "workspace"
-
 [[routes]]
 thread = "telegram:dm:123456789"
 agent = "claude"
-permission_profile = "trusted-workspace"
 ```
 
 Legacy flat channel fields remain accepted for migration, but new
 configurations should use `[imessage]` and `[telegram]`. JSON configuration and
-raw backend permission fields are no longer supported.
+gateway permission fields are no longer supported. Configure permissions in
+the selected agent instead.
 
 Legacy `assistant_dir` and `jobs_dir` settings remain compatible only when the
 jobs path is exactly `<assistant_dir>/jobs`. For separate legacy paths, move

--- a/docs/core-system/design.md
+++ b/docs/core-system/design.md
@@ -7,7 +7,7 @@
 ## Summary
 
 Push is a local personal-assistant gateway. It owns channels, conversation
-history, routing, permissions, scheduling, approvals, and delivery while
+history, routing, scheduling, approvals, and delivery while
 delegating reasoning and tool use to disposable agent runtimes such as Claude
 Code and Codex. The durable assistant is one user-owned Git repository with
 `SOUL.md`, `context/`, and `jobs/`. Push stores the canonical conversation
@@ -29,8 +29,7 @@ history in SQLite outside that repository.
 - Generate or reconcile `MEMORY.md` in the first implementation.
 - Inject an entire conversation transcript into every request.
 - Build embeddings, semantic retrieval, or a general knowledge system.
-- Build a new filesystem sandbox. Push uses the existing named permission
-  profiles and each backend's filesystem controls.
+- Build a new filesystem sandbox. Push defers to each agent's own controls.
 - Build a custom agent loop, tool runner, plugin system, or MCP layer in Push.
 - Build assistant registries, IDs, selection, or multi-assistant commands.
 - Define autonomous memory write-back here.
@@ -89,9 +88,9 @@ Propose job changes through Push's approval workflow.
 Claude Code and Pi receive the composed text as appended system instructions.
 Codex receives it as developer instructions. Push never writes resolved machine paths
 into `SOUL.md` and does not inject all context files into every prompt. The
-backend decides which files to inspect. Conversation routes receive `context/`
-as an additional workspace subject to their permission profile; `SOUL.md` and
-installed jobs remain protected by the existing sandbox and approval boundary.
+backend decides which files to inspect. Conversation instructions include the
+absolute `context/` path. The agent's own configuration decides access;
+`SOUL.md` and installed jobs remain protected by Push's workflow rules and OS permissions.
 
 Push owns the footer so customising `SOUL.md` cannot remove repository
 locations or ownership rules. Runtime sessions, drafts, databases, audit logs,
@@ -169,7 +168,7 @@ backend session id. The request separates:
 - instructions: composed `SOUL.md`, resolved assistant paths, and gateway-owned policy;
 - current message: the user's request;
 - conversation identity and backend session state;
-- working directory, timeout, and permissions.
+- working directory and timeout.
 
 Conversation history storage happens around this boundary and is independent
 of the selected backend. Agent tools, skills, MCP servers, model choice, and

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,13 +93,8 @@ the repository.
     assistant_root = "~/Code/assistant"
 
     [telegram]
+    bot_token = "token-from-BotFather"
     allow_user_ids = [123456789]
-    ```
-
-    Export the token in the same environment that starts Push:
-
-    ```sh
-    export TELEGRAM_BOT_TOKEN='token-from-BotFather'
     ```
 
     Read the [Telegram guide](telegram.md) for token storage, allowlisting,
@@ -146,12 +141,10 @@ Try:
 
 > Summarize `/absolute/path/to/my-project/README.md`. Do not change anything.
 
-Replace the example path with a file the service user can read. The default
-`restricted` profile makes local filesystem and process access read-only, but
-Codex MCP servers keep the capabilities from your Codex configuration. Broader
-local access is an explicit configuration choice. Read
-[permissions and security](security.md) before enabling writes or inheriting
-backend permissions.
+Replace the example path with a file the service user can read. Push does not
+override the agent's sandbox, approval mode, or tool list. The selected agent's
+configuration decides what the request can do. Read [permissions and
+security](security.md) before running the gateway unattended.
 
 ## 6. Keep it online
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -99,7 +99,7 @@ skipped; repeated local times run once at their first instant.
 ## Execution and delivery guarantees
 
 - Every run uses a fresh backend session, without chat history.
-- Jobs always inherit the backend's own permission configuration.
+- Jobs use the selected agent's own permission configuration.
 - Push does not retry failed or timed-out backend execution because the agent
   may have completed external side effects before failing.
 - Success, failure, timeout, overlap, and delivery state are stored separately.
@@ -113,10 +113,10 @@ destination, bounded result, and error details.
 
 ## Agent-drafted jobs
 
-A `workspace` or `inherit` chat route can propose a new job by writing one
-complete runbook to its origin-specific drafts inbox. Push provides that
-opaque path as an additional writable boundary, so different senders, chats,
-and topics cannot claim each other's drafts.
+An agent with write access can propose a new job by writing one complete
+runbook to its origin-specific drafts inbox. Push creates the opaque inbox and
+includes its path in the instructions. The agent configuration controls access,
+and different senders, chats, and topics cannot claim each other's drafts.
 
 Push validates the filename, complete contents, work directory, timeout,
 backend, trigger, symlink status, and protected paths before presenting the
@@ -130,6 +130,6 @@ job. Rejection leaves the proposal inactive.
 
 !!! warning
 
-    Jobs use backend-inherited permissions, not chat permission profiles. A
-    headless backend cannot ask for approval interactively, so configure its
+    Jobs use the selected agent's own permissions. A headless backend may not
+    ask for approval interactively, so configure its
     unattended permissions carefully and keep job work directories narrow.

--- a/docs/jobs/design.md
+++ b/docs/jobs/design.md
@@ -8,8 +8,8 @@
 
 Push jobs are user-owned Markdown runbooks stored under
 `<assistant_root>/jobs/`. A job
-contains one instruction body plus execution policy such as its permission
-profile, timeout, working directory, and backend override.
+contains one instruction body plus execution policy such as its timeout,
+working directory, and backend override.
 Manual and cron starts are triggers attached to the same job rather than
 different job types. Every run uses a fresh backend session. Once the scheduler
 ships, it uses the same SQLite claim and execution path as manual runs,
@@ -20,9 +20,8 @@ an agent runtime.
 
 - Keep jobs readable, reviewable, and editable without a database UI.
 - Use one execution path for manual and scheduled runs.
-- Require permissions, timeouts, and working directories to be explicit and
-  validated before execution.
-- Prevent jobs from exceeding the operator-configured permission ceiling.
+- Require timeouts and working directories to be explicit and validated before
+  execution.
 - Make scheduling safe across restarts, overlap, timezones, and delivery
   failures.
 - Preserve Push's existing polling-only architecture and backend boundary.
@@ -42,8 +41,8 @@ an agent runtime.
 - Push has one long-running gateway process with no inbound server port.
   Commands may run as short-lived local processes against the same SQLite
   store.
-- Claude Code, Codex, and Pi have different permission controls, but a job selects
-  only a named Push permission profile.
+- Claude Code, Codex, and Pi own their permission controls. Push passes no
+  permission or tool overrides.
 - Scheduled work can have external side effects, so duplicate execution is more
   dangerous than skipping a missed run.
 - Job files, `SOUL.md`, and `context/` belong to the Git-versioned assistant
@@ -65,7 +64,6 @@ The file uses TOML frontmatter between `+++` delimiters followed by a non-empty
 Markdown instruction body. Version 1 supports these fields:
 
 - `version`: required and equal to `1`.
-- `permission_profile`: required named profile from Push configuration.
 - `timeout`: required positive duration, capped by the configured job maximum.
 - `workdir`: required fixed directory, expanded and canonicalised at validation.
 - `backend`: optional `claude`, `codex`, or `pi` override; otherwise use the configured
@@ -81,7 +79,6 @@ Manual-only example:
 ```markdown
 +++
 version = 1
-permission_profile = "research-readonly"
 timeout = "10m"
 workdir = "~/Code"
 backend = "codex"
@@ -97,7 +94,6 @@ Scheduled example:
 ```markdown
 +++
 version = 1
-permission_profile = "calendar-readonly"
 timeout = "5m"
 workdir = "~/.push/workspaces/morning-agenda"
 
@@ -137,32 +133,24 @@ without stopping unrelated messaging or jobs. Every manual or scheduled claim
 rereads and validates the exact file bytes, then records their snapshot hash.
 A scheduled occurrence is cancelled if its trigger no longer exists in that
 validated snapshot. Immediately before spawning a backend, Push resolves the
-work directory again and rechecks it against the permission profile so a path
-replacement is likely to be detected. This path-based check does not eliminate
-a replacement race between validation and child startup; backend sandboxing
-and OS permissions remain the enforcement boundary.
-
-The selected permission profile must exist and be included in the configured
-set of profiles allowed for jobs. This allow-set is the capability ceiling: a
-job may select one approved name but cannot define permissions, backend flags,
-or a new profile. Push resolves the profile to backend controls only after the
-job passes validation. The timeout must not exceed the configured jobs maximum,
-and the canonical work directory must meet the restrictions of the permission
-profile.
+work directory again so a path replacement is likely to be detected. This
+path-based check does not eliminate a replacement race between validation and
+child startup; the agent's configuration and OS permissions remain the
+enforcement boundary. The timeout must not exceed the configured jobs maximum.
 
 Notification behavior follows the trigger rather than job metadata. A manual
 run prints its result to the invoking terminal and does not send a message. A
 scheduled run sends its success, failure, or timeout result to the configured
 primary destination. If no primary destination is valid, scheduled triggers
 remain disabled with an actionable error while the job remains manually
-runnable. Secrets are referenced through the selected profile or process
-environment policy, never embedded as special job fields.
+runnable. Secrets are referenced through the agent or process environment
+policy, never embedded as special job fields.
 
 ### Execution
 
 Manual and cron triggers create the same immutable run request containing a
 snapshot hash of the validated job, trigger information, scheduled time,
-backend, permission profile, timeout, and canonical work directory. Editing the
+backend, timeout, and canonical work directory. Editing the
 job affects later runs but not an already claimed run.
 
 Each run starts a fresh Claude Code, Codex, or Pi session. Push supplies the composed
@@ -205,7 +193,7 @@ logical fields are:
 
 - run id, job name, job snapshot hash, trigger kind/id, and claim owner kind;
 - scheduled, queued, started, and finished timestamps;
-- backend, permission profile, timeout, canonical work directory, and resolved
+- backend, timeout, canonical work directory, and resolved
   notification destination when applicable;
 - lifecycle state and a bounded result or error reference;
 - delivery state, attempt count, last attempt time, and delivery error.
@@ -249,11 +237,10 @@ operator-owned.
 ### Agent-authored draft extension
 
 Route agents may write proposals only in an opaque, exact-origin inbox under
-`~/.push/drafts/`, which Push adds as a Push-owned writable root for contained
-workspace profiles. Concurrent channels, senders, chats, and topics therefore
-cannot claim each other's files. Full-access
-routes and jobs are rejected because backend bypass modes cannot prevent direct
-writes to Push-owned files. Job work directories may not overlap the assistant
+`~/.push/drafts/`. Push creates the inbox and includes its path in the
+instructions. The agent's own configuration decides whether it is writable.
+Concurrent channels, senders, chats, and topics therefore cannot claim each other's files. Job work
+directories may not overlap the assistant
 root, configuration, session, draft, installed-job, lock, audit, or database
 paths.
 
@@ -264,7 +251,7 @@ originating allowlisted channel. The
 following `ask_user` question binds Approve and Reject to that channel, sender,
 chat, thread or topic, and exact SHA-256 revision. SQLite stores the exact bytes
 and proposer identity with the question. Approval rereads and revalidates the
-draft and current permission ceiling. A changed revision is invalidated; a
+draft. A changed revision is invalidated; a
 valid stored revision is staged inside the derived assistant `jobs/` directory
 and installed with an atomic
 no-clobber link. Rejection leaves the draft inactive. Proposal and approver
@@ -316,11 +303,11 @@ fewer moving parts.
 
 ## Risks
 
-- A permissive profile can still grant broad machine access. Named profiles,
-  the job allow-set, fixed work directories, and startup validation limit this
-  risk but do not make arbitrary agent execution safe.
+- A permissive agent configuration can grant broad machine access. Fixed work
+  directories and startup validation limit this risk but do not make arbitrary
+  agent execution safe.
 - A job body or file in its work directory may contain untrusted instructions.
-  The permission profile remains the enforcement boundary; `SOUL.md` and the
+  The agent configuration remains the enforcement boundary; `SOUL.md` and the
   job body stay at distinct instruction levels.
 - A local process with permission to replace the work directory can race the
   final path check. The first version treats this as a residual local-user risk

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -136,10 +136,8 @@ user prompt.
 |---|---|
 | `agent` | `claude`, `codex`, or `pi`. |
 | `routes` | Exact thread to backend overrides. |
-| `permission_profile` | Default named profile; defaults to `restricted`. |
 | `channels` | Optional advanced list of reply channels to poll concurrently; otherwise `channel` is used unchanged. |
 | `primary_delivery` | Optional enabled channel and allowlisted target for proactive output. |
-| `permission_profiles` | Custom names mapped to a common capability. |
 | `assistant_root` | Canonical root of the one assistant repository. `SOUL.md`, `context/`, and `jobs/` are derived. |
 | `drafts_dir` | Agent-written inactive job proposals; defaults to `~/.push/drafts`. |
 | `jobs_agent` | Optional default job backend; otherwise uses `agent`. |
@@ -151,6 +149,7 @@ user prompt.
 | `run_timeout` | Max backend run time. |
 | `imessage.self_handles` | User's own iMessage handles. |
 | `imessage.allow_from` | Other allowed senders. |
+| `telegram.bot_token` | Telegram bot token stored in the private config. |
 | `telegram.bot_token_env` | Environment variable containing the bot token. |
 | `telegram.allow_user_ids` | Allowed private-chat sender IDs. |
 | `telegram.allow_chat_ids` | Allowed private chat IDs. |
@@ -180,7 +179,7 @@ user prompt.
 - Claude backend can create and resume a session.
 - Codex backend can create a session, store the Codex thread id, and resume it.
 - Pi backend can create a session, store the Pi session id, and resume it.
-- Workspace routes can propose a validated job draft, but only an exact-revision
+- Agents with write access can propose a validated job draft, but only an exact-revision
   approval from the bound allowlisted identity can install it.
 - Fresh or lost backend sessions receive bounded recent canonical history;
   resumed sessions receive only the new request.
@@ -198,7 +197,7 @@ user prompt.
 - A crash during an in-flight run retries that message on restart, which can
   duplicate backend work but avoids silently losing the message.
 - Codex resume behavior depends on the Codex CLI session store.
-- Full-access profiles are powerful local execution modes.
+- Permissive agent settings are powerful local execution modes.
 - iMessage database shape can change across macOS versions.
 
 ## Next Scope

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,7 +8,7 @@ security boundary rather than a convenience setting.
 
 An accepted sender is an operator of the configured backend. They may be able
 to read files, edit repositories, run commands, call MCP servers, or use local
-credentials, depending on the route's permission profile and backend settings.
+credentials, depending on the selected agent's settings.
 
 Keep these allowlists narrow:
 
@@ -19,52 +19,28 @@ Use stable numeric Telegram IDs. Usernames are mutable and are not accepted as
 security identities. Treat a lost phone, shared messaging account, or
 compromised allowed sender as access to the assistant.
 
-## Chat permission profiles
+## Agent permissions
 
-| Profile | Claude Code | Codex | Pi | Intended use |
-| --- | --- | --- | --- | --- |
-| `restricted` | Read, Grep, and Glob; Bash and write tools denied | read-only sandbox, approvals disabled | `read,grep,find,ls` allowlist | Default inspection and conversation |
-| `workspace` | Read and file-edit tools; Bash omitted | workspace-write sandbox, approvals disabled | `read,edit,write,grep,find,ls` allowlist; no Bash | Repository edits and job drafts |
-| `inherit` | No Push mode or tool filters | No Push sandbox override | No Push tool allowlist | Defer to the operator's backend configuration |
-| `full-access` | Backend bypass mode | Backend bypass mode | Explicit allowlist including Bash | Rejected for unattended chat routes |
+Push does not pass sandbox, approval-policy, permission-mode, or tool-list
+overrides to Claude Code, Codex, or Pi. The selected agent's own configuration
+is the sole permission source for chats and jobs.
 
-Claude Code does not expose a Codex-equivalent filesystem sandbox. Its
-`workspace` mapping allows file tools but deliberately omits shell access.
-Pi also has no native sandbox or permission prompts. Its tool allowlist can
-remove mutating tools or Bash, but it cannot confine file tools to the session
-workspace. `workspace` prevents direct shell access but Pi's read, edit, and
-write tools can still address paths allowed by the operating-system user.
-`inherit` may enable built-in or extension tools from Pi's configuration.
-`full-access` explicitly enables all built-in tools, including unrestricted
-Bash, and therefore remains unsuitable for unattended chat routes.
+This makes Push behave like the agent you already configured, but it also means
+every agent-approved capability may be one accepted message away. Review the
+agent's tools, MCP servers, filesystem access, shell access, and unattended
+approval behavior before running Push as a service. Pi has no native filesystem
+sandbox or interactive permission prompt, so its configured tools deserve
+particular care.
 
-These profiles control the local filesystem and process capabilities that Push
-passes to the backend. They do not rewrite the backend's own integration
-configuration. In particular, Codex MCP servers remain available with whatever
-read or write capabilities their configuration grants. Audit or disable those
-servers before treating a `restricted` or `workspace` route as safe for an
-untrusted request.
-
-`inherit` can be the right choice when the backend already has a carefully
-designed unattended policy. It can also make every backend-approved tool one
-text message away. A headless run cannot pause for an interactive approval.
-
-Custom profiles only alias a capability:
-
-```toml
-[permission_profiles.repo-editor]
-capability = "workspace"
-```
-
-Push rejects raw backend permission flags in TOML so a route cannot
-quietly bypass the shared local policy model.
+Push rejects old `permission_profile`, `permission_profiles`, and raw backend
+permission fields with a migration error. Remove those keys and configure the
+selected agent instead.
 
 ## Job permissions
 
-Jobs always inherit the backend's own permission configuration. They do not
-select a Push permission profile. Push compensates by requiring a fixed,
-existing work directory and rejecting overlap with Push-owned files, including
-the loaded config file.
+Jobs use the selected agent's own permission configuration. Push requires a
+fixed, existing work directory and rejects overlap with Push-owned files,
+including the loaded config file.
 
 Do not place secrets in a job body. Make them available through the backend or
 service environment using the narrowest policy that works.
@@ -114,10 +90,10 @@ IDs, file paths, and backend errors. Protect and rotate it like a service log.
 ## Deployment checklist
 
 - allow only identities you control
-- start with `restricted`
+- configure the selected agent for unattended use
 - run `push doctor` as the service user
 - keep backend credentials out of TOML and logs
 - use absolute config paths in service files
 - keep Push state and job work directories separate
 - inspect agent-authored jobs before approving them
-- review the audit log after routing or permission changes
+- review the audit log after routing or agent permission changes

--- a/docs/services.md
+++ b/docs/services.md
@@ -26,13 +26,13 @@ Use absolute paths in service files. The service user needs:
 - write access to `sessions_dir`
 - read access to `assistant_root/SOUL.md`, `assistant_root/context/`, and
   `assistant_root/jobs/`
-- write access to `assistant_root/context/` for workspace or inherited routes,
-  and to `assistant_root/jobs/` only for approved job installation
+- access to `assistant_root/context/` as allowed by the selected agent, and
+  write access to `assistant_root/jobs/` only for approved job installation
 - access to the selected `claude`, `codex`, or `pi` executable on `PATH`
 - backend login, tokens, settings, MCP config, and project credentials
 - for iMessage on macOS, Full Disk Access and `osascript`
-- for Telegram, `TELEGRAM_BOT_TOKEN` in the service environment and network
-  access to `api.telegram.org`
+- for Telegram, a token in the private config and network access to
+  `api.telegram.org`
 
 `state_path` stores independent cursors for each channel. `sessions_dir` stores
 per-thread backend work directories, and `state.json` stores backend session
@@ -139,7 +139,6 @@ WorkingDirectory=%h/.push
 Restart=on-failure
 RestartSec=10
 Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
-EnvironmentFile=%h/.config/push/telegram.env
 
 [Install]
 WantedBy=default.target
@@ -154,9 +153,8 @@ systemctl --user status push.service
 journalctl --user -u push.service -f
 ```
 
-Create `~/.config/push/telegram.env` with mode `0600` and a single
-`TELEGRAM_BOT_TOKEN=...` entry. Do not commit this file or print it in service
-logs.
+Keep `~/.push/config.toml` at mode `0600` because it contains the Telegram bot
+token. Do not commit this file or print it in service logs.
 
 For a user service that survives logout, enable lingering:
 
@@ -184,8 +182,9 @@ from delivery attempts.
 ## Drafted Jobs
 
 The service prepares `drafts_dir` and the derived assistant `jobs/` directory
-with owner-only permissions. A workspace route may write proposals only to its
-origin-specific drafts inbox, but they remain inactive until the exact revision
+with owner-only permissions. Push exposes only the route's origin-specific
+drafts inbox, and the agent's configuration decides whether it may write there.
+Proposals remain inactive until the exact revision
 is approved from its originating allowlisted channel identity. Pending
 questions survive service restart.
 
@@ -206,11 +205,9 @@ is completed.
 
 Managed services run without a person watching the terminal. An allowed sender
 can instruct the configured backend to use its tools, subject to your backend
-settings. Keep `imessage.allow_from` narrow and use the least-powerful named
-permission profile that works. The default `restricted` profile omits shell and
-write tools. Push rejects `full-access` for unattended routes because it cannot
-enforce the drafted-job boundary. Jobs inherit backend permissions and are
-kept away from Push-owned paths by work-directory validation.
+settings. Keep `imessage.allow_from` narrow and configure each selected agent
+for unattended use. Push passes no sandbox, approval, or tool overrides. Jobs
+are kept away from Push-owned paths by work-directory validation.
 
 Store config files, state files, audit logs, backend credentials, and service
 logs with permissions appropriate for the service user. Logs may contain

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -99,7 +99,7 @@ input:
   resolved assistant, context, and jobs locations
   conversation/session id if one exists
   working directory
-  timeout and permission config
+  timeout
 
 output:
   final reply

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -9,8 +9,8 @@ server port. Telegram documents the polling contract in the official
 
 1. Open a private chat with Telegram's official `@BotFather` account.
 2. Send `/newbot` and follow the prompts.
-3. Store the bot token in a service environment variable. Do not paste it into
-   source control, issue comments, commands that enter shell history, or logs.
+3. Store the bot token in `~/.push/config.toml`. Keep that file private and do
+   not commit it, paste it into issue comments, or print it in logs.
 4. Send one private message to the new bot.
 5. Find your stable numeric user and chat ids from a trusted Bot API
    `getUpdates` response or a trusted id lookup bot. Do not allowlist a Telegram
@@ -21,12 +21,6 @@ Telegram does not allow `getUpdates` while a webhook is active. The first Push
 start discards pending updates, so send a new message after the gateway reports
 that it is running.
 
-Export the token in the environment that starts Push:
-
-```sh
-export TELEGRAM_BOT_TOKEN='replace-with-the-token-from-BotFather'
-```
-
 Use a Telegram-only config:
 
 ```toml
@@ -35,6 +29,7 @@ agent = "codex"
 assistant_root = "~/Code/assistant"
 
 [telegram]
+bot_token = "replace-with-the-token-from-BotFather"
 allow_user_ids = [123456789]
 
 [[routes]]
@@ -42,11 +37,9 @@ thread = "telegram:dm:123456789"
 agent = "claude"
 ```
 
-The token environment variable defaults to `TELEGRAM_BOT_TOKEN`. Set
-`telegram.bot_token_env` only when you need a different variable name.
-`telegram.bot_token` is supported for constrained deployments, but the
-environment-variable form is safer because it keeps the credential out of the
-config file. Push never prints the token. Run:
+`push init` creates a new config with owner-only mode `0600` on Unix. An
+environment variable remains supported through `telegram.bot_token_env`, which
+defaults to `TELEGRAM_BOT_TOKEN`. Push never prints the token. Run:
 
 ```sh
 push doctor --config /absolute/path/to/config.toml

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use uuid::Uuid;
 
-use crate::config::{AgentBackend, Config, PermissionCapability};
+use crate::config::{AgentBackend, Config};
 use crate::{claude, codex, pi};
 
 /// One headless agent turn.
@@ -13,9 +13,7 @@ pub struct Request<'a> {
     pub session_id: &'a str,
     pub is_new: bool,
     pub work_dir: &'a str,
-    pub additional_dirs: &'a [&'a str],
     pub instructions: &'a str,
-    pub permission: PermissionCapability,
     pub prompt: &'a str,
 }
 
@@ -141,9 +139,7 @@ pub struct FakeRunCall {
     pub session_id: String,
     pub is_new: bool,
     pub prompt: String,
-    pub permission: PermissionCapability,
     pub instructions: String,
-    pub additional_dirs: Vec<String>,
 }
 
 #[cfg(test)]
@@ -153,13 +149,7 @@ impl FakeRunner {
             session_id: req.session_id.to_string(),
             is_new: req.is_new,
             prompt: req.prompt.to_string(),
-            permission: req.permission,
             instructions: req.instructions.to_string(),
-            additional_dirs: req
-                .additional_dirs
-                .iter()
-                .map(|path| (*path).to_string())
-                .collect(),
         });
         if !req.is_new
             && self

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -47,11 +47,13 @@ Store durable facts and working context here when they should be available acros
 Good examples include preferences, active projects, people, recurring processes, and reference notes. Keep secrets out of this repository. Start with small, focused Markdown files and update or remove stale information.
 "#;
 
-const DEFAULT_CONFIG: &str = r#"# Telegram quick start. Export TELEGRAM_BOT_TOKEN before running Push.
+const DEFAULT_CONFIG: &str = r#"# Telegram quick start.
 channel = "telegram"
 agent = "codex"
 
 [telegram]
+# Paste the token from BotFather here.
+bot_token = ""
 # Replace this with your numeric Telegram user ID.
 allow_user_ids = []
 "#;
@@ -463,6 +465,10 @@ fn write_config(config_path: &Path, contents: &[u8]) -> Result<()> {
             fs::set_permissions(&temporary, metadata.permissions()).with_context(|| {
                 format!("preserve config permissions for {}", destination.display())
             })?;
+        } else {
+            crate::util::restrict_permissions(&temporary, false).with_context(|| {
+                format!("restrict config permissions for {}", destination.display())
+            })?;
         }
         file.write_all(contents)
             .with_context(|| format!("write temporary config {}", temporary.display()))?;
@@ -591,7 +597,7 @@ mod tests {
         let config = parent.join("push.toml");
         fs::write(
             &config,
-            "channel = 'imessage'\nself_handles = ['me@example.com']\npermission_profile = 'custom'\n\n[permission_profiles.custom]\ncapability = 'read-only'\n",
+            "channel = 'imessage'\nself_handles = ['me@example.com']\n\n[telegram]\nbot_token = 'secret'\n",
         )
         .unwrap();
 
@@ -603,9 +609,7 @@ mod tests {
             value.get("assistant_root").and_then(toml::Value::as_str),
             Some(result.root.to_str().unwrap())
         );
-        assert!(value["permission_profiles"]["custom"]
-            .get("assistant_root")
-            .is_none());
+        assert!(value["telegram"].get("assistant_root").is_none());
         assert_eq!(
             crate::config::Config::load(config.to_str().unwrap())
                 .unwrap()

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -6,7 +6,6 @@ use serde::Deserialize;
 use tokio::process::Command;
 
 use crate::agent::{Request, RunError, RunOutput};
-use crate::config::PermissionCapability;
 use crate::util::non_empty_session_id;
 
 /// Runner invokes the `claude` binary in print mode.
@@ -45,18 +44,10 @@ impl Runner {
 
     fn command(&self, req: &Request<'_>) -> Command {
         let mut cmd = Command::new(&self.bin);
-        let controls = controls(req.permission);
         cmd.arg("-p")
             .arg(req.prompt)
             .arg("--output-format")
             .arg("json");
-        if let Some(mode) = controls.permission_mode {
-            cmd.arg("--permission-mode").arg(mode);
-        }
-        cmd.arg("--add-dir").arg(req.work_dir);
-        for path in req.additional_dirs {
-            cmd.arg("--add-dir").arg(path);
-        }
         if req.is_new {
             cmd.arg("--session-id").arg(req.session_id);
         } else {
@@ -64,16 +55,6 @@ impl Runner {
         }
         if !req.instructions.trim().is_empty() {
             cmd.arg("--append-system-prompt").arg(req.instructions);
-        }
-        if let Some(tools) = controls.tools {
-            cmd.arg("--tools");
-            cmd.args(tools);
-        }
-        for tool in controls.allowed_tools {
-            cmd.arg("--allowed-tools").arg(tool);
-        }
-        for tool in controls.disallowed_tools {
-            cmd.arg("--disallowed-tools").arg(tool);
         }
         cmd.current_dir(req.work_dir);
         cmd.kill_on_drop(true);
@@ -129,50 +110,6 @@ fn missing_resume_error(message: &str) -> bool {
         .contains("no conversation found with session id")
 }
 
-struct Controls {
-    permission_mode: Option<&'static str>,
-    tools: Option<&'static [&'static str]>,
-    allowed_tools: &'static [&'static str],
-    disallowed_tools: &'static [&'static str],
-}
-
-const READ_ONLY_TOOLS: &[&str] = &["Read", "Grep", "Glob"];
-const WORKSPACE_TOOLS: &[&str] = &["Read", "Grep", "Glob", "Edit", "Write", "NotebookEdit"];
-const NO_TOOLS: &[&str] = &[];
-const DENY_SHELL_AND_WRITES: &[&str] = &["Bash", "Edit", "Write", "NotebookEdit"];
-const DENY_SHELL: &[&str] = &["Bash"];
-
-fn controls(capability: PermissionCapability) -> Controls {
-    match capability {
-        PermissionCapability::ReadOnly => Controls {
-            permission_mode: Some("dontAsk"),
-            tools: Some(READ_ONLY_TOOLS),
-            allowed_tools: READ_ONLY_TOOLS,
-            disallowed_tools: DENY_SHELL_AND_WRITES,
-        },
-        PermissionCapability::Workspace => Controls {
-            permission_mode: Some("dontAsk"),
-            tools: Some(WORKSPACE_TOOLS),
-            allowed_tools: WORKSPACE_TOOLS,
-            disallowed_tools: DENY_SHELL,
-        },
-        // No mode and no tool lists: the operator's own Claude Code settings
-        // decide what is allowed, exactly as in an interactive session.
-        PermissionCapability::Inherit => Controls {
-            permission_mode: None,
-            tools: None,
-            allowed_tools: NO_TOOLS,
-            disallowed_tools: NO_TOOLS,
-        },
-        PermissionCapability::FullAccess => Controls {
-            permission_mode: Some("bypassPermissions"),
-            tools: None,
-            allowed_tools: NO_TOOLS,
-            disallowed_tools: NO_TOOLS,
-        },
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -207,32 +144,6 @@ mod tests {
             non_empty_session_id(" claude-session "),
             Some("claude-session")
         );
-    }
-
-    #[test]
-    fn translates_all_permission_capabilities() {
-        let read_only = controls(PermissionCapability::ReadOnly);
-        assert_eq!(read_only.permission_mode, Some("dontAsk"));
-        assert_eq!(read_only.tools, Some(READ_ONLY_TOOLS));
-        assert!(read_only.disallowed_tools.contains(&"Bash"));
-        assert!(read_only.disallowed_tools.contains(&"Edit"));
-
-        let workspace = controls(PermissionCapability::Workspace);
-        assert_eq!(workspace.permission_mode, Some("dontAsk"));
-        assert_eq!(workspace.tools, Some(WORKSPACE_TOOLS));
-        assert!(workspace.allowed_tools.contains(&"Edit"));
-        assert!(workspace.disallowed_tools.contains(&"Bash"));
-
-        let inherit = controls(PermissionCapability::Inherit);
-        assert_eq!(inherit.permission_mode, None);
-        assert_eq!(inherit.tools, None);
-        assert!(inherit.allowed_tools.is_empty());
-        assert!(inherit.disallowed_tools.is_empty());
-
-        let full = controls(PermissionCapability::FullAccess);
-        assert_eq!(full.permission_mode, Some("bypassPermissions"));
-        assert_eq!(full.tools, None);
-        assert!(full.disallowed_tools.is_empty());
     }
 
     #[test]
@@ -272,9 +183,7 @@ mod tests {
                     session_id: "push-session",
                     is_new: true,
                     work_dir: work_dir.to_str().unwrap(),
-                    additional_dirs: &[],
                     instructions: "assistant identity",
-                    permission: PermissionCapability::ReadOnly,
                     prompt: "hello",
                 },
                 Duration::from_secs(5),
@@ -286,15 +195,19 @@ mod tests {
         assert_eq!(out.session_id, Some("claude-returned".to_string()));
         let args = read_args(&args_path);
         assert_arg_pair(&args, "--session-id", "push-session");
-        assert_arg_pair(&args, "--permission-mode", "dontAsk");
         assert_arg_pair(&args, "--append-system-prompt", "assistant identity");
         assert_arg_pair(&args, "-p", "hello");
-        assert_arg_pair(&args, "--tools", "Read");
-        assert_arg_pair(&args, "--allowed-tools", "Read");
-        assert_arg_pair(&args, "--disallowed-tools", "Bash");
-        assert!(args.contains(&"Grep".to_string()));
-        assert!(args.contains(&"Glob".to_string()));
-        assert!(args.contains(&"Edit".to_string()));
+        for flag in [
+            "--permission-mode",
+            "--tools",
+            "--allowed-tools",
+            "--disallowed-tools",
+        ] {
+            assert!(
+                !args.contains(&flag.to_string()),
+                "unexpected {flag} in {args:?}"
+            );
+        }
         assert!(!args.contains(&"--resume".to_string()));
     }
 
@@ -302,8 +215,6 @@ mod tests {
     async fn runs_resumed_session_with_resume_flag() {
         let args_path = temp_path("claude-resume-args");
         let work_dir = temp_dir("claude-resume-work");
-        let context_dir = temp_dir("claude-resume-context");
-        let drafts_dir = temp_dir("claude-resume-drafts");
         let script = format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nprintf '%s\\n' '{{\"result\":\"resumed\",\"session_id\":\"claude-returned\"}}'\n",
             sh_arg(&args_path)
@@ -317,9 +228,7 @@ mod tests {
                     session_id: "existing-session",
                     is_new: false,
                     work_dir: work_dir.to_str().unwrap(),
-                    additional_dirs: &[context_dir.to_str().unwrap(), drafts_dir.to_str().unwrap()],
                     instructions: "assistant identity",
-                    permission: PermissionCapability::Workspace,
                     prompt: "continue",
                 },
                 Duration::from_secs(5),
@@ -332,17 +241,8 @@ mod tests {
         assert_arg_pair(&args, "--resume", "existing-session");
         assert!(!args.contains(&"--session-id".to_string()));
         assert_arg_pair(&args, "--append-system-prompt", "assistant identity");
-        assert!(args
-            .windows(2)
-            .any(|pair| { pair == ["--add-dir", drafts_dir.to_str().unwrap()] }));
-        assert!(args
-            .windows(2)
-            .any(|pair| { pair == ["--add-dir", context_dir.to_str().unwrap()] }));
+        assert!(!args.contains(&"--add-dir".to_string()));
         assert_arg_pair(&args, "-p", "continue");
-        assert!(args
-            .windows(2)
-            .any(|pair| pair == ["--allowed-tools", "Edit"]));
-        assert_arg_pair(&args, "--disallowed-tools", "Bash");
     }
 
     #[tokio::test]
@@ -360,9 +260,7 @@ mod tests {
                     session_id: "missing",
                     is_new: false,
                     work_dir: work_dir.to_str().unwrap(),
-                    additional_dirs: &[],
                     instructions: "",
-                    permission: PermissionCapability::ReadOnly,
                     prompt: "continue",
                 },
                 Duration::from_secs(5),
@@ -418,9 +316,7 @@ mod tests {
             session_id: "session",
             is_new: true,
             work_dir,
-            additional_dirs: &[],
             instructions: "",
-            permission: PermissionCapability::ReadOnly,
             prompt: "hello",
         }
     }
@@ -520,7 +416,6 @@ mod tests {
             is_new,
             work_dir,
             instructions: String::new(),
-            permission: PermissionCapability::ReadOnly,
             prompt: "hello".to_string(),
         }
     }

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -9,7 +9,6 @@ use tokio::process::Command;
 use uuid::Uuid;
 
 use crate::agent::{Request, RunError, RunOutput};
-use crate::config::PermissionCapability;
 
 /// Runner invokes `codex exec` in non-interactive mode.
 pub struct Runner {
@@ -82,10 +81,6 @@ impl Runner {
 
     fn command(&self, req: &Request<'_>, out_path: &Path) -> Command {
         let mut cmd = Command::new(&self.bin);
-        cmd.arg("--ask-for-approval").arg("never");
-        if let Some(sandbox) = sandbox(req.permission) {
-            cmd.arg("--sandbox").arg(sandbox);
-        }
         if !req.instructions.trim().is_empty() {
             cmd.arg("-c")
                 .arg(developer_instructions(req.instructions.trim()));
@@ -96,22 +91,14 @@ impl Runner {
                 .arg("--skip-git-repo-check")
                 .arg("-C")
                 .arg(req.work_dir)
-                .arg("--add-dir")
-                .arg(req.work_dir)
                 .arg("-o")
                 .arg(out_path);
-            for path in req.additional_dirs {
-                cmd.arg("--add-dir").arg(path);
-            }
             if let Some(model) = self.model.as_deref() {
                 cmd.arg("-m").arg(model);
             }
             cmd.arg(req.prompt);
         } else {
             cmd.arg("exec");
-            for path in req.additional_dirs {
-                cmd.arg("--add-dir").arg(path);
-            }
             cmd.arg("resume")
                 .arg("--json")
                 .arg("--skip-git-repo-check")
@@ -132,16 +119,6 @@ fn missing_resume_error(message: &str) -> bool {
     message
         .to_ascii_lowercase()
         .contains("no rollout found for thread id")
-}
-
-fn sandbox(capability: PermissionCapability) -> Option<&'static str> {
-    match capability {
-        PermissionCapability::ReadOnly => Some("read-only"),
-        PermissionCapability::Workspace => Some("workspace-write"),
-        // No --sandbox flag: the operator's own Codex configuration decides.
-        PermissionCapability::Inherit => None,
-        PermissionCapability::FullAccess => Some("danger-full-access"),
-    }
 }
 
 fn developer_instructions(instructions: &str) -> String {
@@ -248,9 +225,7 @@ mod tests {
                     session_id: "",
                     is_new: true,
                     work_dir: work_dir.to_str().unwrap(),
-                    additional_dirs: &[],
                     instructions: "assistant identity",
-                    permission: PermissionCapability::Workspace,
                     prompt: "hello",
                 },
                 Duration::from_secs(5),
@@ -261,12 +236,12 @@ mod tests {
         assert_eq!(out.reply, "codex reply");
         assert_eq!(out.session_id, Some("codex-thread".to_string()));
         let args = read_args(&args_path);
-        assert_arg_pair(&args, "--ask-for-approval", "never");
-        assert_arg_pair(&args, "--sandbox", "workspace-write");
+        assert!(!args.contains(&"--ask-for-approval".to_string()));
+        assert!(!args.contains(&"--sandbox".to_string()));
         assert_arg_present(&args, "exec");
         assert_arg_present(&args, "--json");
         assert_arg_pair(&args, "-C", work_dir.to_str().unwrap());
-        assert_arg_pair(&args, "--add-dir", work_dir.to_str().unwrap());
+        assert!(!args.contains(&"--add-dir".to_string()));
         assert_arg_pair(&args, "-c", &developer_instructions("assistant identity"));
         assert_eq!(args.last().unwrap(), "hello");
     }
@@ -275,8 +250,6 @@ mod tests {
     async fn runs_resumed_session_with_resume_command() {
         let args_path = temp_path("codex-resume-args");
         let work_dir = temp_dir("codex-resume-work");
-        let context_dir = temp_dir("codex-resume-context");
-        let drafts_dir = temp_dir("codex-resume-drafts");
         let script = codex_success_script(&args_path, "resumed reply", None);
         let cli = FakeCli::new("codex", &script);
         let runner = runner(cli.bin());
@@ -287,9 +260,7 @@ mod tests {
                     session_id: "existing-thread",
                     is_new: false,
                     work_dir: work_dir.to_str().unwrap(),
-                    additional_dirs: &[context_dir.to_str().unwrap(), drafts_dir.to_str().unwrap()],
                     instructions: "assistant identity",
-                    permission: PermissionCapability::ReadOnly,
                     prompt: "continue",
                 },
                 Duration::from_secs(5),
@@ -300,19 +271,9 @@ mod tests {
         assert_eq!(out.reply, "resumed reply");
         assert_eq!(out.session_id, None);
         let args = read_args(&args_path);
-        assert_arg_sequence(
-            &args,
-            &[
-                "exec",
-                "--add-dir",
-                context_dir.to_str().unwrap(),
-                "--add-dir",
-                drafts_dir.to_str().unwrap(),
-                "resume",
-            ],
-        );
+        assert_arg_sequence(&args, &["exec", "resume"]);
+        assert!(!args.contains(&"--add-dir".to_string()));
         assert_arg_present(&args, "existing-thread");
-        assert_arg_pair(&args, "--sandbox", "read-only");
         assert_arg_pair(&args, "-c", &developer_instructions("assistant identity"));
         assert_eq!(args.last().unwrap(), "continue");
         assert!(!args.contains(&"-C".to_string()));
@@ -333,9 +294,7 @@ mod tests {
                     session_id: "missing",
                     is_new: false,
                     work_dir: work_dir.to_str().unwrap(),
-                    additional_dirs: &[],
                     instructions: "",
-                    permission: PermissionCapability::ReadOnly,
                     prompt: "continue",
                 },
                 Duration::from_secs(5),
@@ -395,9 +354,7 @@ mod tests {
             session_id: "",
             is_new: true,
             work_dir,
-            additional_dirs: &[],
             instructions: "",
-            permission: PermissionCapability::ReadOnly,
             prompt: "hello",
         }
     }
@@ -543,23 +500,8 @@ mod tests {
             is_new,
             work_dir,
             instructions: String::new(),
-            permission: PermissionCapability::ReadOnly,
             prompt: "hello".to_string(),
         }
-    }
-
-    #[test]
-    fn translates_all_permission_capabilities() {
-        assert_eq!(sandbox(PermissionCapability::ReadOnly), Some("read-only"));
-        assert_eq!(
-            sandbox(PermissionCapability::Workspace),
-            Some("workspace-write")
-        );
-        assert_eq!(sandbox(PermissionCapability::Inherit), None);
-        assert_eq!(
-            sandbox(PermissionCapability::FullAccess),
-            Some("danger-full-access")
-        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 //! Gateway configuration loaded from a TOML file.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
@@ -39,10 +39,6 @@ pub struct Config {
     pub agent: String,
     #[serde(default)]
     pub routes: Vec<RouteRule>,
-    #[serde(default = "default_permission_profile")]
-    pub permission_profile: String,
-    #[serde(default)]
-    pub permission_profiles: HashMap<String, PermissionProfileConfig>,
     /// Canonical root of the single user-owned assistant repository.
     #[serde(default)]
     pub assistant_root: String,
@@ -102,6 +98,28 @@ impl Config {
                 "structured [assistant] settings are no longer supported; move assistant identity into assistant_root/SOUL.md"
             );
         }
+        for removed in ["permission_profile", "permission_profiles"] {
+            if root.contains_key(removed) {
+                bail!(
+                    "{removed} is no longer supported; configure permissions in the selected agent and remove this key from Push config"
+                );
+            }
+        }
+        if root
+            .get("routes")
+            .and_then(toml::Value::as_array)
+            .is_some_and(|routes| {
+                routes.iter().any(|route| {
+                    route
+                        .as_table()
+                        .is_some_and(|route| route.contains_key("permission_profile"))
+                })
+            })
+        {
+            bail!(
+                "route permission_profile is no longer supported; configure permissions in the selected agent and remove this key from Push config"
+            );
+        }
         for legacy in [
             "permission_mode",
             "tools",
@@ -116,7 +134,7 @@ impl Config {
         ] {
             if root.contains_key(legacy) {
                 bail!(
-                    "legacy permission setting {legacy:?} is no longer supported; select a named permission_profile instead"
+                    "legacy permission setting {legacy:?} is no longer supported; configure permissions in the selected agent and remove this key from Push config"
                 );
             }
         }
@@ -296,7 +314,6 @@ impl Config {
         }
         Ok(RouteSelection {
             backend: self.agent_backend()?,
-            permission: self.resolve_permission_profile(&self.permission_profile)?,
         })
     }
 
@@ -343,31 +360,8 @@ impl Config {
     }
 
     fn resolve_route(&self, route: &RouteRule) -> Result<RouteSelection> {
-        let profile = route
-            .permission_profile
-            .as_deref()
-            .unwrap_or(&self.permission_profile);
         Ok(RouteSelection {
             backend: AgentBackend::parse(&route.agent)?,
-            permission: self.resolve_permission_profile(profile)?,
-        })
-    }
-
-    fn resolve_permission_profile(&self, name: &str) -> Result<PermissionProfile> {
-        let capability = match name {
-            "restricted" => PermissionCapability::ReadOnly,
-            "workspace" => PermissionCapability::Workspace,
-            "inherit" => PermissionCapability::Inherit,
-            "full-access" => PermissionCapability::FullAccess,
-            custom => self
-                .permission_profiles
-                .get(custom)
-                .with_context(|| format!("unknown permission profile {custom:?}"))?
-                .capability()?,
-        };
-        Ok(PermissionProfile {
-            name: name.to_string(),
-            capability,
         })
     }
 
@@ -444,24 +438,6 @@ impl Config {
         if self.jobs_max_workers == 0 {
             bail!("jobs_max_workers must be positive");
         }
-        let default_profile = self
-            .resolve_permission_profile(&self.permission_profile)
-            .context("invalid default permission profile")?;
-        reject_uncontained_route_profile(&default_profile)?;
-        for (name, profile) in &self.permission_profiles {
-            if name.trim().is_empty() {
-                bail!("permission profile names cannot be empty");
-            }
-            if matches!(
-                name.as_str(),
-                "restricted" | "workspace" | "inherit" | "full-access"
-            ) {
-                bail!("built-in permission profile {name:?} cannot be redefined");
-            }
-            profile
-                .capability()
-                .with_context(|| format!("invalid permission profile {name:?}"))?;
-        }
         for route in &self.routes {
             AgentBackend::parse(&route.agent)
                 .with_context(|| format!("invalid route agent for {route:?}"))?;
@@ -474,30 +450,12 @@ impl Config {
             if let Some(channel) = &route.channel {
                 ChannelKind::parse(channel).context("invalid route channel")?;
             }
-            let profile = route
-                .permission_profile
-                .as_deref()
-                .unwrap_or(&self.permission_profile);
-            let profile = self
-                .resolve_permission_profile(profile)
-                .with_context(|| format!("invalid permission profile for route {route:?}"))?;
-            reject_uncontained_route_profile(&profile)?;
         }
         validate_protected_paths(self)?;
         self.poll_interval_dur()?;
         self.run_timeout_dur()?;
         Ok(())
     }
-}
-
-fn reject_uncontained_route_profile(profile: &PermissionProfile) -> Result<()> {
-    if profile.capability == PermissionCapability::FullAccess {
-        bail!(
-            "route permission profile {:?} uses full-access, which cannot prevent direct writes to Push jobs or state",
-            profile.name
-        );
-    }
-    Ok(())
 }
 
 fn validate_protected_paths(cfg: &Config) -> Result<()> {
@@ -692,8 +650,6 @@ pub struct RouteRule {
     #[serde(default)]
     pub channel: Option<String>,
     pub agent: String,
-    #[serde(default)]
-    pub permission_profile: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
@@ -705,49 +661,6 @@ pub struct PrimaryDeliveryConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RouteSelection {
     pub backend: AgentBackend,
-    pub permission: PermissionProfile,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct PermissionProfileConfig {
-    pub capability: String,
-}
-
-impl PermissionProfileConfig {
-    fn capability(&self) -> Result<PermissionCapability> {
-        PermissionCapability::parse(&self.capability)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PermissionProfile {
-    pub name: String,
-    pub capability: PermissionCapability,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PermissionCapability {
-    ReadOnly,
-    Workspace,
-    /// Defer to the backend's own permission configuration. Push passes no
-    /// permission mode, tool lists, or sandbox flags; the operator's backend
-    /// settings decide what the agent may do. Jobs always run with this.
-    Inherit,
-    FullAccess,
-}
-
-impl PermissionCapability {
-    pub fn parse(value: &str) -> Result<Self> {
-        match value {
-            "read-only" => Ok(Self::ReadOnly),
-            "workspace" => Ok(Self::Workspace),
-            "inherit" => Ok(Self::Inherit),
-            "full-access" => Ok(Self::FullAccess),
-            other => bail!(
-                "invalid permission capability {other:?}; expected read-only, workspace, inherit, or full-access"
-            ),
-        }
-    }
 }
 
 impl RouteRule {
@@ -860,9 +773,6 @@ fn default_codex_bin() -> String {
 fn default_pi_bin() -> String {
     "pi".to_string()
 }
-fn default_permission_profile() -> String {
-    "restricted".to_string()
-}
 fn default_jobs_dir() -> String {
     "~/.push/jobs".to_string()
 }
@@ -920,8 +830,6 @@ mod tests {
             telegram_allow_chat_ids: Vec::new(),
             agent: "codex".to_string(),
             routes: Vec::new(),
-            permission_profile: "workspace".to_string(),
-            permission_profiles: HashMap::new(),
             assistant_root: root.to_string_lossy().to_string(),
             jobs_dir: root.join("jobs").to_string_lossy().to_string(),
             drafts_dir: root.join("drafts").to_string_lossy().to_string(),
@@ -953,7 +861,6 @@ mod tests {
             thread: Some("imessage:chat:pi".to_string()),
             channel: Some("imessage".to_string()),
             agent: "pi".to_string(),
-            permission_profile: Some("restricted".to_string()),
         }];
 
         assert_eq!(AgentBackend::parse("pi").unwrap(), AgentBackend::Pi);
@@ -986,7 +893,6 @@ mod tests {
             thread: None,
             channel: Some("telegram".to_string()),
             agent: "pi".to_string(),
-            permission_profile: None,
         });
         assert_eq!(cfg.required_agent_bins().unwrap(), vec!["codex"]);
 
@@ -1001,14 +907,6 @@ mod tests {
         let mut cfg = config();
         assert!(cfg.validate().is_ok());
 
-        cfg.permission_profile = "full-access".to_string();
-        assert!(cfg
-            .validate()
-            .unwrap_err()
-            .to_string()
-            .contains("full-access"));
-
-        cfg.permission_profile = "workspace".to_string();
         cfg.drafts_dir = format!("{}/drafts", cfg.jobs_dir);
         assert!(cfg
             .validate()

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -88,12 +88,11 @@ fn check_config(cfg: &config::Config, checks: &mut Vec<Check>) {
     checks.push(Check::pass(
         "config",
         format!(
-            "channels={}, agent={}, permission_profile={}, assistant_root={}, imessage.self_handles={}, imessage.allow_from={}, telegram.allow_user_ids={}, telegram.allow_chat_ids={}",
+            "channels={}, agent={}, assistant_root={}, imessage.self_handles={}, imessage.allow_from={}, telegram.allow_user_ids={}, telegram.allow_chat_ids={}",
             cfg.enabled_channel_kinds()
                 .map(|channels| channels.into_iter().map(|kind| kind.as_str()).collect::<Vec<_>>().join(","))
                 .unwrap_or_else(|_| cfg.channel.clone()),
             cfg.agent,
-            cfg.permission_profile,
             cfg.assistant_root,
             cfg.self_handles.len(),
             cfg.allow_from.len(),
@@ -506,7 +505,6 @@ claude_tools = []
             thread: None,
             channel: Some("imessage".to_string()),
             agent: "claude".to_string(),
-            permission_profile: None,
         }];
         let mut checks = Vec::new();
 

--- a/src/drafts.rs
+++ b/src/drafts.rs
@@ -411,7 +411,6 @@ fn hash(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
 
     use crate::approval::{AnswerOrigin, AnswerOutcome, Choice, Question};
     use crate::config::Config;
@@ -436,8 +435,6 @@ mod tests {
                 telegram_allow_chat_ids: Vec::new(),
                 agent: "codex".to_string(),
                 routes: Vec::new(),
-                permission_profile: "workspace".to_string(),
-                permission_profiles: HashMap::new(),
                 assistant_root: root.to_string_lossy().to_string(),
                 jobs_dir: root.join("jobs").to_string_lossy().to_string(),
                 drafts_dir: root.join("drafts").to_string_lossy().to_string(),

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -20,7 +20,7 @@ use crate::agent::Runner;
 use crate::approval::{AnswerOrigin, AnswerOutcome};
 use crate::audit::{AuditEvent, AuditLog};
 use crate::channel::{Channel, RawMessage};
-use crate::config::{AgentBackend, ChannelKind, Config, PermissionProfile, PrimaryDeliveryConfig};
+use crate::config::{AgentBackend, ChannelKind, Config, PrimaryDeliveryConfig};
 use crate::history::{History, OutboundOrigin};
 use crate::jobs;
 use crate::store::Store;
@@ -38,7 +38,6 @@ struct Job {
     thread: String,
     target: String,
     backend: AgentBackend,
-    permission: PermissionProfile,
     approval_origin: AnswerOrigin,
     text: String,
 }
@@ -595,7 +594,6 @@ impl Gateway {
                     thread,
                     target,
                     backend,
-                    permission: route.permission,
                     approval_origin,
                     text: m.text.trim().to_string(),
                 };

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -196,10 +196,6 @@ fn setup_failure_job(row_id: i64) -> Job {
         thread: "imessage:self:me".to_string(),
         target: "me@icloud.com".to_string(),
         backend: AgentBackend::Claude,
-        permission: PermissionProfile {
-            name: "restricted".to_string(),
-            capability: crate::config::PermissionCapability::ReadOnly,
-        },
         approval_origin: AnswerOrigin {
             channel: "imessage".to_string(),
             thread_key: "imessage:self:me".to_string(),
@@ -494,8 +490,7 @@ async fn draft_boundary_failure_completes_in_flight_row_and_advances_cursor() {
         temp_path("sessions").to_string_lossy().to_string(),
     );
     ctx.cfg.drafts_dir = drafts_blocker.to_string_lossy().to_string();
-    let mut job = setup_failure_job(10);
-    job.permission.capability = crate::config::PermissionCapability::Workspace;
+    let job = setup_failure_job(10);
 
     handle(&ctx, job).await;
 
@@ -531,8 +526,7 @@ async fn draft_boundary_failure_delivers_existing_outbound_without_misreporting_
         .unwrap()
         .record_outbound(1, OutboundOrigin::Backend, Some("claude"), "stored reply")
         .unwrap();
-    let mut job = setup_failure_job(10);
-    job.permission.capability = crate::config::PermissionCapability::Workspace;
+    let job = setup_failure_job(10);
 
     handle(&ctx, job).await;
 
@@ -598,7 +592,6 @@ async fn fake_channel_e2e_replies_once_ignores_unallowlisted_and_reuses_session(
         thread: Some("imessage:dm:+15551234567".to_string()),
         channel: None,
         agent: "codex".to_string(),
-        permission_profile: Some("workspace".to_string()),
     }];
     let mut gateway = Gateway::new(cfg).unwrap();
     gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
@@ -637,10 +630,6 @@ async fn fake_channel_e2e_replies_once_ignores_unallowlisted_and_reuses_session(
         assert!(!calls[1].is_new);
         assert_eq!(calls[1].prompt, "second");
         for call in calls.iter() {
-            assert_eq!(
-                call.permission,
-                crate::config::PermissionCapability::Workspace
-            );
             assert!(call.instructions.starts_with("Be useful."));
             assert!(call.instructions.contains(&format!(
                 "Assistant root: {}",
@@ -658,15 +647,6 @@ async fn fake_channel_e2e_replies_once_ignores_unallowlisted_and_reuses_session(
                     .unwrap()
                     .display()
             )));
-            assert!(call.additional_dirs.contains(
-                &std::fs::canonicalize(assistant_dir.join("context"))
-                    .unwrap()
-                    .to_string_lossy()
-                    .to_string()
-            ));
-            assert!(!call
-                .additional_dirs
-                .contains(&assistant_dir.join("jobs").to_string_lossy().to_string()));
         }
     }
     let events = audit_events(&audit_path);
@@ -1097,7 +1077,6 @@ async fn backend_switch_and_clear_start_fresh_sessions_with_history() {
         thread: Some("imessage:dm:+15551234567".to_string()),
         channel: None,
         agent: "claude".to_string(),
-        permission_profile: None,
     }];
     run_messages(
         &mut gateway,
@@ -1762,12 +1741,11 @@ async fn route_agent_draft_requires_bound_approval_before_atomic_install() {
     let workdir = temp_path("draft-e2e-workdir");
     std::fs::create_dir_all(&assistant_dir).unwrap();
     std::fs::create_dir_all(&workdir).unwrap();
-    let mut cfg = test_config(
+    let cfg = test_config(
         &state_path,
         sessions_dir.to_str().unwrap(),
         assistant_dir.to_str().unwrap(),
     );
-    cfg.permission_profile = "workspace".to_string();
     let calls = Arc::new(Mutex::new(Vec::new()));
     let mut gateway = Gateway::new(cfg.clone()).unwrap();
     let inbound = message(
@@ -1845,12 +1823,11 @@ async fn concurrent_origins_present_only_their_isolated_drafts() {
     let workdir = temp_path("draft-concurrent-workdir");
     std::fs::create_dir_all(&assistant_dir).unwrap();
     std::fs::create_dir_all(&workdir).unwrap();
-    let mut cfg = test_config(
+    let cfg = test_config(
         &state_path,
         sessions_dir.to_str().unwrap(),
         assistant_dir.to_str().unwrap(),
     );
-    cfg.permission_profile = "workspace".to_string();
     let gateway = Gateway::new(cfg.clone()).unwrap();
     let first_origin = AnswerOrigin {
         channel: "imessage".to_string(),
@@ -1918,12 +1895,11 @@ async fn failed_run_and_recovered_outbound_still_reconcile_origin_drafts() {
     let workdir = temp_path("draft-failure-workdir");
     std::fs::create_dir_all(&assistant_dir).unwrap();
     std::fs::create_dir_all(&workdir).unwrap();
-    let mut cfg = test_config(
+    let cfg = test_config(
         &state_path,
         sessions_dir.to_str().unwrap(),
         assistant_dir.to_str().unwrap(),
     );
-    cfg.permission_profile = "workspace".to_string();
     let mut gateway = Gateway::new(cfg.clone()).unwrap();
     let failed_message = message(1, "+15551234567", "+15551234567", false, "draft then fail");
     let (thread, _) = gateway.channel.accept(&failed_message).unwrap();
@@ -2008,12 +1984,11 @@ async fn failed_draft_delivery_retries_after_restart_before_expiry() {
     let workdir = temp_path("draft-delivery-workdir");
     std::fs::create_dir_all(&assistant_dir).unwrap();
     std::fs::create_dir_all(&workdir).unwrap();
-    let mut cfg = test_config(
+    let cfg = test_config(
         &state_path,
         sessions_dir.to_str().unwrap(),
         assistant_dir.to_str().unwrap(),
     );
-    cfg.permission_profile = "workspace".to_string();
     let origin = AnswerOrigin {
         channel: "imessage".to_string(),
         thread_key: "imessage:dm:15551234567".to_string(),
@@ -2064,10 +2039,6 @@ fn draft_test_job(row_id: i64, target: &str, origin: AnswerOrigin) -> Job {
         thread: origin.thread_key.clone(),
         target: target.to_string(),
         backend: AgentBackend::Codex,
-        permission: PermissionProfile {
-            name: "workspace".to_string(),
-            capability: crate::config::PermissionCapability::Workspace,
-        },
         approval_origin: origin,
         text: "draft".to_string(),
     }
@@ -2089,8 +2060,6 @@ fn test_config(state_path: &str, sessions_dir: &str, assistant_dir: &str) -> Con
         telegram_allow_chat_ids: Vec::new(),
         agent: "codex".to_string(),
         routes: Vec::new(),
-        permission_profile: "restricted".to_string(),
-        permission_profiles: HashMap::new(),
         assistant_root: assistant_dir.to_string(),
         jobs_dir: format!("{state_path}.jobs"),
         drafts_dir: format!("{state_path}.drafts"),

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -33,7 +33,6 @@ pub(super) async fn run(ctx: Ctx, mut rx: mpsc::Receiver<Job>) {
 }
 
 pub(super) async fn handle(ctx: &Ctx, job: Job) {
-    use crate::config::PermissionCapability;
     let existing_outbound = match ctx.history.lock().unwrap().outbound_for(job.inbound_id) {
         Ok(outbound) => outbound,
         Err(error) => {
@@ -41,34 +40,26 @@ pub(super) async fn handle(ctx: &Ctx, job: Job) {
             return;
         }
     };
-    // Threads whose capability allows writes get the draft boundary, so they
-    // can propose recurring jobs for approval.
-    let can_write = matches!(
-        job.permission.capability,
-        PermissionCapability::Workspace | PermissionCapability::Inherit
-    );
-    let draft_directory = if can_write {
-        match crate::drafts::origin_directory(&ctx.cfg, &job.approval_origin) {
-            Ok(directory) => Some(directory),
-            Err(error) => {
-                error!("[{}] draft boundary error: {error:#}", job.thread);
-                if let Some(outbound) = &existing_outbound {
-                    report_delivery(
-                        ctx,
-                        &job,
-                        deliver_stored(ctx, &job, outbound).await,
-                        &outbound.content,
-                        "recovered_outbound",
-                        "recover outbound",
-                    );
-                } else {
-                    complete_setup_failure(ctx, &job, SANDBOX_SETUP_FAILURE).await;
-                }
-                return;
+    // Push exposes the draft boundary. The selected agent's own configuration
+    // decides whether it may write there.
+    let draft_directory = match crate::drafts::origin_directory(&ctx.cfg, &job.approval_origin) {
+        Ok(directory) => Some(directory),
+        Err(error) => {
+            error!("[{}] draft boundary error: {error:#}", job.thread);
+            if let Some(outbound) = &existing_outbound {
+                report_delivery(
+                    ctx,
+                    &job,
+                    deliver_stored(ctx, &job, outbound).await,
+                    &outbound.content,
+                    "recovered_outbound",
+                    "recover outbound",
+                );
+            } else {
+                complete_setup_failure(ctx, &job, SANDBOX_SETUP_FAILURE).await;
             }
+            return;
         }
-    } else {
-        None
     };
     if let Some(outbound) = existing_outbound {
         if let Some(directory) = &draft_directory {
@@ -194,37 +185,24 @@ pub(super) async fn handle(ctx: &Ctx, job: Job) {
         }
     };
     let draft_write_dir = draft_directory.as_ref().and_then(|path| path.to_str());
-    let context_dir = match ctx.cfg.backend_context_dir() {
-        Ok(context_dir) => context_dir,
-        Err(error) => {
-            error!("[{}] assistant context error: {error:#}", job.thread);
-            audit(
-                ctx,
-                ctx.audit.failed(
-                    "backend_setup_failed",
-                    job.row_id,
-                    &job.thread,
-                    Some(job.backend),
-                    error.to_string(),
-                ),
-            );
-            complete_setup_failure(ctx, &job, SESSION_SETUP_FAILURE).await;
-            return;
-        }
-    };
-    let context_access_dir = context_dir.as_deref().and_then(Path::to_str);
-    // The footer exposes jobs by absolute path for reads. Do not add jobs here:
-    // backend --add-dir flags can make a path writable under workspace modes.
-    let mut additional_dirs = Vec::with_capacity(2);
-    if let Some(context_access_dir) = context_access_dir {
-        additional_dirs.push(context_access_dir);
-    }
-    if let Some(draft_write_dir) = draft_write_dir {
-        additional_dirs.push(draft_write_dir);
+    if let Err(error) = ctx.cfg.backend_context_dir() {
+        error!("[{}] assistant context error: {error:#}", job.thread);
+        audit(
+            ctx,
+            ctx.audit.failed(
+                "backend_setup_failed",
+                job.row_id,
+                &job.thread,
+                Some(job.backend),
+                error.to_string(),
+            ),
+        );
+        complete_setup_failure(ctx, &job, SESSION_SETUP_FAILURE).await;
+        return;
     }
     if let Some(draft_write_dir) = draft_write_dir {
         instructions.push_str(&format!(
-            "\n\nTo propose a recurring job, write one complete validated Markdown runbook to {}/<lowercase-slug>.md. This drafts directory is the only Push-owned path you may write. The user-owned context directory may also be editable when the selected permission profile allows it. A draft remains inactive until the allowlisted user approves its exact revision. Never write to the installed jobs directory, Push configuration, or Push state.",
+            "\n\nTo propose a recurring job, write one complete validated Markdown runbook to {}/<lowercase-slug>.md. This drafts directory is the only Push-owned path you may write. Your agent configuration decides whether the user-owned context directory is editable. A draft remains inactive until the allowlisted user approves its exact revision. Never write to the installed jobs directory, Push configuration, or Push state.",
             draft_write_dir
         ));
     }
@@ -275,15 +253,7 @@ pub(super) async fn handle(ctx: &Ctx, job: Job) {
         );
         let mut result = runner
             .run(
-                backend_request(
-                    &session_id,
-                    is_new,
-                    &work_dir,
-                    &additional_dirs,
-                    &instructions,
-                    job.permission.capability,
-                    prompt,
-                ),
+                backend_request(&session_id, is_new, &work_dir, &instructions, prompt),
                 ctx.run_timeout,
             )
             .await;
@@ -299,9 +269,7 @@ pub(super) async fn handle(ctx: &Ctx, job: Job) {
                                 &session_id,
                                 false,
                                 &work_dir,
-                                &additional_dirs,
                                 &instructions,
-                                job.permission.capability,
                                 &job.text,
                             ),
                             ctx.run_timeout,
@@ -359,15 +327,7 @@ pub(super) async fn handle(ctx: &Ctx, job: Job) {
                 .map_or(job.text.as_str(), |prompt| prompt.text.as_str());
             result = runner
                 .run(
-                    backend_request(
-                        &session_id,
-                        true,
-                        &work_dir,
-                        &additional_dirs,
-                        &instructions,
-                        job.permission.capability,
-                        prompt,
-                    ),
+                    backend_request(&session_id, true, &work_dir, &instructions, prompt),
                     ctx.run_timeout,
                 )
                 .await;
@@ -891,18 +851,14 @@ fn backend_request<'a>(
     session_id: &'a str,
     is_new: bool,
     work_dir: &'a str,
-    additional_dirs: &'a [&'a str],
     instructions: &'a str,
-    permission: crate::config::PermissionCapability,
     prompt: &'a str,
 ) -> Request<'a> {
     Request {
         session_id,
         is_new,
         work_dir,
-        additional_dirs,
         instructions,
-        permission,
         prompt,
     }
 }

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -16,7 +16,7 @@ use tokio::task::JoinSet;
 use uuid::Uuid;
 
 use crate::agent::{Request, RunError, Runner};
-use crate::config::{AgentBackend, Config, PermissionCapability};
+use crate::config::{AgentBackend, Config};
 use crate::util::{expand_home, now_ms, restrict_permissions, same_file};
 use crate::{history::History, soul};
 
@@ -715,7 +715,7 @@ impl Ledger {
                 queued_at_ms,
                 state,
                 job.backend.as_str(),
-                "inherit",
+                "agent",
                 duration_ms(job.timeout),
                 job.workdir.to_string_lossy(),
                 error,
@@ -948,7 +948,7 @@ fn insert_run(
             now,
             state,
             job.backend.as_str(),
-            "inherit",
+            "agent",
             duration_ms(job.timeout),
             job.workdir.to_string_lossy(),
             error,
@@ -1184,27 +1184,17 @@ async fn execute(cfg: &Config, job: &Job) -> std::result::Result<String, Executi
     let runner = Runner::for_backend(job.backend, cfg);
     let session_id = runner.initial_session_id();
     let workdir = job.workdir.to_string_lossy().to_string();
-    let context_dir = cfg
-        .backend_context_dir()
+    cfg.backend_context_dir()
         .map_err(|error| ExecutionError::Failed(format!("prepare assistant context: {error}")))?;
-    let additional_dirs = context_dir
-        .as_deref()
-        .and_then(Path::to_str)
-        .into_iter()
-        .collect::<Vec<_>>();
-    // Installed jobs are readable through the absolute path in `instructions`,
-    // but are intentionally not added as a backend workspace.
     let request = Request {
         session_id: &session_id,
         is_new: true,
         work_dir: &workdir,
-        additional_dirs: &additional_dirs,
         instructions: &instructions,
-        permission: PermissionCapability::Inherit,
         prompt: &job.body,
     };
     tracing::info!(
-        "job {} starting: backend={} permission=inherit workdir={} timeout={}",
+        "job {} starting: backend={} workdir={} timeout={}",
         job.name,
         job.backend.as_str(),
         workdir,

--- a/src/main.rs
+++ b/src/main.rs
@@ -413,10 +413,12 @@ mod tests {
         assert!(cfg.primary_delivery.is_none());
         assert_eq!(cfg.agent, "codex");
         assert_eq!(cfg.telegram_bot_token_env, "TELEGRAM_BOT_TOKEN");
+        assert_eq!(
+            cfg.telegram_bot_token.as_deref(),
+            Some("replace-with-the-token-from-BotFather")
+        );
         assert_eq!(cfg.telegram_allow_user_ids, [123456789]);
         assert!(cfg.telegram_allow_chat_ids.is_empty());
-        assert_eq!(cfg.permission_profile, "restricted");
-        assert!(cfg.permission_profiles.is_empty());
         assert_eq!(cfg.jobs_agent, None);
         assert_eq!(cfg.jobs_max_timeout, "30m");
         assert_eq!(cfg.jobs_max_workers, 2);
@@ -738,7 +740,7 @@ disallowed_tools = ["Edit"]
 
         let error = Config::load(path.to_str().unwrap()).unwrap_err();
 
-        assert!(error.to_string().contains("named permission_profile"));
+        assert!(error.to_string().contains("selected agent"));
         let _ = std::fs::remove_file(path);
     }
 
@@ -755,12 +757,12 @@ tools = ["Read", "Grep"]
 
         let error = Config::load(path.to_str().unwrap()).unwrap_err();
 
-        assert!(error.to_string().contains("named permission_profile"));
+        assert!(error.to_string().contains("selected agent"));
         let _ = std::fs::remove_file(path);
     }
 
     #[test]
-    fn inherit_profile_is_selectable_for_default_and_routes() {
+    fn removed_permission_profiles_have_an_actionable_error() {
         let path = temp_path("inherit-profile-config");
         std::fs::write(
             &path,
@@ -778,27 +780,14 @@ permission_profile = "trusted"
         )
         .unwrap();
 
-        let cfg = Config::load(path.to_str().unwrap()).unwrap();
+        let error = Config::load(path.to_str().unwrap()).unwrap_err();
 
-        assert_eq!(
-            cfg.route_for_message("imessage", "imessage:dm:someone")
-                .unwrap()
-                .permission
-                .capability,
-            config::PermissionCapability::Inherit
-        );
-        assert_eq!(
-            cfg.route_for_message("imessage", "imessage:self:me@icloud.com")
-                .unwrap()
-                .permission
-                .capability,
-            config::PermissionCapability::Inherit
-        );
+        assert!(error.to_string().contains("selected agent"));
         let _ = std::fs::remove_file(path);
     }
 
     #[test]
-    fn built_in_inherit_profile_cannot_be_redefined() {
+    fn removed_permission_profile_tables_have_an_actionable_error() {
         let path = temp_path("inherit-redefined-config");
         std::fs::write(
             &path,
@@ -812,7 +801,7 @@ capability = "read-only"
 
         let error = Config::load(path.to_str().unwrap()).unwrap_err();
 
-        assert!(error.to_string().contains("cannot be redefined"));
+        assert!(error.to_string().contains("selected agent"));
         let _ = std::fs::remove_file(path);
     }
 
@@ -915,25 +904,21 @@ allow_user_ids = [7]
                 thread: None,
                 channel: Some("telegram".to_string()),
                 agent: "codex".to_string(),
-                permission_profile: Some("workspace".to_string()),
             },
             config::RouteRule {
                 thread: Some("telegram:dm:7".to_string()),
                 channel: None,
                 agent: "claude".to_string(),
-                permission_profile: None,
             },
             config::RouteRule {
                 thread: Some("telegram:dm:7:topic:99".to_string()),
                 channel: None,
                 agent: "codex".to_string(),
-                permission_profile: None,
             },
             config::RouteRule {
                 thread: Some("self:me@icloud.com".to_string()),
                 channel: None,
                 agent: "codex".to_string(),
-                permission_profile: None,
             },
         ];
 
@@ -948,13 +933,6 @@ allow_user_ids = [7]
                 .unwrap()
                 .backend,
             config::AgentBackend::Codex
-        );
-        assert_eq!(
-            cfg.route_for_message("telegram", "telegram:dm:8")
-                .unwrap()
-                .permission
-                .capability,
-            config::PermissionCapability::Workspace
         );
         assert_eq!(
             cfg.route_for_message("telegram", "telegram:dm:7:topic:99")
@@ -977,7 +955,7 @@ allow_user_ids = [7]
     }
 
     #[test]
-    fn unknown_route_permission_profile_fails_config_load() {
+    fn removed_route_permission_profile_has_an_actionable_error() {
         let path = temp_path("unknown-route-permission");
         std::fs::write(
             &path,
@@ -993,9 +971,7 @@ permission_profile = "missing"
 
         let error = Config::load(path.to_str().unwrap()).unwrap_err();
 
-        assert!(error
-            .to_string()
-            .contains("invalid permission profile for route"));
+        assert!(error.to_string().contains("selected agent"));
         let _ = std::fs::remove_file(path);
     }
 }

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -8,7 +8,6 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
 use crate::agent::{Request, RunError, RunOutput};
-use crate::config::PermissionCapability;
 
 /// Runner invokes `pi` in non-interactive JSON event mode.
 pub struct Runner {
@@ -87,9 +86,6 @@ impl Runner {
         if !req.instructions.trim().is_empty() {
             cmd.arg("--append-system-prompt")
                 .arg(req.instructions.trim());
-        }
-        if let Some(tools) = tools(req.permission) {
-            cmd.arg("--tools").arg(tools);
         }
         if !req.is_new {
             cmd.arg("--session").arg(req.session_id);
@@ -179,19 +175,6 @@ fn missing_resume_error(message: &str) -> bool {
         .contains("no session found matching")
 }
 
-const READ_ONLY_TOOLS: &str = "read,grep,find,ls";
-const WORKSPACE_TOOLS: &str = "read,edit,write,grep,find,ls";
-const FULL_ACCESS_TOOLS: &str = "read,bash,edit,write,grep,find,ls";
-
-fn tools(capability: PermissionCapability) -> Option<&'static str> {
-    match capability {
-        PermissionCapability::ReadOnly => Some(READ_ONLY_TOOLS),
-        PermissionCapability::Workspace => Some(WORKSPACE_TOOLS),
-        PermissionCapability::Inherit => None,
-        PermissionCapability::FullAccess => Some(FULL_ACCESS_TOOLS),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,9 +219,7 @@ mod tests {
                     session_id: "",
                     is_new: true,
                     work_dir: work_dir.to_str().unwrap(),
-                    additional_dirs: &[],
                     instructions: "SOUL instructions",
-                    permission: PermissionCapability::Workspace,
                     prompt: "user message",
                 },
                 Duration::from_secs(5),
@@ -251,7 +232,7 @@ mod tests {
         let args = read_args(&args_path);
         assert_arg_pair(&args, "--mode", "json");
         assert_arg_pair(&args, "--append-system-prompt", "SOUL instructions");
-        assert_arg_pair(&args, "--tools", WORKSPACE_TOOLS);
+        assert!(!args.contains(&"--tools".to_string()));
         assert!(!args.contains(&"--session".to_string()));
         assert_eq!(read_prompt(&args_path), "user message");
         assert!(!args.contains(&"user message".to_string()));
@@ -299,9 +280,7 @@ mod tests {
                     session_id: "pi-session",
                     is_new: false,
                     work_dir: work_dir.to_str().unwrap(),
-                    additional_dirs: &[],
                     instructions: "SOUL instructions",
-                    permission: PermissionCapability::ReadOnly,
                     prompt: "continue",
                 },
                 Duration::from_secs(5),
@@ -313,7 +292,7 @@ mod tests {
         assert_eq!(output.session_id, None);
         let args = read_args(&args_path);
         assert_arg_pair(&args, "--session", "pi-session");
-        assert_arg_pair(&args, "--tools", READ_ONLY_TOOLS);
+        assert!(!args.contains(&"--tools".to_string()));
     }
 
     #[tokio::test]
@@ -425,21 +404,6 @@ mod tests {
         assert_eq!(output.reply, "recovered");
     }
 
-    #[test]
-    fn maps_all_permission_profiles_conservatively() {
-        assert_eq!(tools(PermissionCapability::ReadOnly), Some(READ_ONLY_TOOLS));
-        assert_eq!(
-            tools(PermissionCapability::Workspace),
-            Some(WORKSPACE_TOOLS)
-        );
-        assert_eq!(tools(PermissionCapability::Inherit), None);
-        assert_eq!(
-            tools(PermissionCapability::FullAccess),
-            Some(FULL_ACCESS_TOOLS)
-        );
-        assert!(!WORKSPACE_TOOLS.split(',').any(|tool| tool == "bash"));
-    }
-
     fn success_script(args_path: &std::path::Path, session: &str, reply: &str) -> String {
         format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\ncat > {}.stdin\nprintf '%s\\n' '{{\"type\":\"session\",\"id\":\"{session}\"}}'\nprintf '%s\\n' '{{\"type\":\"message_end\",\"message\":{{\"role\":\"assistant\",\"content\":[{{\"type\":\"text\",\"text\":\"{reply}\"}}],\"stopReason\":\"stop\"}}}}'\n",
@@ -453,9 +417,7 @@ mod tests {
             session_id: if is_new { "" } else { "existing-session" },
             is_new,
             work_dir,
-            additional_dirs: &[],
             instructions: "",
-            permission: PermissionCapability::ReadOnly,
             prompt: "hello",
         }
     }
@@ -544,7 +506,6 @@ mod tests {
             is_new,
             work_dir,
             instructions: String::new(),
-            permission: PermissionCapability::ReadOnly,
             prompt: "hello".to_string(),
         }
     }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use crate::agent::{Request, RunError, RunOutput};
-use crate::config::PermissionCapability;
 
 pub struct FakeCli {
     root: PathBuf,
@@ -58,8 +57,6 @@ pub fn test_config() -> crate::config::Config {
         telegram_allow_chat_ids: Vec::new(),
         agent: "codex".to_string(),
         routes: Vec::new(),
-        permission_profile: "restricted".to_string(),
-        permission_profiles: std::collections::HashMap::new(),
         assistant_root: "/fake/assistant".to_string(),
         jobs_dir: "/fake/jobs".to_string(),
         drafts_dir: "/fake/drafts".to_string(),
@@ -117,7 +114,6 @@ pub struct ContractRequest {
     pub is_new: bool,
     pub work_dir: PathBuf,
     pub instructions: String,
-    pub permission: PermissionCapability,
     pub prompt: String,
 }
 
@@ -127,9 +123,7 @@ impl ContractRequest {
             session_id: &self.session_id,
             is_new: self.is_new,
             work_dir: self.work_dir.to_str().unwrap(),
-            additional_dirs: &[],
             instructions: &self.instructions,
-            permission: self.permission,
             prompt: &self.prompt,
         }
     }

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -33,7 +33,7 @@ fn init_without_path_creates_assistant_in_current_directory() {
     assert!(config.contains("agent = \"codex\""));
     assert!(config.contains("[telegram]"));
     assert!(config.contains("allow_user_ids = []"));
-    assert!(config.contains("TELEGRAM_BOT_TOKEN"));
+    assert!(config.contains("bot_token = \"\""));
     assert!(config.contains(
         &assistant
             .canonicalize()
@@ -41,6 +41,18 @@ fn init_without_path_creates_assistant_in_current_directory() {
             .to_string_lossy()
             .to_string()
     ));
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            std::fs::metadata(&config_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Review or configure the channel and its allowlist:"));
     assert!(stdout.contains("push doctor"));


### PR DESCRIPTION
## Summary
- remove Push permission profiles and every backend sandbox, approval, tool, and add-directory override
- reject removed permission settings with actionable migration errors
- put the Telegram bot token in generated config and create new config files with mode 0600 on Unix
- update tests and documentation for agent-owned permissions

## Breaking change
Remove permission_profile, permission_profiles, route permission overrides, and raw backend permission fields from Push config. Configure permissions in Claude Code, Codex, or Pi instead.

## Verification
- cargo fmt --all -- --check
- cargo test --locked
- cargo clippy --locked --all-targets -- -D warnings
- cargo build --release --locked
- mkdocs build --strict
- independent subagent diff review