### PR TITLE
feat(gateway): run chats from assistant root

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ and the rest of your day.
 - Durable conversation history and backend session recovery
 - Agent-owned permissions with no gateway sandbox or tool overrides
 - Manual and scheduled Markdown jobs with a durable run ledger
-- Agent-drafted jobs that require approval of the exact revision in chat
+- An agent-drafted job workflow that approves the exact revision in chat
 - Local structured audit logs with message content redacted by default
 
 Push is early software. Its scope is intentionally smaller than a general
 agent platform, and its security depends on a tight sender allowlist plus the
-permissions you give your backend.
+permissions you give your backend. Push does not override agent permissions, so
+write access to the assistant repository can also change `SOUL.md` or installed
+jobs outside the draft approval workflow.
 
 ## Start here
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,7 +160,7 @@ Claude Code lets Push choose the session id.
 - New conversation: `claude -p --session-id <uuid>`
 - Existing conversation: `claude -p --resume <uuid>`
 - Instructions: `--append-system-prompt <SOUL.md + resolved assistant paths + gateway policy>`
-- Work dir: per-thread sandbox dir
+- Work dir: `assistant_root`
 
 ### Codex Adapter
 
@@ -169,7 +169,7 @@ Codex creates its own thread id.
 - New conversation: `codex exec --json ...`
 - Existing conversation: `codex exec resume <thread_id> ...`
 - Instructions: `-c developer_instructions=<SOUL.md + resolved assistant paths + gateway policy>`
-- Work dir: per-thread sandbox dir on the first run
+- Work dir: `assistant_root`, including resumed runs
 
 The adapter reads Codex JSONL events to capture `thread.started.thread_id` and
 stores that id for future turns.
@@ -181,7 +181,7 @@ Pi creates its own session id and reports it in the first JSON event.
 - New conversation: `pi --print --mode json ...`
 - Existing conversation: `pi --print --mode json --session <session_id> ...`
 - Instructions: `--append-system-prompt <SOUL.md + resolved assistant paths + gateway policy>`
-- Work dir: per-thread session directory
+- Work dir: `assistant_root`
 
 The adapter reads the session header and final assistant `message_end` event.
 Push passes no tool override to Pi. Pi has no native filesystem sandbox or
@@ -250,8 +250,9 @@ crash boundary. SQLite history does not replace `state.json` cursors or backend
 session IDs in this phase.
 
 The same database stores immutable job-run claims and bounded terminal results.
-Markdown runbooks remain operator-owned files under `<assistant_root>/jobs`. A manual CLI
-start rereads and validates the exact file, acquires a non-blocking per-job lock,
+Markdown runbooks live under `<assistant_root>/jobs`; their write boundary is
+set by the selected agent's configuration. A manual CLI start rereads and
+validates the exact file, acquires a non-blocking per-job lock,
 then records and claims the run in one immediate SQLite transaction before
 spawning a fresh backend session. The CLI holds the lock through result
 persistence. Only a process that acquired the released lock may fail a stale
@@ -271,7 +272,10 @@ expired terminal state, so later cancellation cannot overwrite the timeout.
 
 Agent-written job proposals live separately under origin-specific inboxes in
 `drafts_dir`. Push creates the exact inbox and includes its path in the route's
-instructions. The selected agent's configuration decides whether it is writable. Push snapshots
+instructions. The selected agent's configuration decides whether it and the
+assistant root are writable. Push's approval flow governs drafts it installs;
+it does not prevent a write-enabled agent from changing installed jobs
+directly. Push snapshots
 and validates a changed regular file, stores its exact bytes, hash, proposer,
 and bound approval question in SQLite, then sends the full proposal to the
 originating channel. Reconciliation also runs after backend failure or timeout

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,7 +176,7 @@ the selected agent and review [permissions and security](security.md).
 | Setting | Default | Purpose |
 | --- | --- | --- |
 | `assistant_root` | required for new setups | Canonical root of the one assistant repository; `SOUL.md`, `context/`, and `jobs/` are derived |
-| `sessions_dir` | `~/.push/sessions` | Per-thread backend work directories |
+| `sessions_dir` | `~/.push/sessions` | Legacy compatibility setting; chat work directories use `assistant_root` |
 | `state_path` | `~/.push/state.json` | Channel cursors and backend session IDs |
 | `database_path` | `~/.push/push.db` | Canonical conversation, approval, and job history |
 | `audit_log_path` | `~/.push/audit.jsonl` | Structured local audit log |

--- a/docs/core-system/design.md
+++ b/docs/core-system/design.md
@@ -90,7 +90,9 @@ Codex receives it as developer instructions. Push never writes resolved machine 
 into `SOUL.md` and does not inject all context files into every prompt. The
 backend decides which files to inspect. Conversation instructions include the
 absolute `context/` path. The agent's own configuration decides access;
-`SOUL.md` and installed jobs remain protected by Push's workflow rules and OS permissions.
+Push does not create a separate filesystem boundary around `SOUL.md` or
+installed jobs. An agent with write access to the assistant root can change
+them directly, outside Push's draft approval workflow.
 
 Push owns the footer so customising `SOUL.md` cannot remove repository
 locations or ownership rules. Runtime sessions, drafts, databases, audit logs,
@@ -215,8 +217,8 @@ only when real usage identifies the failure mode.
 - A future reconciler may preserve an incorrect or injected claim. Keep memory
   small, derived, inspectable, replaceable, and lower priority than `SOUL.md`.
 - An inherited backend configuration may still grant broad filesystem access.
-  Keep `SOUL.md` and installed jobs protected by policy and the existing route
-  restrictions, and reserve normal assistant edits for `context/`.
+  Restrict assistant-root writes in the backend configuration when `SOUL.md`
+  and installed jobs must only change through an operator-controlled path.
 
 ## Rollout
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,10 +15,10 @@ You need:
 - `curl` and `tar` for the release installer
 
 Push uses the backend's existing login, settings, tools, MCP servers, skills,
-and backend configuration. Each chat runs from a Push-owned per-thread
-directory under `sessions_dir`, not the shell directory that launched Push.
-Use absolute paths when you want the agent to inspect a repository elsewhere.
-Confirm the selected command works before starting Push:
+and backend configuration. Each chat runs from `assistant_root`, so the backend
+can discover project instructions such as `AGENTS.md` and work with the
+assistant's context directly. Confirm the selected command works before
+starting Push:
 
 === "Codex"
 

--- a/docs/jobs/design.md
+++ b/docs/jobs/design.md
@@ -231,8 +231,9 @@ execution:
 - `push job runs [<name>]`
 
 Push is the only writer to the run ledger. The CLI owns the manual run it
-claims, and the gateway owns scheduled runs. Installed job files remain
-operator-owned.
+claims, and the gateway owns scheduled runs. Push installs draft jobs only
+after approval, but an agent with assistant-root write access can change
+installed job files outside that workflow.
 
 ### Agent-authored draft extension
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -157,7 +157,7 @@ user prompt.
 | `codex_bin` | Codex binary. |
 | `codex_model` | Optional Codex model override. |
 | `pi_bin` | Pi coding agent binary. |
-| `sessions_dir` | Per-thread working dirs. |
+| `sessions_dir` | Legacy compatibility setting. |
 | `state_path` | JSON state path. |
 | `audit_log_path` | Local JSONL audit log path. |
 | `audit_log_content` | Whether audit events include message and reply text. |

--- a/docs/security.md
+++ b/docs/security.md
@@ -54,12 +54,11 @@ service environment using the narrowest policy that works.
 | `~/.push/state.json` | channel cursors and backend session IDs |
 | `~/.push/push.db` | conversation history, approvals, and job runs |
 | `~/.push/audit.jsonl` | metadata, errors, handles, and optional content |
-| `~/.push/sessions/` | per-thread backend workspaces |
 | `~/.push/drafts/` | inactive agent-authored proposals |
 
 Keep them on local durable storage with permissions restricted to the service
 user. Keep the assistant directory in its own private Git repository. Never
-put real config secrets, state, audit logs, session workspaces, or databases in
+put real config secrets, state, audit logs, or databases in
 that repository. An explicit `assistant_root` config stored inside it cannot
 contain an inline Telegram token; use `telegram.bot_token_env` or move the
 config outside.
@@ -76,6 +75,10 @@ Agent-drafted jobs remain inactive until the exact revision is approved from
 the originating allowed identity. Approval questions are stored before
 delivery, survive restart, expire, and can be consumed once. Mismatched,
 duplicate, ambiguous, cancelled, and expired answers do not reach an agent.
+This protects proposals submitted through Push's drafts directory. It is not a
+filesystem sandbox. If the selected agent can write to `assistant_root`, it can
+also change `SOUL.md` or installed jobs directly. Restrict that access in the
+agent's own configuration when the approval boundary must be enforced.
 
 ## Audit log
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -23,26 +23,23 @@ Use absolute paths in service files. The service user needs:
 - write access to `state_path`
 - write access to `audit_log_path`
 - write access to `database_path`
-- write access to `sessions_dir`
-- read access to `assistant_root/SOUL.md`, `assistant_root/context/`, and
-  `assistant_root/jobs/`
-- access to `assistant_root/context/` as allowed by the selected agent, and
-  write access to `assistant_root/jobs/` only for approved job installation
+- filesystem access to `assistant_root` as allowed by the selected agent
+- write access to `assistant_root/jobs/` for Push to install approved drafts;
+  agent write access can also change installed jobs outside that workflow
 - access to the selected `claude`, `codex`, or `pi` executable on `PATH`
 - backend login, tokens, settings, MCP config, and project credentials
 - for iMessage on macOS, Full Disk Access and `osascript`
 - for Telegram, a token in the private config and network access to
   `api.telegram.org`
 
-`state_path` stores independent cursors for each channel. `sessions_dir` stores
-per-thread backend work directories, and `state.json` stores backend session
-ids. `database_path` stores the canonical conversation journal. Keep these
-paths on durable storage. Restarting the service resumes after
-the last completed row and reuses existing backend sessions when the backend for
-that thread has not changed.
+`state_path` stores independent cursors for each channel and backend session
+ids. `database_path` stores the canonical conversation journal. Chat agents run
+from `assistant_root`. Keep these paths on durable storage. Restarting the
+service resumes after the last completed row and reuses existing backend
+sessions when the backend for that thread has not changed.
 
 Keep `assistant_root` in its own Git repository. Keep config secrets, state,
-sessions, databases, drafts, logs, locks, and service credentials outside it.
+databases, drafts, logs, locks, and service credentials outside it.
 
 ## macOS launchd
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -98,11 +98,10 @@ Protect these files as credentials or private assistant data:
 - the bot token and configuration
 - `state.json` and the audit log
 - `push.db`
-- the session workspace directory
 - the private `assistant_root` repository, including `SOUL.md`, context, and jobs
 
 The assistant directory is intended to be versioned in its own private Git
-repository. Never put bot tokens, config secrets, state files, audit logs,
-session workspaces, or databases in it. Rotate the bot token with BotFather
+repository. Never put bot tokens, config secrets, state files, audit logs, or
+databases in it. Rotate the bot token with BotFather
 immediately if it is exposed. Keep allowlists narrow because an allowed sender
 can instruct the configured agent to use its local tools and credentials.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -138,6 +138,7 @@ pub struct FakeRunner {
 pub struct FakeRunCall {
     pub session_id: String,
     pub is_new: bool,
+    pub work_dir: String,
     pub prompt: String,
     pub instructions: String,
 }
@@ -148,6 +149,7 @@ impl FakeRunner {
         self.calls.lock().unwrap().push(FakeRunCall {
             session_id: req.session_id.to_string(),
             is_new: req.is_new,
+            work_dir: req.work_dir.to_string(),
             prompt: req.prompt.to_string(),
             instructions: req.instructions.to_string(),
         });

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -1,6 +1,8 @@
 //! Runs the Codex CLI headlessly for a single message.
 
-use std::path::Path;
+use std::fs::OpenOptions;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::Deserialize;
@@ -26,13 +28,37 @@ struct JsonEvent {
     item: Value,
 }
 
+struct OutputFile {
+    path: PathBuf,
+}
+
+impl OutputFile {
+    fn create() -> std::io::Result<Self> {
+        let path =
+            std::env::temp_dir().join(format!("push-codex-last-message-{}.txt", Uuid::new_v4()));
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for OutputFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
 impl Runner {
     /// Executes one turn and returns Codex's final reply plus the Codex session id.
     pub async fn run(&self, req: Request<'_>, timeout: Duration) -> Result<RunOutput, RunError> {
-        let out_path = Path::new(req.work_dir)
-            .join(format!(".push-codex-last-message-{}.txt", Uuid::new_v4()));
+        let output_file = OutputFile::create()
+            .map_err(|error| RunError::Failed(format!("prepare Codex output: {error}")))?;
+        let out_path = output_file.path.as_path();
         let attempt = crate::agent::output_with_retry(|| {
-            let mut cmd = self.command(&req, &out_path);
+            let mut cmd = self.command(&req, out_path);
             async move { cmd.output().await }
         });
         let out = match tokio::time::timeout(timeout, attempt).await {
@@ -43,13 +69,11 @@ impl Runner {
 
         let stdout = String::from_utf8_lossy(&out.stdout);
         let session_id = session_id_from_jsonl(&stdout);
-        let reply = std::fs::read_to_string(&out_path)
+        let reply = std::fs::read_to_string(out_path)
             .ok()
             .filter(|s| !s.trim().is_empty())
             .or_else(|| last_agent_message_from_jsonl(&stdout))
             .unwrap_or_default();
-        let _ = std::fs::remove_file(&out_path);
-
         if !out.status.success() {
             let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
             let message = if stderr.is_empty() {
@@ -328,7 +352,21 @@ mod tests {
     #[tokio::test]
     async fn reports_timeout() {
         let work_dir = temp_dir("codex-timeout-work");
-        let cli = FakeCli::new("codex", "#!/bin/sh\nsleep 2\n");
+        let cli = FakeCli::new(
+            "codex",
+            r#"#!/bin/sh
+out=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = '-o' ]; then
+    shift
+    out="$1"
+  fi
+  shift
+done
+printf '%s\n' 'partial reply' > "$out"
+sleep 2
+"#,
+        );
         let runner = runner(cli.bin());
 
         let err = match runner
@@ -343,6 +381,7 @@ mod tests {
         };
 
         assert_timeout(err);
+        assert!(std::fs::read_dir(&work_dir).unwrap().next().is_none());
     }
 
     fn runner(bin: String) -> Runner {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -55,12 +55,6 @@ fn run_checks(cfg: &config::Config) -> CheckReport {
         &cfg.state_path,
         &mut checks,
     );
-    check_writable_dir(
-        "sessions directory",
-        "sessions_dir",
-        Path::new(&cfg.sessions_dir),
-        &mut checks,
-    );
     check_drafts_dir(cfg, &mut checks);
     check_parent_dir(
         "audit log directory",
@@ -565,7 +559,6 @@ claude_tools = []
         let db_path = temp_path("chat-db");
         std::fs::write(&db_path, "").unwrap();
         let state_path = temp_path("state-dir").join("state.json");
-        let sessions_dir = temp_dir("sessions-dir");
         let mut cfg = test_config();
         cfg.db_path = db_path.to_string_lossy().to_string();
         cfg.state_path = state_path.to_string_lossy().to_string();
@@ -577,8 +570,6 @@ claude_tools = []
             .with_extension("push.db")
             .to_string_lossy()
             .to_string();
-        cfg.sessions_dir = sessions_dir.to_string_lossy().to_string();
-
         let report = run_checks(&cfg);
 
         assert!(report
@@ -587,9 +578,6 @@ claude_tools = []
             .any(|check| check.name == "config" && matches!(check.status, CheckStatus::Pass)));
         assert!(report.checks.iter().any(|check| {
             check.name == "state directory" && matches!(check.status, CheckStatus::Pass)
-        }));
-        assert!(report.checks.iter().any(|check| {
-            check.name == "sessions directory" && matches!(check.status, CheckStatus::Pass)
         }));
         assert!(report.checks.iter().any(|check| {
             check.name == "audit log directory" && matches!(check.status, CheckStatus::Pass)
@@ -605,7 +593,6 @@ claude_tools = []
         let _ = std::fs::remove_file(state_path);
         let _ = std::fs::remove_file(cfg.audit_log_path);
         let _ = std::fs::remove_file(cfg.database_path);
-        let _ = std::fs::remove_dir_all(sessions_dir);
     }
 
     #[test]

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -53,7 +53,6 @@ struct Ctx {
     channel: Channel,
     run_timeout: Duration,
     reply_marker: String,
-    sessions_dir: String,
     assistant_dir: String,
     audit: Arc<AuditLog>,
     #[cfg(test)]
@@ -340,7 +339,6 @@ impl Gateway {
             channel: channel.clone(),
             run_timeout: cfg.run_timeout_dur()?,
             reply_marker: cfg.reply_marker.clone(),
-            sessions_dir: cfg.sessions_dir.clone(),
             assistant_dir: cfg.assistant_dir.clone(),
             audit,
             #[cfg(test)]

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -1,6 +1,6 @@
 use super::worker::{
-    handle, present_drafts, run_with_periodic_activity, sandbox, DELIVERY_ATTEMPTS,
-    SANDBOX_SETUP_FAILURE, SESSION_SETUP_FAILURE,
+    handle, present_drafts, run_with_periodic_activity, DELIVERY_ATTEMPTS, DRAFT_SETUP_FAILURE,
+    SESSION_SETUP_FAILURE,
 };
 use super::*;
 use crate::agent::{FakeRunCall, FakeRunner};
@@ -146,7 +146,7 @@ fn temp_path(name: &str) -> PathBuf {
 fn setup_failure_ctx(
     store: Arc<Mutex<Store>>,
     ack: Arc<Mutex<AckState>>,
-    sessions_dir: String,
+    assistant_dir: String,
 ) -> Ctx {
     let mut runners = HashMap::new();
     runners.insert(
@@ -164,8 +164,8 @@ fn setup_failure_ctx(
     Ctx {
         cfg: test_config(
             &temp_path("setup-failure-state").to_string_lossy(),
-            &sessions_dir,
-            "",
+            &temp_path("setup-failure-sessions").to_string_lossy(),
+            &assistant_dir,
         ),
         store,
         history: Arc::new(Mutex::new(history)),
@@ -174,8 +174,7 @@ fn setup_failure_ctx(
         channel: filter(),
         run_timeout: Duration::from_secs(1),
         reply_marker: String::new(),
-        sessions_dir,
-        assistant_dir: String::new(),
+        assistant_dir,
         audit: Arc::new(AuditLog::new(
             temp_path("setup-failure-audit")
                 .to_string_lossy()
@@ -341,18 +340,6 @@ fn group_chat_dropped_even_from_allowlisted_sender() {
 }
 
 #[test]
-fn imessage_keeps_legacy_sandbox_path_while_telegram_is_qualified() {
-    assert_eq!(
-        sandbox("/sessions", "imessage:dm:+15551234567"),
-        "/sessions/dm__15551234567"
-    );
-    assert_eq!(
-        sandbox("/sessions", "telegram:dm:15551234567"),
-        "/sessions/telegram_dm_15551234567"
-    );
-}
-
-#[test]
 fn ack_does_not_advance_past_in_flight_row() {
     let mut ack = AckState::default();
     ack.in_flight.insert(10);
@@ -440,39 +427,6 @@ async fn session_lookup_failure_completes_in_flight_row() {
 }
 
 #[tokio::test]
-async fn sandbox_setup_failure_completes_in_flight_row_and_advances_cursor() {
-    let state_path = temp_state_path();
-    let store = Arc::new(Mutex::new(Store::open(&state_path).unwrap()));
-    let sessions_blocker = temp_path("sessions-blocker");
-    std::fs::write(&sessions_blocker, "not a directory").unwrap();
-    let ack = Arc::new(Mutex::new(AckState::default()));
-    {
-        let mut ack = ack.lock().unwrap();
-        ack.in_flight.insert(10);
-        ack.completed.insert(11);
-    }
-    let ctx = setup_failure_ctx(
-        store.clone(),
-        ack.clone(),
-        sessions_blocker.to_string_lossy().to_string(),
-    );
-
-    handle(&ctx, setup_failure_job(10)).await;
-
-    assert_eq!(
-        ctx.setup_failure_replies.lock().unwrap().as_slice(),
-        [SANDBOX_SETUP_FAILURE]
-    );
-    assert_eq!(store.lock().unwrap().last_row(), 11);
-    let ack = ack.lock().unwrap();
-    assert!(ack.in_flight.is_empty());
-    assert!(ack.completed.is_empty());
-
-    let _ = std::fs::remove_file(state_path);
-    let _ = std::fs::remove_file(sessions_blocker);
-}
-
-#[tokio::test]
 async fn draft_boundary_failure_completes_in_flight_row_and_advances_cursor() {
     let state_path = temp_state_path();
     let store = Arc::new(Mutex::new(Store::open(&state_path).unwrap()));
@@ -496,7 +450,7 @@ async fn draft_boundary_failure_completes_in_flight_row_and_advances_cursor() {
 
     assert_eq!(
         ctx.setup_failure_replies.lock().unwrap().as_slice(),
-        [SANDBOX_SETUP_FAILURE]
+        [DRAFT_SETUP_FAILURE]
     );
     assert_eq!(store.lock().unwrap().last_row(), 11);
     let ack = ack.lock().unwrap();
@@ -625,9 +579,16 @@ async fn fake_channel_e2e_replies_once_ignores_unallowlisted_and_reuses_session(
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].session_id, "");
         assert!(calls[0].is_new);
+        assert_eq!(
+            calls[0].work_dir,
+            std::fs::canonicalize(&assistant_dir)
+                .unwrap()
+                .to_string_lossy()
+        );
         assert_eq!(calls[0].prompt, "first");
         assert_eq!(calls[1].session_id, "fake-session");
         assert!(!calls[1].is_new);
+        assert_eq!(calls[1].work_dir, calls[0].work_dir);
         assert_eq!(calls[1].prompt, "second");
         for call in calls.iter() {
             assert!(call.instructions.starts_with("Be useful."));

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -22,8 +22,8 @@ const TYPING_REFRESH: Duration = Duration::from_secs(4);
 pub(super) const DELIVERY_ATTEMPTS: usize = 3;
 pub(super) const SESSION_SETUP_FAILURE: &str =
     "Push could not prepare this conversation. Check the local logs, then resend.";
-pub(super) const SANDBOX_SETUP_FAILURE: &str =
-    "Push could not create its session workspace. Check the local logs, then resend.";
+pub(super) const DRAFT_SETUP_FAILURE: &str =
+    "Push could not prepare its draft workspace. Check the local logs, then resend.";
 
 /// Processes one thread's jobs strictly in order, exiting when the queue closes.
 pub(super) async fn run(ctx: Ctx, mut rx: mpsc::Receiver<Job>) {
@@ -56,7 +56,7 @@ pub(super) async fn handle(ctx: &Ctx, job: Job) {
                     "recover outbound",
                 );
             } else {
-                complete_setup_failure(ctx, &job, SANDBOX_SETUP_FAILURE).await;
+                complete_setup_failure(ctx, &job, DRAFT_SETUP_FAILURE).await;
             }
             return;
         }
@@ -149,24 +149,26 @@ pub(super) async fn handle(ctx: &Ctx, job: Job) {
         }
     };
 
-    let work_dir = sandbox(&ctx.sessions_dir, &job.thread);
-    if let Err(e) = std::fs::create_dir_all(&work_dir) {
-        error!("[{}] sandbox error: {e}", job.thread);
-        audit(
-            ctx,
-            ctx.audit.failed(
-                "backend_setup_failed",
-                job.row_id,
-                &job.thread,
-                Some(job.backend),
-                e.to_string(),
-            ),
-        );
-        complete_setup_failure(ctx, &job, SANDBOX_SETUP_FAILURE).await;
-        return;
-    }
+    let work_dir = match std::fs::canonicalize(&ctx.assistant_dir) {
+        Ok(path) => path.to_string_lossy().to_string(),
+        Err(error) => {
+            error!("[{}] assistant workspace error: {error}", job.thread);
+            audit(
+                ctx,
+                ctx.audit.failed(
+                    "backend_setup_failed",
+                    job.row_id,
+                    &job.thread,
+                    Some(job.backend),
+                    error.to_string(),
+                ),
+            );
+            complete_setup_failure(ctx, &job, SESSION_SETUP_FAILURE).await;
+            return;
+        }
+    };
 
-    let mut instructions = match soul::load(&ctx.assistant_dir) {
+    let mut instructions = match soul::load(&work_dir) {
         Ok(instructions) => instructions,
         Err(error) => {
             error!("[{}] assistant identity error: {error}", job.thread);
@@ -832,11 +834,6 @@ fn short(msg: &str) -> String {
     }
 }
 
-pub(super) fn sandbox(sessions_dir: &str, thread: &str) -> String {
-    let directory_key = thread.strip_prefix("imessage:").unwrap_or(thread);
-    format!("{sessions_dir}/{}", sanitize(directory_key))
-}
-
 fn rehydration_prompt(ctx: &Ctx, job: &Job) -> Result<RehydrationPrompt> {
     let messages = ctx.history.lock().unwrap().recent_messages_before(
         ctx.channel.id(),
@@ -861,14 +858,4 @@ fn backend_request<'a>(
         instructions,
         prompt,
     }
-}
-
-/// Turns a thread key into a filesystem-safe directory name.
-fn sanitize(s: &str) -> String {
-    s.chars()
-        .map(|c| match c {
-            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => c,
-            _ => '_',
-        })
-        .collect()
 }


### PR DESCRIPTION
## Summary

- run every chat backend turn from the canonical `assistant_root` so project instructions and context are discoverable
- remove per-thread chat workspace creation while retaining backend session continuity and legacy config parsing
- keep Codex reply output in a private runtime temp file outside the assistant repository
- document that assistant-root write access is controlled by the selected agent and can bypass Push's draft approval workflow

## Checks

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --locked --release`
- `cargo fmt -- --check`
- `git diff --check`
- independent diff review: no remaining findings