### PR TITLE
chore: prepare v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "push"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "push"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 description = "A tiny messaging gateway that turns coding agents into a personal assistant you text."


### PR DESCRIPTION
## Summary

Bump the package and lockfile versions from 0.4.0 to 0.5.0.

## Why

Publish the assistant-root chat workspace change merged in PR #99.

## Test plan

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --locked --release`
- `cargo metadata --locked` reports `push 0.5.0`
- independent release review found no issues

## Risks

Low. The diff changes package metadata only.

## Related issue

None.