### PR TITLE
chore: prepare v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "push"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "push"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 description = "A tiny messaging gateway that turns coding agents into a personal assistant you text."


### PR DESCRIPTION
## Summary

Bump the package version from 0.5.0 to 0.6.0.

## Why

Prepare the merged voice message feature for a tagged release.

## Test plan

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo build --locked --release`
- `git diff --check`

## Risks

Low. This only updates the package version in Cargo.toml and Cargo.lock.

## Related issue

None.