### PR TITLE
 feat(agent): add aider.chat as a fourth agent backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ and the rest of your day.
 
 - iMessage on macOS and Telegram private chats on macOS or Linux
 - Telegram voice notes with OpenAI transcription and spoken replies
-- Claude Code, Codex, and Pi backends, selectable by channel or conversation
+- Claude Code, Codex, Pi, and aider backends, selectable by channel or conversation
 - One Git-versioned assistant repository containing `SOUL.md`, `context/`, and
   approved `jobs/`
 - Durable conversation history and backend session recovery

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,8 +43,8 @@ allow_user_ids = [123456789]
 ```
 
 `channel` is the easiest single-provider setup. `agent` is `claude`, `codex`,
-or `pi`. Push does not set sandbox, approval, permission-mode, or tool flags.
-Configure those in the selected agent.
+`pi`, or `aider`. Push does not set sandbox, approval, permission-mode, or tool
+flags. Configure those in the selected agent.
 
 ### Pi setup
 
@@ -62,6 +62,28 @@ stream, and resumes it with `--session`. Clearing a conversation discards that
 mapping, so the next turn creates a fresh Pi session. Push appends `SOUL.md` as
 system instructions, separate from the user message. Pi is not required unless
 the default backend, an enabled route, or `jobs_agent` selects it.
+
+### Aider setup
+
+Install [aider](https://aider.chat/) and configure a model provider (for
+example `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`) for the same user that runs
+Push. Confirm `aider --version` works in the service environment, then select
+it:
+
+```toml
+agent = "aider"
+aider_bin = "aider"
+```
+
+Aider has no server-side session identifier, so Push owns the session id and
+maps it to a per-session chat history file under `sessions_dir`. Each turn runs
+`aider --message <text> --yes-always --no-pretty --no-stream --chat-history-file
+<file>`, adding `--restore-chat-history` to resume an existing conversation.
+Clearing a conversation starts a fresh session; a missing history file on
+resume makes Push rebuild context from its own conversation history. `SOUL.md`
+is attached as a read-only conventions file rather than a system prompt, since
+aider exposes no system-prompt flag. Aider is not required unless the default
+backend, an enabled route, or `jobs_agent` selects it.
 
 ## Channels
 
@@ -162,7 +184,8 @@ Thread keys are:
 ## Agent permissions
 
 Permissions belong to the agent, not the gateway. Push invokes Claude Code,
-Codex, and Pi without overriding their sandbox, approval mode, or tool lists.
+Codex, Pi, and aider without overriding their sandbox, approval mode, or tool
+lists.
 This keeps interactive and gateway behavior aligned. Configure permissions in
 the selected agent and review [permissions and security](security.md).
 
@@ -181,6 +204,7 @@ the selected agent and review [permissions and security](security.md).
 | `codex_bin` | `"codex"` | Codex executable |
 | `codex_model` | unset | Optional Codex model override |
 | `pi_bin` | `"pi"` | Pi coding agent executable |
+| `aider_bin` | `"aider"` | aider.chat executable |
 | `reply_marker` | `"\n\n-- sent by push"` | iMessage loop-prevention marker |
 
 ### Local state

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,8 +119,9 @@ the repository.
     Read the [iMessage guide](channels/imessage.md) for database permissions
     and filtering behavior.
 
-Replace `codex` with `claude` for Claude Code or `pi` for Pi. Pi must already
-have a configured model provider or authenticated account for the service user.
+Replace `codex` with `claude` for Claude Code, `pi` for Pi, or `aider` for
+aider. Pi and aider must already have a configured model provider or
+authenticated account for the service user.
 
 If you replace the config file created by `push init`, keep its
 `assistant_root` setting. Running the same init command again is safe for a

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -33,7 +33,7 @@ Frontmatter fields:
 | `version` | yes | Format version, currently `1` |
 | `timeout` | yes | Positive duration no greater than `jobs_max_timeout` |
 | `workdir` | yes | Existing working directory for the backend |
-| `backend` | no | `claude`, `codex`, or `pi`; defaults to `jobs_agent`, then root `agent` |
+| `backend` | no | `claude`, `codex`, `pi`, or `aider`; defaults to `jobs_agent`, then root `agent` |
 | `triggers` | no | One or more cron trigger tables |
 
 Unknown fields are errors. A job work directory may not overlap the assistant

--- a/docs/jobs/design.md
+++ b/docs/jobs/design.md
@@ -66,7 +66,7 @@ Markdown instruction body. Version 1 supports these fields:
 - `version`: required and equal to `1`.
 - `timeout`: required positive duration, capped by the configured job maximum.
 - `workdir`: required fixed directory, expanded and canonicalised at validation.
-- `backend`: optional `claude`, `codex`, or `pi` override; otherwise use the configured
+- `backend`: optional `claude`, `codex`, `pi`, or `aider` override; otherwise use the configured
   jobs default.
 - `triggers`: optional list of separately identified trigger definitions.
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -134,7 +134,7 @@ user prompt.
 
 | Field | Meaning |
 |---|---|
-| `agent` | `claude`, `codex`, or `pi`. |
+| `agent` | `claude`, `codex`, `pi`, or `aider`. |
 | `routes` | Exact thread to backend overrides. |
 | `channels` | Optional advanced list of reply channels to poll concurrently; otherwise `channel` is used unchanged. |
 | `primary_delivery` | Optional enabled channel and allowlisted target for proactive output. |

--- a/docs/services.md
+++ b/docs/services.md
@@ -26,7 +26,7 @@ Use absolute paths in service files. The service user needs:
 - filesystem access to `assistant_root` as allowed by the selected agent
 - write access to `assistant_root/jobs/` for Push to install approved drafts;
   agent write access can also change installed jobs outside that workflow
-- access to the selected `claude`, `codex`, or `pi` executable on `PATH`
+- access to the selected `claude`, `codex`, `pi`, or `aider` executable on `PATH`
 - backend login, tokens, settings, MCP config, and project credentials
 - for iMessage on macOS, Full Disk Access and `osascript`
 - for Telegram, a token in the private config and network access to

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use crate::config::{AgentBackend, Config};
-use crate::{claude, codex, pi};
+use crate::{aider, claude, codex, pi};
 
 /// One headless agent turn.
 pub struct Request<'a> {
@@ -36,6 +36,7 @@ pub enum Runner {
     Claude(claude::Runner),
     Codex(codex::Runner),
     Pi(pi::Runner),
+    Aider(aider::Runner),
     #[cfg(test)]
     Fake(FakeRunner),
 }
@@ -74,6 +75,10 @@ impl Runner {
             AgentBackend::Pi => Runner::Pi(pi::Runner {
                 bin: cfg.pi_bin.clone(),
             }),
+            AgentBackend::Aider => Runner::Aider(aider::Runner {
+                bin: cfg.aider_bin.clone(),
+                sessions_dir: cfg.sessions_dir.clone(),
+            }),
         }
     }
 
@@ -82,6 +87,7 @@ impl Runner {
             Runner::Claude(_) => AgentBackend::Claude,
             Runner::Codex(_) => AgentBackend::Codex,
             Runner::Pi(_) => AgentBackend::Pi,
+            Runner::Aider(_) => AgentBackend::Aider,
             #[cfg(test)]
             Runner::Fake(r) => r.backend,
         }
@@ -92,6 +98,7 @@ impl Runner {
             Runner::Claude(_) => "Claude",
             Runner::Codex(_) => "Codex",
             Runner::Pi(_) => "Pi",
+            Runner::Aider(_) => "Aider",
             #[cfg(test)]
             Runner::Fake(_) => "Fake",
         }
@@ -102,13 +109,14 @@ impl Runner {
             Runner::Claude(_) => Uuid::new_v4().to_string(),
             Runner::Codex(_) => String::new(),
             Runner::Pi(_) => String::new(),
+            Runner::Aider(_) => Uuid::new_v4().to_string(),
             #[cfg(test)]
             Runner::Fake(_) => String::new(),
         }
     }
 
     pub fn mark_started_before_run(&self) -> bool {
-        matches!(self, Runner::Claude(_))
+        matches!(self, Runner::Claude(_) | Runner::Aider(_))
     }
 
     pub async fn run(&self, req: Request<'_>, timeout: Duration) -> Result<RunOutput, RunError> {
@@ -116,6 +124,7 @@ impl Runner {
             Runner::Claude(r) => r.run(req, timeout).await,
             Runner::Codex(r) => r.run(req, timeout).await,
             Runner::Pi(r) => r.run(req, timeout).await,
+            Runner::Aider(r) => r.run(req, timeout).await,
             #[cfg(test)]
             Runner::Fake(r) => r.run(req, timeout).await,
         }

--- a/src/aider.rs
+++ b/src/aider.rs
@@ -1,0 +1,456 @@
+//! Runs the aider.chat CLI headlessly for a single message.
+//!
+//! Unlike Claude, Codex, and Pi, aider has no server-side session identifier;
+//! conversation context lives in a per-session Markdown chat history file. Push
+//! therefore owns the session id (a UUID generated up front, like Claude) and
+//! maps it to a history file under `sessions_dir`, restoring that file to
+//! resume a conversation. A missing history file on resume is reported as
+//! `SessionMissing` so the gateway can rebuild context from its own history.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tokio::process::Command;
+
+use crate::agent::{Request, RunError, RunOutput};
+
+/// Runner invokes the `aider` binary in non-interactive message mode.
+pub struct Runner {
+    pub bin: String,
+    pub sessions_dir: String,
+}
+
+impl Runner {
+    /// Executes one turn and returns aider's reply text, or a RunError.
+    pub async fn run(&self, req: Request<'_>, timeout: Duration) -> Result<RunOutput, RunError> {
+        let history = self.session_file(req.session_id, "chat.history.md")?;
+        if !req.is_new && !history.exists() {
+            return Err(RunError::SessionMissing(format!(
+                "aider chat history {} is missing; Push will rebuild it from conversation history",
+                history.display()
+            )));
+        }
+        if let Some(parent) = history.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| RunError::Failed(format!("create aider sessions dir: {e}")))?;
+        }
+
+        // Aider has no system-prompt flag, so persistent instructions are
+        // written to a conventions file and attached read-only, matching how
+        // the other backends fold SOUL.md in as separate context.
+        let conventions = if req.instructions.trim().is_empty() {
+            None
+        } else {
+            let path = self.session_file(req.session_id, "conventions.md")?;
+            std::fs::write(&path, req.instructions.trim())
+                .map_err(|e| RunError::Failed(format!("write aider instructions: {e}")))?;
+            Some(path)
+        };
+
+        let attempt = crate::agent::output_with_retry(|| {
+            let mut cmd = self.command(&req, &history, conventions.as_deref());
+            async move { cmd.output().await }
+        });
+        let out = match tokio::time::timeout(timeout, attempt).await {
+            Err(_) => return Err(RunError::Timeout),
+            Ok(Err(e)) => return Err(RunError::Failed(format!("spawn aider: {e}"))),
+            Ok(Ok(o)) => o,
+        };
+
+        if !out.status.success() {
+            return Err(RunError::Failed(exit_diagnostic(out.status.code())));
+        }
+
+        let reply = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if reply.is_empty() {
+            return Err(RunError::Failed(
+                "aider exited without a reply on stdout".to_string(),
+            ));
+        }
+
+        Ok(RunOutput {
+            reply,
+            session_id: req.is_new.then(|| req.session_id.to_string()),
+        })
+    }
+
+    fn command(&self, req: &Request<'_>, history: &Path, conventions: Option<&Path>) -> Command {
+        let mut cmd = Command::new(&self.bin);
+        cmd.arg("--message")
+            .arg(req.prompt)
+            .arg("--yes-always")
+            .arg("--no-pretty")
+            .arg("--no-stream")
+            .arg("--chat-history-file")
+            .arg(history);
+        if !req.is_new {
+            cmd.arg("--restore-chat-history");
+        }
+        if let Some(conventions) = conventions {
+            cmd.arg("--read").arg(conventions);
+        }
+        cmd.current_dir(req.work_dir);
+        cmd.kill_on_drop(true);
+        cmd
+    }
+
+    /// Resolves a Push-owned per-session file, rejecting ids that could escape
+    /// `sessions_dir`.
+    fn session_file(&self, session_id: &str, suffix: &str) -> Result<PathBuf, RunError> {
+        let id = session_id.trim();
+        if id.is_empty()
+            || id == "."
+            || id == ".."
+            || id.contains('/')
+            || id.contains('\\')
+            || id.contains('\0')
+        {
+            return Err(RunError::Failed(format!(
+                "invalid aider session id {session_id:?}"
+            )));
+        }
+        Ok(Path::new(&self.sessions_dir).join(format!("aider-{id}.{suffix}")))
+    }
+}
+
+fn exit_diagnostic(status: Option<i32>) -> String {
+    match status {
+        Some(code) => format!(
+            "aider exited with status {code}; run aider directly as the service user to check model provider and authentication settings"
+        ),
+        None => "aider was terminated; run aider directly as the service user to check model provider and authentication settings"
+            .to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{
+        assert_runner_contract, sh_arg, temp_dir, temp_path, ContractCase, ContractRequest,
+        ContractRunner, FakeCli, RunnerContract,
+    };
+
+    impl ContractRunner for Runner {
+        fn run<'a>(
+            &'a self,
+            req: Request<'a>,
+            timeout: Duration,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<RunOutput, RunError>> + 'a>>
+        {
+            Box::pin(self.run(req, timeout))
+        }
+    }
+
+    #[tokio::test]
+    async fn satisfies_runner_contract() {
+        assert_runner_contract(RunnerContract {
+            name: "Aider",
+            new_session: contract_new_session,
+            resumed_session: contract_resumed_session,
+            failed_run: contract_failed_run,
+            timeout_run: contract_timeout_run,
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn new_session_writes_history_and_instructions_without_restore() {
+        let args_path = temp_path("aider-new-args");
+        let work_dir = temp_dir("aider-new-work");
+        let sessions = temp_dir("aider-new-sessions");
+        let cli = FakeCli::new("aider", &success_script(&args_path, "hello"));
+        let runner = Runner {
+            bin: cli.bin(),
+            sessions_dir: sessions.to_string_lossy().to_string(),
+        };
+
+        let out = runner
+            .run(
+                Request {
+                    session_id: "abc123",
+                    is_new: true,
+                    work_dir: work_dir.to_str().unwrap(),
+                    instructions: "SOUL instructions",
+                    prompt: "hello",
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(out.reply, "hello");
+        assert_eq!(out.session_id.as_deref(), Some("abc123"));
+        let history = sessions.join("aider-abc123.chat.history.md");
+        let conventions = sessions.join("aider-abc123.conventions.md");
+        let args = read_args(&args_path);
+        assert_arg_pair(&args, "--message", "hello");
+        assert_arg_pair(&args, "--chat-history-file", history.to_str().unwrap());
+        assert_arg_pair(&args, "--read", conventions.to_str().unwrap());
+        assert!(args.iter().any(|arg| arg == "--yes-always"));
+        assert!(!args.contains(&"--restore-chat-history".to_string()));
+        assert_eq!(
+            std::fs::read_to_string(&conventions).unwrap(),
+            "SOUL instructions"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_restores_existing_history_and_keeps_the_session_id() {
+        let args_path = temp_path("aider-resume-args");
+        let work_dir = temp_dir("aider-resume-work");
+        let sessions = temp_dir("aider-resume-sessions");
+        let history = sessions.join("aider-existing.chat.history.md");
+        std::fs::write(&history, "#### earlier turn\n").unwrap();
+        let cli = FakeCli::new("aider", &success_script(&args_path, "again"));
+        let runner = Runner {
+            bin: cli.bin(),
+            sessions_dir: sessions.to_string_lossy().to_string(),
+        };
+
+        let out = runner
+            .run(
+                Request {
+                    session_id: "existing",
+                    is_new: false,
+                    work_dir: work_dir.to_str().unwrap(),
+                    instructions: "",
+                    prompt: "continue",
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(out.reply, "again");
+        assert_eq!(out.session_id, None);
+        let args = read_args(&args_path);
+        assert_arg_pair(&args, "--chat-history-file", history.to_str().unwrap());
+        assert!(args.iter().any(|arg| arg == "--restore-chat-history"));
+        assert!(!args.contains(&"--read".to_string()));
+    }
+
+    #[tokio::test]
+    async fn missing_history_on_resume_is_typed_for_rehydration() {
+        let work_dir = temp_dir("aider-missing-work");
+        let sessions = temp_dir("aider-missing-sessions");
+        let cli = FakeCli::new("aider", &success_script(&temp_path("aider-unused"), "x"));
+        let runner = Runner {
+            bin: cli.bin(),
+            sessions_dir: sessions.to_string_lossy().to_string(),
+        };
+
+        let error = runner
+            .run(
+                Request {
+                    session_id: "gone",
+                    is_new: false,
+                    work_dir: work_dir.to_str().unwrap(),
+                    instructions: "",
+                    prompt: "continue",
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RunError::SessionMissing(_)));
+    }
+
+    #[tokio::test]
+    async fn rejects_session_ids_that_escape_the_sessions_dir() {
+        let work_dir = temp_dir("aider-escape-work");
+        let sessions = temp_dir("aider-escape-sessions");
+        let cli = FakeCli::new("aider", &success_script(&temp_path("aider-unused"), "x"));
+        let runner = Runner {
+            bin: cli.bin(),
+            sessions_dir: sessions.to_string_lossy().to_string(),
+        };
+
+        for id in ["../escape", "a/b", ""] {
+            let error = runner
+                .run(
+                    Request {
+                        session_id: id,
+                        is_new: true,
+                        work_dir: work_dir.to_str().unwrap(),
+                        instructions: "",
+                        prompt: "hello",
+                    },
+                    Duration::from_secs(5),
+                )
+                .await
+                .unwrap_err();
+            assert!(matches!(error, RunError::Failed(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn reports_non_zero_exit_without_forwarding_stderr_secrets() {
+        let work_dir = temp_dir("aider-failed-work");
+        let sessions = temp_dir("aider-failed-sessions");
+        let secret = "provider-token-abcdef";
+        let cli = FakeCli::new(
+            "aider",
+            &format!("#!/bin/sh\nprintf '%s\\n' 'boom {secret}' >&2\nexit 2\n"),
+        );
+        let runner = Runner {
+            bin: cli.bin(),
+            sessions_dir: sessions.to_string_lossy().to_string(),
+        };
+
+        let error = runner
+            .run(
+                Request {
+                    session_id: "abc123",
+                    is_new: true,
+                    work_dir: work_dir.to_str().unwrap(),
+                    instructions: "",
+                    prompt: "hello",
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap_err();
+
+        let message = failed_message(error);
+        assert!(message.contains("status 2"));
+        assert!(!message.contains(secret));
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_reply() {
+        let work_dir = temp_dir("aider-empty-work");
+        let sessions = temp_dir("aider-empty-sessions");
+        let cli = FakeCli::new("aider", "#!/bin/sh\nprintf '   \\n'\n");
+        let runner = Runner {
+            bin: cli.bin(),
+            sessions_dir: sessions.to_string_lossy().to_string(),
+        };
+
+        let error = runner
+            .run(
+                Request {
+                    session_id: "abc123",
+                    is_new: true,
+                    work_dir: work_dir.to_str().unwrap(),
+                    instructions: "",
+                    prompt: "hello",
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(failed_message(error).contains("without a reply"));
+    }
+
+    fn success_script(args_path: &std::path::Path, reply: &str) -> String {
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nprintf '%s\\n' '{reply}'\n",
+            sh_arg(args_path)
+        )
+    }
+
+    fn read_args(path: &std::path::Path) -> Vec<String> {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn assert_arg_pair(args: &[String], flag: &str, value: &str) {
+        let index = args
+            .iter()
+            .position(|arg| arg == flag)
+            .unwrap_or_else(|| panic!("missing flag {flag} in {args:?}"));
+        assert_eq!(args.get(index + 1).map(String::as_str), Some(value));
+    }
+
+    fn failed_message(error: RunError) -> String {
+        match error {
+            RunError::Failed(message) => message,
+            other => panic!("expected failed error, got {other:?}"),
+        }
+    }
+
+    fn contract_new_session() -> ContractCase {
+        let sessions = temp_dir("aider-contract-new-sessions");
+        let work_dir = temp_dir("aider-contract-new-work");
+        let cli = FakeCli::new("aider", "#!/bin/sh\nprintf 'new reply\\n'\n");
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(Runner {
+                bin,
+                sessions_dir: sessions.to_string_lossy().to_string(),
+            }),
+            request: contract_request(work_dir, true),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn contract_resumed_session() -> ContractCase {
+        let sessions = temp_dir("aider-contract-resume-sessions");
+        std::fs::write(
+            sessions.join("aider-contract-session.chat.history.md"),
+            "#### earlier\n",
+        )
+        .unwrap();
+        let work_dir = temp_dir("aider-contract-resume-work");
+        let cli = FakeCli::new("aider", "#!/bin/sh\nprintf 'resumed reply\\n'\n");
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(Runner {
+                bin,
+                sessions_dir: sessions.to_string_lossy().to_string(),
+            }),
+            request: contract_request(work_dir, false),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn contract_failed_run() -> ContractCase {
+        let sessions = temp_dir("aider-contract-fail-sessions");
+        let work_dir = temp_dir("aider-contract-fail-work");
+        let cli = FakeCli::new("aider", "#!/bin/sh\nprintf 'boom\\n' >&2\nexit 1\n");
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(Runner {
+                bin,
+                sessions_dir: sessions.to_string_lossy().to_string(),
+            }),
+            request: contract_request(work_dir, true),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn contract_timeout_run() -> ContractCase {
+        let sessions = temp_dir("aider-contract-timeout-sessions");
+        let work_dir = temp_dir("aider-contract-timeout-work");
+        let cli = FakeCli::new("aider", "#!/bin/sh\nsleep 2\n");
+        let bin = cli.bin();
+        ContractCase {
+            fake_cli: cli,
+            runner: Box::new(Runner {
+                bin,
+                sessions_dir: sessions.to_string_lossy().to_string(),
+            }),
+            request: contract_request(work_dir, true),
+            timeout: Duration::from_millis(10),
+        }
+    }
+
+    fn contract_request(work_dir: std::path::PathBuf, is_new: bool) -> ContractRequest {
+        ContractRequest {
+            session_id: "contract-session".to_string(),
+            is_new,
+            work_dir,
+            instructions: String::new(),
+            prompt: "hello".to_string(),
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,8 @@ pub struct Config {
     pub codex_model: Option<String>,
     #[serde(default = "default_pi_bin")]
     pub pi_bin: String,
+    #[serde(default = "default_aider_bin")]
+    pub aider_bin: String,
     #[serde(default = "default_sessions_dir")]
     pub sessions_dir: String,
     #[serde(default = "default_state_path")]
@@ -400,6 +402,7 @@ impl Config {
             AgentBackend::Claude => self.claude_bin.as_str(),
             AgentBackend::Codex => self.codex_bin.as_str(),
             AgentBackend::Pi => self.pi_bin.as_str(),
+            AgentBackend::Aider => self.aider_bin.as_str(),
         }
     }
 
@@ -754,6 +757,7 @@ pub enum AgentBackend {
     Claude,
     Codex,
     Pi,
+    Aider,
 }
 
 impl AgentBackend {
@@ -762,7 +766,10 @@ impl AgentBackend {
             "claude" => Ok(AgentBackend::Claude),
             "codex" => Ok(AgentBackend::Codex),
             "pi" => Ok(AgentBackend::Pi),
-            other => bail!("invalid agent {other:?}; expected \"claude\", \"codex\", or \"pi\""),
+            "aider" => Ok(AgentBackend::Aider),
+            other => bail!(
+                "invalid agent {other:?}; expected \"claude\", \"codex\", \"pi\", or \"aider\""
+            ),
         }
     }
 
@@ -771,6 +778,7 @@ impl AgentBackend {
             AgentBackend::Claude => "claude",
             AgentBackend::Codex => "codex",
             AgentBackend::Pi => "pi",
+            AgentBackend::Aider => "aider",
         }
     }
 }
@@ -801,6 +809,9 @@ fn default_codex_bin() -> String {
 }
 fn default_pi_bin() -> String {
     "pi".to_string()
+}
+fn default_aider_bin() -> String {
+    "aider".to_string()
 }
 fn default_jobs_dir() -> String {
     "~/.push/jobs".to_string()
@@ -871,6 +882,7 @@ mod tests {
             codex_bin: "codex".to_string(),
             codex_model: None,
             pi_bin: "pi".to_string(),
+            aider_bin: "aider".to_string(),
             sessions_dir: root.join("sessions").to_string_lossy().to_string(),
             state_path: root.join("state.json").to_string_lossy().to_string(),
             audit_log_path: root.join("audit.jsonl").to_string_lossy().to_string(),
@@ -904,6 +916,38 @@ mod tests {
             AgentBackend::Pi
         );
         assert_eq!(cfg.required_agent_bins().unwrap(), vec!["pi"]);
+    }
+
+    #[test]
+    fn aider_parses_and_is_selectable_for_default_routes_and_jobs() {
+        let mut cfg = config();
+        cfg.agent = "aider".to_string();
+        cfg.jobs_agent = Some("aider".to_string());
+        cfg.routes = vec![RouteRule {
+            thread: Some("imessage:chat:aider".to_string()),
+            channel: Some("imessage".to_string()),
+            agent: "aider".to_string(),
+        }];
+
+        assert_eq!(AgentBackend::parse("aider").unwrap(), AgentBackend::Aider);
+        assert_eq!(AgentBackend::Aider.as_str(), "aider");
+        assert_eq!(cfg.agent_backend().unwrap(), AgentBackend::Aider);
+        assert_eq!(cfg.jobs_backend().unwrap(), AgentBackend::Aider);
+        assert_eq!(
+            cfg.route_for_message("imessage", "imessage:chat:aider")
+                .unwrap()
+                .backend,
+            AgentBackend::Aider
+        );
+        assert_eq!(cfg.required_agent_bins().unwrap(), vec!["aider"]);
+    }
+
+    #[test]
+    fn aider_binary_defaults_to_aider_when_loading_toml() {
+        let cfg: Config = toml::from_str("agent = 'aider'").unwrap();
+
+        assert_eq!(cfg.agent_backend().unwrap(), AgentBackend::Aider);
+        assert_eq!(cfg.aider_bin, "aider");
     }
 
     #[test]

--- a/src/drafts.rs
+++ b/src/drafts.rs
@@ -447,6 +447,7 @@ mod tests {
                 codex_bin: "codex".to_string(),
                 codex_model: None,
                 pi_bin: "pi".to_string(),
+                aider_bin: "aider".to_string(),
                 sessions_dir: root.join("sessions").to_string_lossy().to_string(),
                 state_path: root.join("state.json").to_string_lossy().to_string(),
                 audit_log_path: root.join("audit.jsonl").to_string_lossy().to_string(),

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -826,10 +826,15 @@ fn complete_row(store: &Arc<Mutex<Store>>, ack: &Arc<Mutex<AckState>>, channel: 
 }
 
 fn runners(cfg: &Config) -> HashMap<AgentBackend, Runner> {
-    [AgentBackend::Claude, AgentBackend::Codex, AgentBackend::Pi]
-        .into_iter()
-        .map(|backend| (backend, Runner::for_backend(backend, cfg)))
-        .collect()
+    [
+        AgentBackend::Claude,
+        AgentBackend::Codex,
+        AgentBackend::Pi,
+        AgentBackend::Aider,
+    ]
+    .into_iter()
+    .map(|backend| (backend, Runner::for_backend(backend, cfg)))
+    .collect()
 }
 
 impl AckState {

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -2235,6 +2235,7 @@ fn test_config(state_path: &str, sessions_dir: &str, assistant_dir: &str) -> Con
         codex_bin: "codex".to_string(),
         codex_model: None,
         pi_bin: "pi".to_string(),
+        aider_bin: "aider".to_string(),
         sessions_dir: sessions_dir.to_string(),
         state_path: state_path.to_string(),
         audit_log_path: format!("{state_path}.audit.jsonl"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 //! coding-agent backend, and texts the reply back.
 
 mod agent;
+mod aider;
 mod approval;
 mod assistant;
 mod audit;

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -69,6 +69,7 @@ pub fn test_config() -> crate::config::Config {
         codex_bin: "/fake/codex".to_string(),
         codex_model: None,
         pi_bin: "/fake/pi".to_string(),
+        aider_bin: "/fake/aider".to_string(),
         sessions_dir: "/fake/sessions".to_string(),
         state_path: "/fake/state.json".to_string(),
         audit_log_path: "/fake/audit.jsonl".to_string(),


### PR DESCRIPTION
What shipped:

New src/aider.rs runner: message-mode aider with per-session --chat-history-file, --restore-chat-history on resume, SessionMissing on missing history, SOUL.md attached read-only via --read, stderr never leaked into errors, and session-id path-escape guards.
AgentBackend::Aider wired through config.rs, agent.rs, gateway/mod.rs, main.rs, test helpers, and docs.
All checks green locally: fmt, clippy -D warnings, build, 254 unit + integration tests, mkdocs build --strict, tests/install.sh.

Two notes:

1. Building needs Rust with edition2024 support (I used stable 1.97; VM shipped 1.83); upstream CI uses latest stable so this only affects local builds. 
2. Live end-to-end testing would need a real aider install + model-provider API key.
