### PR TITLE
feat(cli): add gateway restart command

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,6 +9,7 @@ The default is `~/.push/config.toml`.
 | `push init [path]` | Create and Git-initialize the one assistant repository; defaults to `./assistant` |
 | `push` | Start the configured channel gateway and scheduler |
 | `push doctor` | Validate config, paths, channel requirements, and required backend binaries |
+| `push restart` | Restart the managed gateway to load updated config |
 | `push job validate` | Validate every installed job; exits non-zero if any are invalid |
 | `push job list` | List valid and invalid jobs with backend or error |
 | `push job show <name>` | Print the parsed installed job |
@@ -21,6 +22,7 @@ Examples:
 push init ~/Code/assistant
 push doctor
 push
+push restart
 push job validate
 push job run repo-review
 push job runs repo-review
@@ -28,6 +30,13 @@ push job runs repo-review
 
 Unknown commands and missing values fail with the accepted command forms. The
 CLI does not currently provide shell completion or a generated `--help` page.
+
+`push restart` targets the service definitions documented by Push:
+`com.owainlewis.push` under launchd on macOS and the `push.service` user unit
+under systemd on Linux. The service definition controls its config path,
+environment, and executable; `--config` does not override the service definition
+for this command. Run `push doctor` separately when you want to validate those
+settings from the current shell.
 
 `push init` accepts an empty target, the selected config by itself, or a
 complete existing assistant layout. It refuses unrelated and partial non-empty

--- a/docs/services.md
+++ b/docs/services.md
@@ -104,6 +104,12 @@ launchctl print gui/$(id -u)/com.owainlewis.push
 tail -f ~/Library/Logs/push.err.log ~/Library/Logs/push.out.log
 ```
 
+After editing `~/.push/config.toml`, restart the gateway with:
+
+```sh
+push restart
+```
+
 After changing the plist:
 
 ```sh
@@ -156,6 +162,12 @@ systemctl --user daemon-reload
 systemctl --user enable --now push.service
 systemctl --user status push.service
 journalctl --user -u push.service -f
+```
+
+After editing `~/.push/config.toml`, restart the gateway with:
+
+```sh
+push restart
 ```
 
 For voice support, prefer `voice.openai_api_key` in `~/.push/config.toml`. As an

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -60,21 +60,16 @@ voice transcription and spoken replies:
 openai_api_key = "your-api-key"
 ```
 
-Validate the config, then restart the one existing Push process:
+Restart the managed gateway to load the updated config:
 
 ```sh
-push doctor
+push restart
 ```
 
-For a foreground process, stop it and run `push` again. For launchd, use:
-
-```sh
-launchctl kickstart -k gui/$(id -u)/com.owainlewis.push
-```
-
-See [Running Push as a Service](services.md) for the full launchd and systemd
-restart commands. Do not start a foreground gateway while the service is
-running because Telegram permits only one poller for a bot token.
+For a foreground process, stop it, run `push doctor`, and run `push` again.
+See [Running Push as a Service](services.md) for launchd and systemd setup. Do
+not start a foreground gateway while the service is running because Telegram
+permits only one poller for a bot token.
 
 `OPENAI_API_KEY` remains available for CI and service secret injection. A
 non-empty environment value overrides the configured key.

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod imessage;
 mod jobs;
 mod pi;
 mod rehydration;
+mod restart;
 mod soul;
 mod store;
 mod telegram;
@@ -63,6 +64,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Command::Doctor => doctor::doctor(&args.config_path),
+        Command::Restart => restart::gateway(),
         Command::Job(command) => run_job_command(&args.config_path, command).await,
         Command::Run => {
             let cfg = load_run_config(&args.config_path)?;
@@ -122,6 +124,7 @@ enum Command {
     Run,
     Init(String),
     Doctor,
+    Restart,
     Job(JobCommand),
 }
 
@@ -159,6 +162,7 @@ impl Args {
             ["init"] => Command::Init("./assistant".to_string()),
             ["init", path] => Command::Init((*path).to_string()),
             ["doctor"] => Command::Doctor,
+            ["restart"] => Command::Restart,
             ["job", "validate"] => Command::Job(JobCommand::Validate),
             ["job", "list"] => Command::Job(JobCommand::List),
             ["job", "show", name] => Command::Job(JobCommand::Show((*name).to_string())),
@@ -166,7 +170,7 @@ impl Args {
             ["job", "runs"] => Command::Job(JobCommand::Runs(None)),
             ["job", "runs", name] => Command::Job(JobCommand::Runs(Some((*name).to_string()))),
             _ => bail!(
-                "unknown command; expected init [path], doctor, job validate, job list, job show <name>, job run <name>, job runs [<name>], or --config <path>"
+                "unknown command; expected init [path], doctor, restart, job validate, job list, job show <name>, job run <name>, job runs [<name>], or --config <path>"
             ),
         };
         Ok(Self {
@@ -301,6 +305,24 @@ mod tests {
             args,
             Args {
                 command: Command::Doctor,
+                config_path: "custom.toml".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_restart_with_config_path() {
+        let args = Args::parse(vec![
+            "--config".to_string(),
+            "custom.toml".to_string(),
+            "restart".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            args,
+            Args {
+                command: Command::Restart,
                 config_path: "custom.toml".to_string(),
             }
         );

--- a/src/restart.rs
+++ b/src/restart.rs
@@ -1,0 +1,194 @@
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+
+const LAUNCHD_LABEL: &str = "com.owainlewis.push";
+const SYSTEMD_UNIT: &str = "push.service";
+
+pub fn gateway() -> Result<()> {
+    let command = platform_command()?;
+    let message = execute(&command, |command| {
+        let mut process = Command::new(command.program);
+        process.args(&command.args);
+        let status = process.status()?;
+        Ok(ProcessStatus {
+            success: status.success(),
+            description: status.to_string(),
+        })
+    })?;
+    println!("{message}");
+    Ok(())
+}
+
+struct ProcessStatus {
+    success: bool,
+    description: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct PlatformCommand {
+    program: &'static str,
+    args: Vec<String>,
+}
+
+impl PlatformCommand {
+    fn display(&self) -> String {
+        std::iter::once(self.program.to_string())
+            .chain(self.args.iter().cloned())
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+fn execute(
+    command: &PlatformCommand,
+    runner: impl FnOnce(&PlatformCommand) -> std::io::Result<ProcessStatus>,
+) -> Result<&'static str> {
+    let status = runner(command).with_context(|| format!("run {}", command.display()))?;
+    if !status.success {
+        bail!(
+            "gateway restart failed: {} exited with {}",
+            command.display(),
+            status.description
+        );
+    }
+    Ok("Restarted the Push gateway.")
+}
+
+fn platform_command() -> Result<PlatformCommand> {
+    command_for(std::env::consts::OS, effective_user_id()?.as_deref())
+}
+
+fn command_for(os: &str, user_id: Option<&str>) -> Result<PlatformCommand> {
+    match os {
+        "macos" => {
+            let user_id = user_id.context("determine current user id for launchd")?;
+            Ok(PlatformCommand {
+                program: "launchctl",
+                args: vec![
+                    "kickstart".to_string(),
+                    "-k".to_string(),
+                    format!("gui/{user_id}/{LAUNCHD_LABEL}"),
+                ],
+            })
+        }
+        "linux" => Ok(PlatformCommand {
+            program: "systemctl",
+            args: vec![
+                "--user".to_string(),
+                "restart".to_string(),
+                SYSTEMD_UNIT.to_string(),
+            ],
+        }),
+        _ => bail!("gateway restart is supported only on macOS and Linux"),
+    }
+}
+
+fn effective_user_id() -> Result<Option<String>> {
+    if std::env::consts::OS != "macos" {
+        return Ok(None);
+    }
+    let output = Command::new("id").arg("-u").output().context("run id -u")?;
+    if !output.status.success() {
+        bail!("id -u exited with {}", output.status);
+    }
+    let user_id = String::from_utf8(output.stdout).context("read user id")?;
+    let user_id = user_id.trim();
+    if user_id.is_empty() || !user_id.bytes().all(|byte| byte.is_ascii_digit()) {
+        bail!("id -u returned an invalid user id");
+    }
+    Ok(Some(user_id.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn macos_restarts_the_documented_launchd_service() {
+        assert_eq!(
+            command_for("macos", Some("501")).unwrap(),
+            PlatformCommand {
+                program: "launchctl",
+                args: vec![
+                    "kickstart".to_string(),
+                    "-k".to_string(),
+                    "gui/501/com.owainlewis.push".to_string(),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn linux_restarts_the_documented_user_service() {
+        assert_eq!(
+            command_for("linux", None).unwrap(),
+            PlatformCommand {
+                program: "systemctl",
+                args: vec![
+                    "--user".to_string(),
+                    "restart".to_string(),
+                    "push.service".to_string(),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn unsupported_platform_reports_the_supported_hosts() {
+        let error = command_for("windows", None).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("supported only on macOS and Linux"));
+    }
+
+    #[test]
+    fn successful_restart_reports_completion() {
+        let command = command_for("linux", None).unwrap();
+
+        let message = execute(&command, |_| {
+            Ok(ProcessStatus {
+                success: true,
+                description: "exit status: 0".to_string(),
+            })
+        })
+        .unwrap();
+
+        assert_eq!(message, "Restarted the Push gateway.");
+    }
+
+    #[test]
+    fn failed_restart_reports_the_command_and_status() {
+        let command = command_for("linux", None).unwrap();
+
+        let error = execute(&command, |_| {
+            Ok(ProcessStatus {
+                success: false,
+                description: "exit status: 5".to_string(),
+            })
+        })
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("systemctl --user restart push.service exited with exit status: 5"));
+    }
+
+    #[test]
+    fn restart_spawn_failure_reports_the_command() {
+        let command = command_for("linux", None).unwrap();
+
+        let error = execute(&command, |_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "missing service manager",
+            ))
+        })
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("run systemctl --user restart push.service"));
+    }
+}

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -163,6 +163,63 @@ fn job_without_default_config_reports_init_guidance() {
     assert_missing_default_config_guidance(&["job", "list"]);
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[test]
+fn restart_invokes_the_platform_service_manager() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = temp_dir("restart-service-manager");
+    let bin_dir = root.join("bin");
+    let args_path = root.join("args");
+    std::fs::create_dir(&bin_dir).unwrap();
+    let manager = if cfg!(target_os = "macos") {
+        "launchctl"
+    } else {
+        "systemctl"
+    };
+    let manager_path = bin_dir.join(manager);
+    std::fs::write(
+        &manager_path,
+        format!("#!/bin/sh\nprintf '%s\\n' \"$@\" > {:?}\n", args_path),
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&manager_path).unwrap().permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&manager_path, permissions).unwrap();
+    let path = std::env::join_paths(
+        std::iter::once(bin_dir.clone()).chain(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        )),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_push"))
+        .arg("restart")
+        .env("PATH", path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "Restarted the Push gateway."
+    );
+    let args = std::fs::read_to_string(args_path).unwrap();
+    if cfg!(target_os = "macos") {
+        let lines = args.lines().collect::<Vec<_>>();
+        assert_eq!(&lines[..2], &["kickstart", "-k"]);
+        assert!(lines[2].starts_with("gui/"));
+        assert!(lines[2].ends_with("/com.owainlewis.push"));
+    } else {
+        assert_eq!(args, "--user\nrestart\npush.service\n");
+    }
+    let _ = std::fs::remove_dir_all(root);
+}
+
 fn assert_missing_default_config_guidance(args: &[&str]) {
     let root = temp_dir("missing-default-config-command");
     let home = root.join("home");

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -180,7 +180,7 @@ fn restart_invokes_the_platform_service_manager() {
     let manager_path = bin_dir.join(manager);
     std::fs::write(
         &manager_path,
-        format!("#!/bin/sh\nprintf '%s\\n' \"$@\" > {:?}\n", args_path),
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$PUSH_RESTART_ARGS_PATH\"\n",
     )
     .unwrap();
     let mut permissions = std::fs::metadata(&manager_path).unwrap().permissions();
@@ -196,6 +196,7 @@ fn restart_invokes_the_platform_service_manager() {
     let output = Command::new(env!("CARGO_BIN_EXE_push"))
         .arg("restart")
         .env("PATH", path)
+        .env("PUSH_RESTART_ARGS_PATH", &args_path)
         .output()
         .unwrap();
 


### PR DESCRIPTION
## Summary

- add `push restart` for managed gateway services
- restart `com.owainlewis.push` with launchd on macOS and `push.service` with user systemd on Linux
- document config reload behavior and cover service-manager execution and failures

## Why

Config changes currently require users to remember the platform-specific service-manager command. This adds one Push command that restarts the documented managed gateway.

## Test plan

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (264 tests passed)
- `uv run --with-requirements requirements-docs.txt mkdocs build --strict`
- `git diff --check`
- independent subagent review, with all findings addressed and no remaining findings

## Risks

The command targets the documented fixed launchd label and systemd user unit. Custom service names are not selected by `--config`.

## Related issue

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `push restart` command to restart the managed Push gateway on macOS and Linux.
  * Added clear success and error feedback when restarting the gateway.

* **Documentation**
  * Updated CLI, service, and Telegram setup guides with restart instructions.
  * Clarified configuration validation and foreground operation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->