### PR TITLE
feat(voice): make speech voice configurable

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -20,3 +20,5 @@ allow_user_ids = [123456789]
 [voice]
 # Optional. Uncomment to enable voice transcription and spoken replies.
 # openai_api_key = "replace-with-your-openai-api-key"
+# Optional. Spoken replies default to the Cedar voice.
+# name = "cedar"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -235,7 +235,8 @@ so slow audio cannot pause polling or work in another conversation.
 
 The first provider uses `voice.openai_api_key`, with `OPENAI_API_KEY` as a
 higher-priority environment override, for both `gpt-4o-transcribe` and
-`gpt-4o-mini-tts`. The first channel implementation is Telegram. A future
+`gpt-4o-mini-tts`. Speech uses the configured `voice.name`, which defaults to
+`cedar`. The first channel implementation is Telegram. A future
 channel needs only voice download and upload support. It does not need to change
 gateway routing, agent requests, or the OpenAI client.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,12 +96,15 @@ Telegram voice notes are optional. Configure the shared voice provider with:
 ```toml
 [voice]
 openai_api_key = "your-api-key"
+name = "cedar"
 ```
 
 `OPENAI_API_KEY` remains available as a higher-priority override for CI and
-service secret injection. Without either value, text remains fully available
-and voice notes get a helpful fallback. See
-[Voice Messages](telegram.md#voice-messages).
+service secret injection. `voice.name` is optional and defaults to `cedar`.
+Supported names are `alloy`, `ash`, `ballad`, `coral`, `echo`, `fable`, `nova`,
+`onyx`, `sage`, `shimmer`, `verse`, `marin`, and `cedar`. Without either API
+key value, text remains fully available and voice notes get a helpful fallback.
+See [Voice Messages](telegram.md#voice-messages).
 
 ### Run both providers
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -58,7 +58,12 @@ voice transcription and spoken replies:
 ```toml
 [voice]
 openai_api_key = "your-api-key"
+name = "cedar"
 ```
+
+`voice.name` is optional and defaults to `cedar`. Supported names are `alloy`,
+`ash`, `ballad`, `coral`, `echo`, `fable`, `nova`, `onyx`, `sage`, `shimmer`,
+`verse`, `marin`, and `cedar`.
 
 Restart the managed gateway to load the updated config:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,11 @@ use serde::Deserialize;
 use crate::util::expand_home;
 
 pub const TELEGRAM_BOT_TOKEN_ENV: &str = "TELEGRAM_BOT_TOKEN";
+pub const DEFAULT_VOICE_NAME: &str = "cedar";
+const SUPPORTED_VOICE_NAMES: &[&str] = &[
+    "alloy", "ash", "ballad", "coral", "echo", "fable", "nova", "onyx", "sage", "shimmer", "verse",
+    "marin", "cedar",
+];
 
 #[cfg(test)]
 #[derive(Debug, Clone)]
@@ -56,6 +61,8 @@ pub struct Config {
     pub telegram_allow_chat_ids: Vec<i64>,
     #[serde(default)]
     pub voice_openai_api_key: Option<String>,
+    #[serde(default = "default_voice_name")]
+    pub voice_name: String,
     #[serde(default = "default_agent")]
     pub agent: String,
     #[serde(default)]
@@ -204,7 +211,14 @@ impl Config {
                 ("allow_chat_ids", "telegram_allow_chat_ids"),
             ],
         )?;
-        flatten_provider_section(root, "voice", &[("openai_api_key", "voice_openai_api_key")])?;
+        flatten_provider_section(
+            root,
+            "voice",
+            &[
+                ("openai_api_key", "voice_openai_api_key"),
+                ("name", "voice_name"),
+            ],
+        )?;
         let mut c: Config = value.try_into().context("parse TOML config")?;
         let config_path = std::fs::canonicalize(&expanded_path)
             .with_context(|| format!("resolve config {expanded_path}"))?;
@@ -447,6 +461,13 @@ impl Config {
             .is_some_and(|value| value.trim().is_empty())
         {
             bail!("voice.openai_api_key cannot be empty");
+        }
+        if !SUPPORTED_VOICE_NAMES.contains(&self.voice_name.as_str()) {
+            bail!(
+                "invalid voice.name {:?}; expected one of: {}",
+                self.voice_name,
+                SUPPORTED_VOICE_NAMES.join(", ")
+            );
         }
         for channel in self.enabled_channel_kinds()? {
             match channel {
@@ -796,6 +817,9 @@ fn default_run_timeout() -> String {
 fn default_agent() -> String {
     "claude".to_string()
 }
+fn default_voice_name() -> String {
+    DEFAULT_VOICE_NAME.to_string()
+}
 fn default_jobs_dir() -> String {
     "~/.push/jobs".to_string()
 }
@@ -844,6 +868,7 @@ mod tests {
             telegram_allow_user_ids: Vec::new(),
             telegram_allow_chat_ids: Vec::new(),
             voice_openai_api_key: None,
+            voice_name: DEFAULT_VOICE_NAME.to_string(),
             agent: "codex".to_string(),
             routes: Vec::new(),
             assistant_root: root.to_string_lossy().to_string(),

--- a/src/drafts.rs
+++ b/src/drafts.rs
@@ -433,6 +433,7 @@ mod tests {
                 telegram_allow_user_ids: vec![7],
                 telegram_allow_chat_ids: Vec::new(),
                 voice_openai_api_key: None,
+                voice_name: crate::config::DEFAULT_VOICE_NAME.to_string(),
                 agent: "codex".to_string(),
                 routes: Vec::new(),
                 assistant_root: root.to_string_lossy().to_string(),

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -2221,6 +2221,7 @@ fn test_config(state_path: &str, _sessions_dir: &str, assistant_dir: &str) -> Co
         telegram_allow_user_ids: Vec::new(),
         telegram_allow_chat_ids: Vec::new(),
         voice_openai_api_key: None,
+        voice_name: crate::config::DEFAULT_VOICE_NAME.to_string(),
         agent: "codex".to_string(),
         routes: Vec::new(),
         assistant_root: assistant_dir.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -746,6 +746,7 @@ allow_chat_ids = [9]
 
 [voice]
 openai_api_key = "config-openai-key"
+name = "onyx"
 "#,
         )
         .unwrap();
@@ -760,7 +761,29 @@ openai_api_key = "config-openai-key"
             cfg.voice_openai_api_key.as_deref(),
             Some("config-openai-key")
         );
+        assert_eq!(cfg.voice_name, "onyx");
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn voice_config_defaults_to_cedar_and_rejects_unknown_names() {
+        let default_path = temp_path("default-voice-config");
+        std::fs::write(&default_path, "self_handles = ['me@icloud.com']\n").unwrap();
+
+        let cfg = Config::load(default_path.to_str().unwrap()).unwrap();
+        assert_eq!(cfg.voice_name, "cedar");
+
+        let invalid_path = temp_path("invalid-voice-config");
+        std::fs::write(
+            &invalid_path,
+            "self_handles = ['me@icloud.com']\n[voice]\nname = 'unknown'\n",
+        )
+        .unwrap();
+
+        let error = Config::load(invalid_path.to_str().unwrap()).unwrap_err();
+        assert!(error.to_string().contains("invalid voice.name \"unknown\""));
+        let _ = std::fs::remove_file(default_path);
+        let _ = std::fs::remove_file(invalid_path);
     }
 
     #[test]

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -55,6 +55,7 @@ pub fn test_config() -> crate::config::Config {
         telegram_allow_user_ids: Vec::new(),
         telegram_allow_chat_ids: Vec::new(),
         voice_openai_api_key: None,
+        voice_name: crate::config::DEFAULT_VOICE_NAME.to_string(),
         agent: "codex".to_string(),
         routes: Vec::new(),
         assistant_root: "/fake/assistant".to_string(),

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -16,7 +16,6 @@ use crate::config::Config;
 pub const OPENAI_API_KEY_ENV: &str = "OPENAI_API_KEY";
 pub const TRANSCRIPTION_MODEL: &str = "gpt-4o-transcribe";
 pub const SPEECH_MODEL: &str = "gpt-4o-mini-tts";
-pub const SPEECH_VOICE: &str = "cedar";
 pub const MAX_AUDIO_BYTES: usize = 20 * 1024 * 1024;
 const MAX_SPEECH_CHARS: usize = 4096;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(90);
@@ -52,13 +51,18 @@ impl Voice {
         Self::from_sources(
             environment.as_deref(),
             config.voice_openai_api_key.as_deref(),
+            &config.voice_name,
         )
     }
 
-    fn from_sources(environment: Option<&str>, configured: Option<&str>) -> Option<Self> {
+    fn from_sources(
+        environment: Option<&str>,
+        configured: Option<&str>,
+        voice_name: &str,
+    ) -> Option<Self> {
         let (key, _) = resolve_openai_api_key(environment, configured)?;
         Some(Self {
-            provider: Arc::new(OpenAiVoice::new(key.to_string())),
+            provider: Arc::new(OpenAiVoice::new(key.to_string(), voice_name.to_string())),
         })
     }
 
@@ -127,23 +131,26 @@ fn resolve_openai_api_key<'a>(
 
 struct OpenAiVoice {
     api_key: String,
+    voice_name: String,
     client: reqwest::Client,
     base_url: String,
 }
 
 impl OpenAiVoice {
-    fn new(api_key: String) -> Self {
+    fn new(api_key: String, voice_name: String) -> Self {
         Self {
             api_key,
+            voice_name,
             client: reqwest::Client::new(),
             base_url: "https://api.openai.com/v1".to_string(),
         }
     }
 
     #[cfg(test)]
-    fn with_base_url(api_key: String, base_url: String) -> Self {
+    fn with_base_url(api_key: String, base_url: String, voice_name: String) -> Self {
         Self {
             api_key,
+            voice_name,
             client: reqwest::Client::new(),
             base_url,
         }
@@ -191,7 +198,7 @@ impl VoiceProvider for OpenAiVoice {
                 .timeout(REQUEST_TIMEOUT)
                 .json(&json!({
                     "model": SPEECH_MODEL,
-                    "voice": SPEECH_VOICE,
+                    "voice": self.voice_name,
                     "input": text,
                     "instructions": "Speak in a natural, clear, concise male voice.",
                     "response_format": "opus"
@@ -260,8 +267,8 @@ mod tests {
             Some(("config-key", VoiceCredentialSource::Config))
         );
         assert_eq!(resolve_openai_api_key(Some(""), Some(" ")), None);
-        assert!(Voice::from_sources(None, Some("config-key")).is_some());
-        assert!(Voice::from_sources(None, None).is_none());
+        assert!(Voice::from_sources(None, Some("config-key"), "cedar").is_some());
+        assert!(Voice::from_sources(None, None, "cedar").is_none());
     }
 
     impl VoiceProvider for FakeProvider {
@@ -370,7 +377,6 @@ mod tests {
     fn defaults_use_current_openai_audio_models() {
         assert_eq!(TRANSCRIPTION_MODEL, "gpt-4o-transcribe");
         assert_eq!(SPEECH_MODEL, "gpt-4o-mini-tts");
-        assert_eq!(SPEECH_VOICE, "cedar");
     }
 
     #[tokio::test]
@@ -380,7 +386,8 @@ mod tests {
             "application/json",
             br#"{"text":"contract transcript"}"#.to_vec(),
         );
-        let provider = OpenAiVoice::with_base_url("test-key".to_string(), base_url);
+        let provider =
+            OpenAiVoice::with_base_url("test-key".to_string(), base_url, "cedar".to_string());
 
         let transcript = provider
             .transcribe(clip(b"audio-bytes".to_vec()))
@@ -403,7 +410,8 @@ mod tests {
     #[tokio::test]
     async fn openai_speech_http_contract_requests_opus_and_returns_audio() {
         let (base_url, request) = serve_once("200 OK", "application/octet-stream", vec![9, 8, 7]);
-        let provider = OpenAiVoice::with_base_url("test-key".to_string(), base_url);
+        let provider =
+            OpenAiVoice::with_base_url("test-key".to_string(), base_url, "onyx".to_string());
 
         let output = provider.synthesize("hello").await.unwrap();
         let request = request.join().unwrap();
@@ -416,7 +424,7 @@ mod tests {
 
         assert_eq!(output.bytes, vec![9, 8, 7]);
         assert_eq!(payload["model"], SPEECH_MODEL);
-        assert_eq!(payload["voice"], SPEECH_VOICE);
+        assert_eq!(payload["voice"], "onyx");
         assert_eq!(
             payload["instructions"],
             "Speak in a natural, clear, concise male voice."
@@ -432,7 +440,8 @@ mod tests {
             "application/json",
             br#"{"error":"secret upstream detail"}"#.to_vec(),
         );
-        let provider = OpenAiVoice::with_base_url("bad-key".to_string(), base_url);
+        let provider =
+            OpenAiVoice::with_base_url("bad-key".to_string(), base_url, "cedar".to_string());
 
         let error = provider
             .transcribe(clip(b"audio".to_vec()))

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -200,7 +200,7 @@ impl VoiceProvider for OpenAiVoice {
                     "model": SPEECH_MODEL,
                     "voice": self.voice_name,
                     "input": text,
-                    "instructions": "Speak in a natural, clear, concise male voice.",
+                    "instructions": "Speak naturally, clearly, and concisely.",
                     "response_format": "opus"
                 }))
                 .send()
@@ -427,7 +427,7 @@ mod tests {
         assert_eq!(payload["voice"], "onyx");
         assert_eq!(
             payload["instructions"],
-            "Speak in a natural, clear, concise male voice."
+            "Speak naturally, clearly, and concisely."
         );
         assert_eq!(payload["response_format"], "opus");
         assert_eq!(payload["input"], "hello");

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -16,7 +16,7 @@ use crate::config::Config;
 pub const OPENAI_API_KEY_ENV: &str = "OPENAI_API_KEY";
 pub const TRANSCRIPTION_MODEL: &str = "gpt-4o-transcribe";
 pub const SPEECH_MODEL: &str = "gpt-4o-mini-tts";
-pub const SPEECH_VOICE: &str = "marin";
+pub const SPEECH_VOICE: &str = "cedar";
 pub const MAX_AUDIO_BYTES: usize = 20 * 1024 * 1024;
 const MAX_SPEECH_CHARS: usize = 4096;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(90);
@@ -193,7 +193,7 @@ impl VoiceProvider for OpenAiVoice {
                     "model": SPEECH_MODEL,
                     "voice": SPEECH_VOICE,
                     "input": text,
-                    "instructions": "Speak naturally, clearly, and concisely.",
+                    "instructions": "Speak in a natural, clear, concise male voice.",
                     "response_format": "opus"
                 }))
                 .send()
@@ -370,6 +370,7 @@ mod tests {
     fn defaults_use_current_openai_audio_models() {
         assert_eq!(TRANSCRIPTION_MODEL, "gpt-4o-transcribe");
         assert_eq!(SPEECH_MODEL, "gpt-4o-mini-tts");
+        assert_eq!(SPEECH_VOICE, "cedar");
     }
 
     #[tokio::test]
@@ -416,6 +417,10 @@ mod tests {
         assert_eq!(output.bytes, vec![9, 8, 7]);
         assert_eq!(payload["model"], SPEECH_MODEL);
         assert_eq!(payload["voice"], SPEECH_VOICE);
+        assert_eq!(
+            payload["instructions"],
+            "Speak in a natural, clear, concise male voice."
+        );
         assert_eq!(payload["response_format"], "opus");
         assert_eq!(payload["input"], "hello");
     }


### PR DESCRIPTION
## Summary

- add `voice.name` with `cedar` as the default
- validate all 13 supported built-in OpenAI voices
- pass the configured voice to speech synthesis while retaining the male-voice instruction
- document the option and verify default, override, invalid, and request paths

## Why

Spoken AI replies should default to a male voice while allowing the built-in OpenAI voice to be selected in config.

## Test plan

- `cargo fmt --check`
- `cargo test` (278 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- independent diff review: no findings

## Risks

Perceived gender is model-dependent because OpenAI does not formally label built-in voices by gender. Custom voice IDs are not accepted by `voice.name`; the option supports the 13 documented built-in names.

## Related issue

None.