### PR TITLE
feat(cli): add gateway reload and version commands

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,10 +7,11 @@ The default is `~/.push/config.toml`.
 | Command | Purpose |
 | --- | --- |
 | `push help`, `push --help` | Print command and option help without loading config or changing files |
+| `push version`, `push --version` | Print the installed Push version without starting the gateway |
 | `push init [path]` | Create and Git-initialize the one assistant repository; defaults to `./assistant` |
 | `push` | Start the configured channel gateway and scheduler |
 | `push doctor` | Validate config, paths, channel requirements, and required backend binaries |
-| `push restart` | Restart the managed gateway to load updated config |
+| `push reload`, `push restart` | Restart the managed gateway to load updated config |
 | `push job validate` | Validate every installed job; exits non-zero if any are invalid |
 | `push job list` | List valid and invalid jobs with backend or error |
 | `push job show <name>` | Print the parsed installed job |
@@ -22,9 +23,10 @@ Examples:
 ```sh
 push init ~/Code/assistant
 push help
+push version
 push doctor
 push
-push restart
+push reload
 push job validate
 push job run repo-review
 push job runs repo-review
@@ -33,7 +35,7 @@ push job runs repo-review
 Unknown commands and missing values fail with the accepted command forms. The
 CLI does not currently provide shell completion.
 
-`push restart` targets the service definitions documented by Push:
+`push reload` and its `push restart` alias target the service definitions documented by Push:
 `com.owainlewis.push` under launchd on macOS and the `push.service` user unit
 under systemd on Linux. The service definition controls its config path,
 environment, and executable; `--config` does not override the service definition

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,7 +7,7 @@ The default is `~/.push/config.toml`.
 | Command | Purpose |
 | --- | --- |
 | `push help`, `push --help` | Print command and option help without loading config or changing files |
-| `push version`, `push --version` | Print the installed Push version without starting the gateway |
+| `push version`, `push --version`, `push -V` | Print the installed Push version without starting the gateway |
 | `push init [path]` | Create and Git-initialize the one assistant repository; defaults to `./assistant` |
 | `push` | Start the configured channel gateway and scheduler |
 | `push doctor` | Validate config, paths, channel requirements, and required backend binaries |

--- a/docs/services.md
+++ b/docs/services.md
@@ -107,7 +107,7 @@ tail -f ~/Library/Logs/push.err.log ~/Library/Logs/push.out.log
 After editing `~/.push/config.toml`, restart the gateway with:
 
 ```sh
-push restart
+push reload
 ```
 
 After changing the plist:
@@ -167,7 +167,7 @@ journalctl --user -u push.service -f
 After editing `~/.push/config.toml`, restart the gateway with:
 
 ```sh
-push restart
+push reload
 ```
 
 For voice support, prefer `voice.openai_api_key` in `~/.push/config.toml`. As an

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,11 @@ Usage: push [OPTIONS] [COMMAND]
 
 Commands:
   help              Print this help
+  version           Print the installed Push version
   init [path]       Create an assistant repository (default: ./assistant)
   doctor            Validate the configuration and dependencies
-  restart           Restart the installed gateway service
+  reload            Reload the installed gateway service
+  restart           Alias for reload
   job validate      Validate all installed jobs
   job list          List installed jobs
   job show <name>   Show an installed job
@@ -48,6 +50,7 @@ Commands:
 Options:
   --config <path>   Use a configuration file (default: ~/.push/config.toml)
   -h, --help        Print help
+  -V, --version     Print version
 ";
 
 #[tokio::main]
@@ -58,6 +61,10 @@ async fn main() -> Result<()> {
     match args.command {
         Command::Help => {
             print!("{HELP}");
+            Ok(())
+        }
+        Command::Version => {
+            println!("push {}", env!("CARGO_PKG_VERSION"));
             Ok(())
         }
         Command::Init(path) => {
@@ -145,6 +152,7 @@ struct Args {
 #[derive(Debug, PartialEq, Eq)]
 enum Command {
     Help,
+    Version,
     Run,
     Init(String),
     Doctor,
@@ -172,6 +180,15 @@ impl Args {
                 config_path: DEFAULT_CONFIG_PATH.to_string(),
             });
         }
+        if args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "-V" | "--version"))
+        {
+            return Ok(Self {
+                command: Command::Version,
+                config_path: DEFAULT_CONFIG_PATH.to_string(),
+            });
+        }
 
         let mut config_path = DEFAULT_CONFIG_PATH.to_string();
         let mut positional = Vec::new();
@@ -194,10 +211,11 @@ impl Args {
         let command = match positional.iter().map(String::as_str).collect::<Vec<_>>().as_slice() {
             [] => Command::Run,
             ["help"] => Command::Help,
+            ["version"] => Command::Version,
             ["init"] => Command::Init("./assistant".to_string()),
             ["init", path] => Command::Init((*path).to_string()),
             ["doctor"] => Command::Doctor,
-            ["restart"] => Command::Restart,
+            ["reload" | "restart"] => Command::Restart,
             ["job", "validate"] => Command::Job(JobCommand::Validate),
             ["job", "list"] => Command::Job(JobCommand::List),
             ["job", "show", name] => Command::Job(JobCommand::Show((*name).to_string())),
@@ -205,7 +223,7 @@ impl Args {
             ["job", "runs"] => Command::Job(JobCommand::Runs(None)),
             ["job", "runs", name] => Command::Job(JobCommand::Runs(Some((*name).to_string()))),
             _ => bail!(
-                "unknown command; expected help, init [path], doctor, restart, job validate, job list, job show <name>, job run <name>, job runs [<name>], or --config <path>"
+                "unknown command; expected help, version, init [path], doctor, reload, restart, job validate, job list, job show <name>, job run <name>, job runs [<name>], or --config <path>"
             ),
         };
         Ok(Self {
@@ -361,6 +379,25 @@ mod tests {
                 config_path: "custom.toml".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn parses_reload_as_restart() {
+        assert_eq!(
+            Args::parse(vec!["reload".into()]).unwrap().command,
+            Command::Restart
+        );
+    }
+
+    #[test]
+    fn parses_version_command_and_flag() {
+        for args in [
+            vec!["version".into()],
+            vec!["--version".into()],
+            vec!["-V".into()],
+        ] {
+            assert_eq!(Args::parse(args).unwrap().command, Command::Version);
+        }
     }
 
     #[test]

--- a/src/restart.rs
+++ b/src/restart.rs
@@ -1,3 +1,4 @@
+use std::io::{self, Write};
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
@@ -7,6 +8,10 @@ const SYSTEMD_UNIT: &str = "push.service";
 
 pub fn gateway() -> Result<()> {
     let command = platform_command()?;
+    println!("Restarting gateway...");
+    io::stdout()
+        .flush()
+        .context("flush gateway restart status")?;
     let message = execute(&command, |command| {
         let mut process = Command::new(command.program);
         process.args(&command.args);
@@ -52,7 +57,7 @@ fn execute(
             status.description
         );
     }
-    Ok("Restarted the Push gateway.")
+    Ok("Gateway restarted.")
 }
 
 fn platform_command() -> Result<PlatformCommand> {
@@ -155,7 +160,7 @@ mod tests {
         })
         .unwrap();
 
-        assert_eq!(message, "Restarted the Push gateway.");
+        assert_eq!(message, "Gateway restarted.");
     }
 
     #[test]

--- a/src/restart.rs
+++ b/src/restart.rs
@@ -8,10 +8,7 @@ const SYSTEMD_UNIT: &str = "push.service";
 
 pub fn gateway() -> Result<()> {
     let command = platform_command()?;
-    println!("Restarting gateway...");
-    io::stdout()
-        .flush()
-        .context("flush gateway restart status")?;
+    write_status("Restarting gateway...");
     let message = execute(&command, |command| {
         let mut process = Command::new(command.program);
         process.args(&command.args);
@@ -21,8 +18,14 @@ pub fn gateway() -> Result<()> {
             description: status.to_string(),
         })
     })?;
-    println!("{message}");
+    write_status(message);
     Ok(())
+}
+
+fn write_status(message: &str) {
+    let mut stdout = io::stdout().lock();
+    let _ = writeln!(stdout, "{message}");
+    let _ = stdout.flush();
 }
 
 struct ProcessStatus {

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -240,7 +240,7 @@ fn restart_invokes_the_platform_service_manager() {
     let manager_path = bin_dir.join(manager);
     std::fs::write(
         &manager_path,
-        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$PUSH_RESTART_ARGS_PATH\"\n",
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$PUSH_RESTART_ARGS_PATH\"\nprintf 'Service manager ran.\\n'\n",
     )
     .unwrap();
     let mut permissions = std::fs::metadata(&manager_path).unwrap().permissions();
@@ -267,7 +267,7 @@ fn restart_invokes_the_platform_service_manager() {
     );
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
-        "Restarted the Push gateway."
+        "Restarting gateway...\nService manager ran.\nGateway restarted."
     );
     let args = std::fs::read_to_string(args_path).unwrap();
     if cfg!(target_os = "macos") {
@@ -298,7 +298,7 @@ fn reload_invokes_the_platform_service_manager() {
     let manager_path = bin_dir.join(manager);
     std::fs::write(
         &manager_path,
-        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$PUSH_RESTART_ARGS_PATH\"\n",
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$PUSH_RESTART_ARGS_PATH\"\nprintf 'Service manager ran.\\n'\n",
     )
     .unwrap();
     let mut permissions = std::fs::metadata(&manager_path).unwrap().permissions();
@@ -322,7 +322,7 @@ fn reload_invokes_the_platform_service_manager() {
     assert!(args_path.is_file());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
-        "Restarted the Push gateway."
+        "Restarting gateway...\nService manager ran.\nGateway restarted."
     );
     let _ = std::fs::remove_dir_all(root);
 }

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -225,7 +225,7 @@ fn job_without_default_config_reports_init_guidance() {
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
-fn restart_invokes_the_platform_service_manager() {
+fn restart_and_reload_invoke_the_platform_service_manager() {
     use std::os::unix::fs::PermissionsExt;
 
     let root = temp_dir("restart-service-manager");
@@ -253,40 +253,46 @@ fn restart_invokes_the_platform_service_manager() {
     )
     .unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_push"))
-        .arg("restart")
-        .env("PATH", path)
-        .env("PUSH_RESTART_ARGS_PATH", &args_path)
-        .output()
-        .unwrap();
+    for command in ["restart", "reload"] {
+        let _ = std::fs::remove_file(&args_path);
+        let output = Command::new(env!("CARGO_BIN_EXE_push"))
+            .arg(command)
+            .env("PATH", &path)
+            .env("PUSH_RESTART_ARGS_PATH", &args_path)
+            .output()
+            .unwrap();
 
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout).trim(),
-        "Restarting gateway...\nService manager ran.\nGateway restarted."
-    );
-    let args = std::fs::read_to_string(args_path).unwrap();
-    if cfg!(target_os = "macos") {
-        let lines = args.lines().collect::<Vec<_>>();
-        assert_eq!(&lines[..2], &["kickstart", "-k"]);
-        assert!(lines[2].starts_with("gui/"));
-        assert!(lines[2].ends_with("/com.owainlewis.push"));
-    } else {
-        assert_eq!(args, "--user\nrestart\npush.service\n");
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "Restarting gateway...\nService manager ran.\nGateway restarted."
+        );
+        let args = std::fs::read_to_string(&args_path).unwrap();
+        if cfg!(target_os = "macos") {
+            let lines = args.lines().collect::<Vec<_>>();
+            assert_eq!(&lines[..2], &["kickstart", "-k"]);
+            assert!(lines[2].starts_with("gui/"));
+            assert!(lines[2].ends_with("/com.owainlewis.push"));
+        } else {
+            assert_eq!(args, "--user\nrestart\npush.service\n");
+        }
     }
     let _ = std::fs::remove_dir_all(root);
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
-fn reload_invokes_the_platform_service_manager() {
+fn reload_runs_the_service_manager_when_stdout_is_closed() {
+    use std::os::fd::OwnedFd;
     use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::net::UnixStream;
+    use std::process::Stdio;
 
-    let root = temp_dir("reload-service-manager");
+    let root = temp_dir("reload-closed-stdout");
     let bin_dir = root.join("bin");
     let args_path = root.join("args");
     std::fs::create_dir(&bin_dir).unwrap();
@@ -298,7 +304,7 @@ fn reload_invokes_the_platform_service_manager() {
     let manager_path = bin_dir.join(manager);
     std::fs::write(
         &manager_path,
-        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$PUSH_RESTART_ARGS_PATH\"\nprintf 'Service manager ran.\\n'\n",
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$PUSH_RESTART_ARGS_PATH\"\n",
     )
     .unwrap();
     let mut permissions = std::fs::metadata(&manager_path).unwrap().permissions();
@@ -311,19 +317,19 @@ fn reload_invokes_the_platform_service_manager() {
     )
     .unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_push"))
+    let (closed_stdout, reader) = UnixStream::pair().unwrap();
+    drop(reader);
+    let closed_stdout = OwnedFd::from(closed_stdout);
+    let status = Command::new(env!("CARGO_BIN_EXE_push"))
         .arg("reload")
         .env("PATH", path)
         .env("PUSH_RESTART_ARGS_PATH", &args_path)
-        .output()
+        .stdout(Stdio::from(closed_stdout))
+        .status()
         .unwrap();
 
-    assert!(output.status.success());
+    assert!(status.success());
     assert!(args_path.is_file());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout).trim(),
-        "Restarting gateway...\nService manager ran.\nGateway restarted."
-    );
     let _ = std::fs::remove_dir_all(root);
 }
 

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -25,7 +25,36 @@ fn help_commands_print_usage_without_creating_files() {
         );
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(stdout.contains("Usage: push"));
+        assert!(stdout.contains("reload"));
         assert!(stdout.contains("restart"));
+        assert!(output.stderr.is_empty());
+    }
+    assert_eq!(std::fs::read_dir(&workdir).unwrap().count(), 0);
+    assert_eq!(std::fs::read_dir(&home).unwrap().count(), 0);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn version_commands_print_version_without_creating_files() {
+    let root = temp_dir("version");
+    let home = root.join("home");
+    let workdir = root.join("workdir");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    for args in [&["version"][..], &["--version"][..], &["-V"][..]] {
+        let output = Command::new(env!("CARGO_BIN_EXE_push"))
+            .args(args)
+            .current_dir(&workdir)
+            .env("HOME", &home)
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            format!("push {}", env!("CARGO_PKG_VERSION"))
+        );
         assert!(output.stderr.is_empty());
     }
     assert_eq!(std::fs::read_dir(&workdir).unwrap().count(), 0);
@@ -249,6 +278,52 @@ fn restart_invokes_the_platform_service_manager() {
     } else {
         assert_eq!(args, "--user\nrestart\npush.service\n");
     }
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[test]
+fn reload_invokes_the_platform_service_manager() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = temp_dir("reload-service-manager");
+    let bin_dir = root.join("bin");
+    let args_path = root.join("args");
+    std::fs::create_dir(&bin_dir).unwrap();
+    let manager = if cfg!(target_os = "macos") {
+        "launchctl"
+    } else {
+        "systemctl"
+    };
+    let manager_path = bin_dir.join(manager);
+    std::fs::write(
+        &manager_path,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$PUSH_RESTART_ARGS_PATH\"\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&manager_path).unwrap().permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&manager_path, permissions).unwrap();
+    let path = std::env::join_paths(
+        std::iter::once(bin_dir.clone()).chain(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        )),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_push"))
+        .arg("reload")
+        .env("PATH", path)
+        .env("PUSH_RESTART_ARGS_PATH", &args_path)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(args_path.is_file());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "Restarted the Push gateway."
+    );
     let _ = std::fs::remove_dir_all(root);
 }
 


### PR DESCRIPTION
## Summary

- add `push reload` as the preferred alias for restarting the managed gateway
- add `push version`, `push --version`, and `push -V` without loading config or starting a gateway
- update CLI and service documentation

## Why

A bare `push` starts a foreground gateway, which is confusing when launchd or systemd already owns the service. These explicit commands make service control and version inspection safe and discoverable.

## Test plan

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- manual: `./target/debug/push --version`
- manual: `./target/debug/push version`
- manual: `./target/debug/push help`
- independent diff review: no findings

## Risks

Low. `reload` delegates to the existing, tested restart implementation. `restart` remains supported as an alias.

## Related issue

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `push version` command and `-V`/`--version` flags to display the installed version.
  - Added `push reload` as an alias for restarting the Push gateway.
  - Updated CLI help and usage guidance for the new commands.

- **Documentation**
  - Updated service management instructions and CLI reference examples to use `push reload`.
  - Clarified the relationship between `reload` and `restart`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->