### PR TITLE
fix(gateway): recover stalled message queues

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -340,6 +340,10 @@ The backend still owns tools, skills, MCP, authentication, and execution.
 One worker task exists per conversation thread. Messages in the same thread run
 in order. Different threads can run in parallel.
 
+`/stop` cancels the active backend subprocess for one conversation without
+discarding messages already queued behind it. A closed worker queue is replaced
+and the message that discovered it is retried once.
+
 This prevents two messages in the same conversation from racing against the same
 backend session.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -52,6 +52,7 @@ These messages are handled by the gateway before backend dispatch:
 | Message | Effect |
 | --- | --- |
 | `/clear`, `/new`, `/reset` | Start a fresh backend session for that conversation |
+| `/stop` | Stop the active request; already queued messages continue in order |
 | `/help` | Return the available chat commands |
 
 Starting a fresh session preserves canonical history. Push can seed the new

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -128,6 +128,7 @@ pub struct FakeRunner {
     pub session_id: String,
     pub calls: std::sync::Arc<std::sync::Mutex<Vec<FakeRunCall>>>,
     pub before_return: Option<std::sync::Arc<dyn Fn() + Send + Sync>>,
+    pub wait_for_release: Option<std::sync::Arc<tokio::sync::Notify>>,
     pub failure: Option<String>,
     pub resume_missing_once: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 }
@@ -164,6 +165,9 @@ impl FakeRunner {
         }
         if let Some(before_return) = &self.before_return {
             before_return();
+        }
+        if let Some(release) = &self.wait_for_release {
+            release.notified().await;
         }
         if let Some(message) = &self.failure {
             return Err(RunError::Failed(message.clone()));

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -6,8 +6,9 @@
 //! short-lived locks. Each channel-qualified thread gets its own worker task,
 //! which serializes that thread's messages.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::future::Future;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -79,7 +80,7 @@ pub struct Gateway {
     ctx: Ctx,
     cfg: Config,
     poll_interval: Duration,
-    queues: HashMap<String, mpsc::Sender<Job>>,
+    queues: HashMap<String, WorkerQueue>,
     handles: Vec<JoinHandle<()>>,
 }
 
@@ -99,6 +100,14 @@ pub struct PrimaryDestination {
 struct AckState {
     in_flight: BTreeSet<i64>,
     completed: BTreeSet<i64>,
+}
+
+struct WorkerQueue {
+    jobs: mpsc::Sender<Job>,
+    pending: Arc<Mutex<VecDeque<Job>>>,
+    cancel_generation: Arc<AtomicU64>,
+    cancel: watch::Sender<u64>,
+    active: Arc<AtomicBool>,
 }
 
 impl GatewayGroup {
@@ -506,6 +515,7 @@ impl Gateway {
     }
 
     async fn process_messages(&mut self, msgs: Vec<RawMessage>) {
+        self.recover_closed_workers();
         let since = self.store.lock().unwrap().cursor(self.channel.id());
         for m in &msgs {
             if m.row_id <= since {
@@ -629,6 +639,10 @@ impl Gateway {
                     reply_with_voice,
                     voice_attachment: m.voice.clone(),
                 };
+                if job.text.trim().eq_ignore_ascii_case("/stop") {
+                    self.stop(job).await;
+                    continue;
+                }
                 if !self.route(job).await {
                     return;
                 }
@@ -644,59 +658,209 @@ impl Gateway {
         let thread = job.thread.clone();
         let target = job.target.clone();
         let backend = job.backend;
+        self.ack.lock().unwrap().in_flight.insert(row_id);
         if !self.queues.contains_key(&thread) {
-            let (tx, rx) = mpsc::channel::<Job>(QUEUE_DEPTH);
-            let ctx = self.ctx.clone();
-            self.handles.push(tokio::spawn(worker::run(ctx, rx)));
-            self.queues.insert(thread.clone(), tx);
+            self.spawn_worker(thread, vec![job]);
+            return true;
         }
 
-        let full = matches!(
-            self.queues.get(&thread).unwrap().try_send(job.clone()),
-            Err(mpsc::error::TrySendError::Full(_))
-        );
-        if full {
-            self.ack.lock().unwrap().in_flight.insert(row_id);
-            warn!("[{thread}] queue full, asking sender to resend");
-            self.audit(self.ctx.audit.failed(
-                "message_queue_failed",
-                row_id,
-                &thread,
-                Some(backend),
-                "queue full",
-            ));
-            let reply = "I'm a bit behind on this thread - resend that in a moment.";
-            match worker::record_and_deliver(&self.ctx, &job, OutboundOrigin::Gateway, reply).await
-            {
-                Ok(
-                    worker::DeliveryOutcome::Delivered | worker::DeliveryOutcome::AlreadyDelivered,
-                ) => {
-                    self.audit(self.ctx.audit.reply_sent(
-                        row_id,
-                        &thread,
-                        &target,
-                        Some(backend),
-                        reply,
-                    ));
-                    self.complete_row(row_id, "queue_full");
-                }
-                Err(error) => {
-                    error!("[{thread}] canonical history write failed: {error}");
-                    self.audit(self.ctx.audit.failed(
-                        "message_history_failed",
-                        row_id,
-                        &thread,
-                        Some(backend),
-                        error.to_string(),
-                    ));
-                    self.ack.lock().unwrap().in_flight.remove(&row_id);
-                    return false;
+        self.queues
+            .get(&thread)
+            .unwrap()
+            .pending
+            .lock()
+            .unwrap()
+            .push_back(job.clone());
+        let enqueue = self.queues.get(&thread).unwrap().jobs.try_send(job.clone());
+        match enqueue {
+            Ok(()) => true,
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.recover_closed_worker(&thread);
+                true
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.queues
+                    .get(&thread)
+                    .unwrap()
+                    .pending
+                    .lock()
+                    .unwrap()
+                    .retain(|pending| pending.row_id != row_id);
+                warn!("[{thread}] queue full, asking sender to resend");
+                self.audit(self.ctx.audit.failed(
+                    "message_queue_failed",
+                    row_id,
+                    &thread,
+                    Some(backend),
+                    "queue full",
+                ));
+                let reply = "I'm a bit behind on this thread - resend that in a moment.";
+                match worker::record_and_deliver_once(
+                    &self.ctx,
+                    &job,
+                    OutboundOrigin::Gateway,
+                    reply,
+                )
+                .await
+                {
+                    Ok(delivered) => {
+                        if delivered {
+                            self.audit(self.ctx.audit.reply_sent(
+                                row_id,
+                                &thread,
+                                &target,
+                                Some(backend),
+                                reply,
+                            ));
+                        } else {
+                            self.audit(self.ctx.audit.reply_failed(
+                                row_id,
+                                &thread,
+                                &target,
+                                Some(backend),
+                                "queue-full reply delivery failed",
+                            ));
+                        }
+                        self.complete_row(row_id, "queue_full");
+                        true
+                    }
+                    Err(error) => {
+                        error!("[{thread}] canonical history write failed: {error}");
+                        self.audit(self.ctx.audit.failed(
+                            "message_history_failed",
+                            row_id,
+                            &thread,
+                            Some(backend),
+                            error.to_string(),
+                        ));
+                        self.ack.lock().unwrap().in_flight.remove(&row_id);
+                        false
+                    }
                 }
             }
-        } else {
-            self.ack.lock().unwrap().in_flight.insert(row_id);
         }
-        true
+    }
+
+    fn spawn_worker(&mut self, thread: String, initial_jobs: Vec<Job>) {
+        let (jobs, rx) = mpsc::channel::<Job>(QUEUE_DEPTH.max(initial_jobs.len()));
+        let (cancel, cancel_rx) = watch::channel(0);
+        let cancel_generation = Arc::new(AtomicU64::new(0));
+        let active = Arc::new(AtomicBool::new(false));
+        let pending = Arc::new(Mutex::new(initial_jobs.iter().cloned().collect()));
+        for job in initial_jobs {
+            jobs.try_send(job)
+                .expect("initial worker queue capacity must fit recovery jobs");
+        }
+        let ctx = self.ctx.clone();
+        self.handles.push(tokio::spawn(worker::run(
+            ctx,
+            rx,
+            cancel_rx,
+            active.clone(),
+            pending.clone(),
+        )));
+        self.queues.insert(
+            thread,
+            WorkerQueue {
+                jobs,
+                pending,
+                cancel_generation,
+                cancel,
+                active,
+            },
+        );
+    }
+
+    fn recover_closed_workers(&mut self) {
+        let closed = self
+            .queues
+            .iter()
+            .filter(|(_, worker)| worker.jobs.is_closed())
+            .map(|(thread, _)| thread.clone())
+            .collect::<Vec<_>>();
+        for thread in closed {
+            self.recover_closed_worker(&thread);
+        }
+    }
+
+    fn recover_closed_worker(&mut self, thread: &str) {
+        let Some(worker) = self.queues.remove(thread) else {
+            return;
+        };
+        let pending = worker.pending.lock().unwrap().drain(..).collect::<Vec<_>>();
+        let Some(first) = pending.first() else {
+            return;
+        };
+        warn!("[{thread}] worker queue closed unexpectedly; replaying retained jobs");
+        self.audit(self.ctx.audit.failed(
+            "message_queue_recovered",
+            first.row_id,
+            thread,
+            Some(first.backend),
+            format!(
+                "worker queue closed; replaying {} retained jobs",
+                pending.len()
+            ),
+        ));
+        self.spawn_worker(thread.to_string(), pending);
+    }
+
+    async fn stop(&self, job: Job) {
+        let row_id = job.row_id;
+        self.ack.lock().unwrap().in_flight.insert(row_id);
+        let stopped = self.queues.get(&job.thread).is_some_and(|worker| {
+            if !worker.active.load(Ordering::SeqCst) {
+                return false;
+            }
+            let generation = worker.cancel_generation.fetch_add(1, Ordering::SeqCst) + 1;
+            worker.cancel.send(generation).is_ok()
+        });
+        let reply = if stopped {
+            "Stop requested. Queued messages will continue."
+        } else {
+            "Nothing is currently running in this conversation."
+        };
+        match worker::record_and_deliver_once(&self.ctx, &job, OutboundOrigin::Gateway, reply).await
+        {
+            Ok(delivered) => {
+                if delivered {
+                    self.audit(self.ctx.audit.reply_sent(
+                        row_id,
+                        &job.thread,
+                        &job.target,
+                        Some(job.backend),
+                        reply,
+                    ));
+                } else {
+                    self.audit(self.ctx.audit.reply_failed(
+                        row_id,
+                        &job.thread,
+                        &job.target,
+                        Some(job.backend),
+                        "stop acknowledgement delivery failed",
+                    ));
+                }
+                self.complete_row(
+                    row_id,
+                    if stopped {
+                        "stop_requested"
+                    } else {
+                        "nothing_to_stop"
+                    },
+                );
+            }
+            Err(error) => {
+                error!("[{}] stop reply failed: {error:#}", job.thread);
+                self.audit(self.ctx.audit.failed(
+                    "message_history_failed",
+                    row_id,
+                    &job.thread,
+                    Some(job.backend),
+                    error.to_string(),
+                ));
+                self.ack.lock().unwrap().in_flight.remove(&row_id);
+            }
+        }
     }
 
     fn complete_row(&self, row_id: i64, reason: &str) {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -813,20 +813,58 @@ impl Gateway {
         self.spawn_worker(thread.to_string(), pending);
     }
 
-    async fn stop(&self, job: Job) -> bool {
+    async fn stop(&mut self, job: Job) -> bool {
         let row_id = job.row_id;
         self.ack.lock().unwrap().in_flight.insert(row_id);
-        let stopped = self.queues.get(&job.thread).is_some_and(|worker| {
+        let candidate_target = self.queues.get(&job.thread).and_then(|worker| {
             let state = worker.state.lock().unwrap();
-            let target_row = state.current_row.or_else(|| {
+            state.current_row.or_else(|| {
                 state
                     .pending
                     .iter()
                     .find(|pending| !state.retained_rows.contains(&pending.row_id))
                     .map(|pending| pending.row_id)
-            });
-            target_row.is_some_and(|row_id| worker.cancel.send(row_id).is_ok())
+            })
         });
+        let target_row = match self
+            .ctx
+            .history
+            .lock()
+            .unwrap()
+            .record_stop_target(job.inbound_id, candidate_target)
+        {
+            Ok(target_row) => target_row,
+            Err(error) => {
+                error!("[{}] stop target write failed: {error:#}", job.thread);
+                self.audit(self.ctx.audit.failed(
+                    "message_history_failed",
+                    row_id,
+                    &job.thread,
+                    Some(job.backend),
+                    error.to_string(),
+                ));
+                self.ack.lock().unwrap().in_flight.remove(&row_id);
+                return false;
+            }
+        };
+        let stopped = target_row.is_some();
+        if let Some(target_row) = target_row {
+            let signaled = self.queues.get(&job.thread).is_none_or(|worker| {
+                let state = worker.state.lock().unwrap();
+                let retained = state.retained_rows.contains(&target_row);
+                let pending = state
+                    .pending
+                    .iter()
+                    .any(|pending| pending.row_id == target_row);
+                let target_is_runnable =
+                    state.current_row == Some(target_row) || (pending && !retained);
+                !target_is_runnable || worker.cancel.send(target_row).is_ok()
+            });
+            if !signaled {
+                self.ack.lock().unwrap().in_flight.remove(&row_id);
+                return false;
+            }
+        }
         let reply = if stopped {
             "Stop requested. Queued messages will continue."
         } else {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -8,7 +8,6 @@
 
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::future::Future;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -104,10 +103,14 @@ struct AckState {
 
 struct WorkerQueue {
     jobs: mpsc::Sender<Job>,
-    pending: Arc<Mutex<VecDeque<Job>>>,
-    cancel_generation: Arc<AtomicU64>,
-    cancel: watch::Sender<u64>,
-    active: Arc<AtomicBool>,
+    state: Arc<Mutex<WorkerState>>,
+    cancel: watch::Sender<i64>,
+}
+
+struct WorkerState {
+    pending: VecDeque<Job>,
+    current_row: Option<i64>,
+    retained_rows: BTreeSet<i64>,
 }
 
 impl GatewayGroup {
@@ -640,7 +643,9 @@ impl Gateway {
                     voice_attachment: m.voice.clone(),
                 };
                 if job.text.trim().eq_ignore_ascii_case("/stop") {
-                    self.stop(job).await;
+                    if !self.stop(job).await {
+                        return;
+                    }
                     continue;
                 }
                 if !self.route(job).await {
@@ -667,9 +672,10 @@ impl Gateway {
         self.queues
             .get(&thread)
             .unwrap()
-            .pending
+            .state
             .lock()
             .unwrap()
+            .pending
             .push_back(job.clone());
         let enqueue = self.queues.get(&thread).unwrap().jobs.try_send(job.clone());
         match enqueue {
@@ -682,9 +688,10 @@ impl Gateway {
                 self.queues
                     .get(&thread)
                     .unwrap()
-                    .pending
+                    .state
                     .lock()
                     .unwrap()
+                    .pending
                     .retain(|pending| pending.row_id != row_id);
                 warn!("[{thread}] queue full, asking sender to resend");
                 self.audit(self.ctx.audit.failed(
@@ -744,29 +751,24 @@ impl Gateway {
     fn spawn_worker(&mut self, thread: String, initial_jobs: Vec<Job>) {
         let (jobs, rx) = mpsc::channel::<Job>(QUEUE_DEPTH.max(initial_jobs.len()));
         let (cancel, cancel_rx) = watch::channel(0);
-        let cancel_generation = Arc::new(AtomicU64::new(0));
-        let active = Arc::new(AtomicBool::new(false));
-        let pending = Arc::new(Mutex::new(initial_jobs.iter().cloned().collect()));
+        let state = Arc::new(Mutex::new(WorkerState {
+            pending: initial_jobs.iter().cloned().collect(),
+            current_row: None,
+            retained_rows: BTreeSet::new(),
+        }));
         for job in initial_jobs {
             jobs.try_send(job)
                 .expect("initial worker queue capacity must fit recovery jobs");
         }
         let ctx = self.ctx.clone();
-        self.handles.push(tokio::spawn(worker::run(
-            ctx,
-            rx,
-            cancel_rx,
-            active.clone(),
-            pending.clone(),
-        )));
+        self.handles
+            .push(tokio::spawn(worker::run(ctx, rx, cancel_rx, state.clone())));
         self.queues.insert(
             thread,
             WorkerQueue {
                 jobs,
-                pending,
-                cancel_generation,
+                state,
                 cancel,
-                active,
             },
         );
     }
@@ -787,7 +789,13 @@ impl Gateway {
         let Some(worker) = self.queues.remove(thread) else {
             return;
         };
-        let pending = worker.pending.lock().unwrap().drain(..).collect::<Vec<_>>();
+        let pending = worker
+            .state
+            .lock()
+            .unwrap()
+            .pending
+            .drain(..)
+            .collect::<Vec<_>>();
         let Some(first) = pending.first() else {
             return;
         };
@@ -805,15 +813,19 @@ impl Gateway {
         self.spawn_worker(thread.to_string(), pending);
     }
 
-    async fn stop(&self, job: Job) {
+    async fn stop(&self, job: Job) -> bool {
         let row_id = job.row_id;
         self.ack.lock().unwrap().in_flight.insert(row_id);
         let stopped = self.queues.get(&job.thread).is_some_and(|worker| {
-            if !worker.active.load(Ordering::SeqCst) {
-                return false;
-            }
-            let generation = worker.cancel_generation.fetch_add(1, Ordering::SeqCst) + 1;
-            worker.cancel.send(generation).is_ok()
+            let state = worker.state.lock().unwrap();
+            let target_row = state.current_row.or_else(|| {
+                state
+                    .pending
+                    .iter()
+                    .find(|pending| !state.retained_rows.contains(&pending.row_id))
+                    .map(|pending| pending.row_id)
+            });
+            target_row.is_some_and(|row_id| worker.cancel.send(row_id).is_ok())
         });
         let reply = if stopped {
             "Stop requested. Queued messages will continue."
@@ -848,6 +860,7 @@ impl Gateway {
                         "nothing_to_stop"
                     },
                 );
+                true
             }
             Err(error) => {
                 error!("[{}] stop reply failed: {error:#}", job.thread);
@@ -859,6 +872,7 @@ impl Gateway {
                     error.to_string(),
                 ));
                 self.ack.lock().unwrap().in_flight.remove(&row_id);
+                false
             }
         }
     }

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -1746,10 +1746,12 @@ async fn closed_worker_queue_is_recovered_without_another_message() {
         thread.to_string(),
         WorkerQueue {
             jobs,
-            pending: Arc::new(Mutex::new(VecDeque::from([lost_job]))),
-            cancel_generation: Arc::new(AtomicU64::new(0)),
+            state: Arc::new(Mutex::new(WorkerState {
+                pending: VecDeque::from([lost_job]),
+                current_row: None,
+                retained_rows: BTreeSet::new(),
+            })),
             cancel,
-            active: Arc::new(AtomicBool::new(false)),
         },
     );
 
@@ -1812,11 +1814,7 @@ async fn stop_interrupts_active_run_and_preserves_queued_messages() {
         .await;
     tokio::time::timeout(Duration::from_secs(1), async {
         loop {
-            if gateway
-                .queues
-                .get("imessage:self:me@icloud.com")
-                .is_some_and(|worker| worker.active.load(Ordering::SeqCst))
-            {
+            if !calls.lock().unwrap().is_empty() {
                 break;
             }
             tokio::task::yield_now().await;
@@ -1871,6 +1869,272 @@ async fn stop_interrupts_active_run_and_preserves_queued_messages() {
         .iter()
         .any(|(_, reply)| reply.contains(r#"{"role":"user","content":"queued"}"#)));
     assert_eq!(gateway.store.lock().unwrap().last_row(), 3);
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn stop_interrupts_a_worker_queued_in_the_same_poll_batch() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("same-batch-stop-sessions");
+    let assistant_dir = temp_path("same-batch-stop-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let release = Arc::new(tokio::sync::Notify::new());
+    let mut gateway = Gateway::new(test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    ))
+    .unwrap();
+    let mut runners = HashMap::new();
+    runners.insert(
+        AgentBackend::Codex,
+        Runner::Fake(FakeRunner {
+            backend: AgentBackend::Codex,
+            session_id: "fake-session".to_string(),
+            calls: calls.clone(),
+            before_return: None,
+            wait_for_release: Some(release.clone()),
+            failure: None,
+            resume_missing_once: None,
+        }),
+    );
+    gateway.ctx.runners = Arc::new(runners);
+
+    gateway
+        .tick_fake(vec![
+            message(1, "me@icloud.com", "", true, "slow"),
+            message(2, "me@icloud.com", "", true, "/stop"),
+        ])
+        .await;
+    let interrupted = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if gateway
+                .ctx
+                .sent_replies
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(_, reply)| reply.contains("Stopped the current request"))
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    release.notify_one();
+    gateway.queues.clear();
+    gateway.drain_workers().await;
+    interrupted.expect("a request queued before /stop in the same batch should be interrupted");
+
+    let replies = gateway.ctx.sent_replies.lock().unwrap();
+    assert!(replies
+        .iter()
+        .any(|(_, reply)| reply.contains("Stop requested")));
+    assert!(!replies
+        .iter()
+        .any(|(_, reply)| reply.contains("Nothing is currently running")));
+    assert_eq!(gateway.store.lock().unwrap().last_row(), 2);
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn stale_stop_signal_does_not_interrupt_a_later_row() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("stale-stop-sessions");
+    let assistant_dir = temp_path("stale-stop-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let mut gateway = Gateway::new(test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    ))
+    .unwrap();
+    gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+    let thread = "imessage:self:me@icloud.com";
+
+    gateway
+        .tick_fake(vec![message(1, "me@icloud.com", "", true, "first")])
+        .await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if gateway.store.lock().unwrap().last_row() == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("first row should complete");
+    gateway.queues.get(thread).unwrap().cancel.send(1).unwrap();
+
+    run_messages(
+        &mut gateway,
+        vec![message(2, "me@icloud.com", "", true, "second")],
+    )
+    .await;
+
+    let prompts = calls
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|call| call.prompt.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(prompts.len(), 2);
+    assert!(prompts[1].contains("second"));
+    assert_eq!(gateway.store.lock().unwrap().last_row(), 2);
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn stop_targets_the_current_row_ahead_of_retained_failures() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("current-row-stop-sessions");
+    let assistant_dir = temp_path("current-row-stop-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let mut gateway = Gateway::new(test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    ))
+    .unwrap();
+    let thread = "imessage:self:me@icloud.com";
+    let make_job = |row_id, inbound_id, text: &str| Job {
+        row_id,
+        inbound_id,
+        thread: thread.to_string(),
+        target: "me@icloud.com".to_string(),
+        backend: AgentBackend::Codex,
+        approval_origin: AnswerOrigin {
+            channel: "imessage".to_string(),
+            thread_key: thread.to_string(),
+            sender_key: "me@icloud.com".to_string(),
+            chat_key: "me@icloud.com".to_string(),
+        },
+        text: text.to_string(),
+        reply_with_voice: false,
+        voice_attachment: None,
+    };
+    let inbound_ids = ["failed", "active", "/stop"]
+        .into_iter()
+        .enumerate()
+        .map(|(index, text)| {
+            gateway
+                .ctx
+                .history
+                .lock()
+                .unwrap()
+                .record_inbound("imessage", thread, &format!("imessage:{}", index + 1), text)
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+    let retained = make_job(1, inbound_ids[0], "failed");
+    let active = make_job(2, inbound_ids[1], "active");
+    let stop = make_job(3, inbound_ids[2], "/stop");
+    let (jobs, _jobs_rx) = mpsc::channel(QUEUE_DEPTH);
+    let (cancel, cancel_rx) = watch::channel(0);
+    gateway.queues.insert(
+        thread.to_string(),
+        WorkerQueue {
+            jobs,
+            state: Arc::new(Mutex::new(WorkerState {
+                pending: VecDeque::from([retained, active]),
+                current_row: Some(2),
+                retained_rows: BTreeSet::from([1]),
+            })),
+            cancel,
+        },
+    );
+
+    assert!(gateway.stop(stop).await);
+
+    assert_eq!(*cancel_rx.borrow(), 2);
+    assert!(gateway
+        .ctx
+        .sent_replies
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|(_, reply)| reply.contains("Stop requested")));
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn failed_stop_history_write_retries_before_later_rows() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("stop-history-failure-sessions");
+    let assistant_dir = temp_path("stop-history-failure-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let mut gateway = Gateway::new(test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    ))
+    .unwrap();
+    gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+    gateway.ctx.history.lock().unwrap().execute_batch_for_test(
+        "CREATE TRIGGER fail_stop_outbound
+         BEFORE INSERT ON messages
+         WHEN NEW.direction = 'outbound'
+          AND NEW.content = 'Nothing is currently running in this conversation.'
+         BEGIN
+           SELECT RAISE(FAIL, 'forced stop acknowledgement failure');
+         END;",
+    );
+    let batch = vec![
+        message(1, "me@icloud.com", "", true, "/stop"),
+        message(2, "me@icloud.com", "", true, "later"),
+    ];
+
+    gateway.tick_fake(batch.clone()).await;
+
+    assert!(calls.lock().unwrap().is_empty());
+    assert!(gateway.queues.is_empty());
+    assert_eq!(gateway.store.lock().unwrap().cursor("imessage"), 0);
+
+    gateway
+        .ctx
+        .history
+        .lock()
+        .unwrap()
+        .execute_batch_for_test("DROP TRIGGER fail_stop_outbound;");
+    run_messages(&mut gateway, batch).await;
+
+    assert_eq!(calls.lock().unwrap().len(), 1);
+    assert_eq!(gateway.store.lock().unwrap().last_row(), 2);
+    let replies = gateway.ctx.sent_replies.lock().unwrap();
+    let stop_reply = replies
+        .iter()
+        .position(|(_, reply)| reply.contains("Nothing is currently running in this conversation."))
+        .expect("failed stop acknowledgement should be delivered on retry");
+    let later_reply = replies
+        .iter()
+        .position(|(_, reply)| reply.contains("later"))
+        .expect("later backend reply should be delivered");
+    assert!(stop_reply < later_reply);
 
     let _ = std::fs::remove_file(&state_path);
     let _ = std::fs::remove_file(format!("{state_path}.db"));

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -2144,6 +2144,138 @@ async fn failed_stop_history_write_retries_before_later_rows() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn retried_stop_acknowledgement_does_not_cancel_the_next_request() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("stop-idempotency-sessions");
+    let assistant_dir = temp_path("stop-idempotency-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let release = Arc::new(tokio::sync::Notify::new());
+    let config = test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    );
+    let mut gateway = Gateway::new(config.clone()).unwrap();
+    let mut runners = HashMap::new();
+    runners.insert(
+        AgentBackend::Codex,
+        Runner::Fake(FakeRunner {
+            backend: AgentBackend::Codex,
+            session_id: "fake-session".to_string(),
+            calls: calls.clone(),
+            before_return: None,
+            wait_for_release: Some(release.clone()),
+            failure: None,
+            resume_missing_once: None,
+        }),
+    );
+    gateway.ctx.runners = Arc::new(runners);
+
+    gateway
+        .tick_fake(vec![message(1, "me@icloud.com", "", true, "slow")])
+        .await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while calls.lock().unwrap().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("first request should start");
+    gateway.ctx.history.lock().unwrap().execute_batch_for_test(
+        "CREATE TRIGGER fail_stop_request_outbound
+         BEFORE INSERT ON messages
+         WHEN NEW.direction = 'outbound'
+          AND NEW.content = 'Stop requested. Queued messages will continue.'
+         BEGIN
+           SELECT RAISE(FAIL, 'forced stop acknowledgement failure');
+         END;",
+    );
+
+    gateway
+        .tick_fake(vec![
+            message(2, "me@icloud.com", "", true, "queued"),
+            message(3, "me@icloud.com", "", true, "/stop"),
+        ])
+        .await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while calls.lock().unwrap().len() < 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("queued request should start after the first request is interrupted");
+    gateway
+        .ctx
+        .history
+        .lock()
+        .unwrap()
+        .execute_batch_for_test("DROP TRIGGER fail_stop_request_outbound;");
+
+    gateway.queues.clear();
+    for worker in gateway.handles.drain(..) {
+        worker.abort();
+        let _ = worker.await;
+    }
+    drop(gateway);
+
+    let restart_calls = Arc::new(Mutex::new(Vec::new()));
+    let restart_release = Arc::new(tokio::sync::Notify::new());
+    let mut restarted = Gateway::new(config).unwrap();
+    let mut restart_runners = HashMap::new();
+    restart_runners.insert(
+        AgentBackend::Codex,
+        Runner::Fake(FakeRunner {
+            backend: AgentBackend::Codex,
+            session_id: "fake-session".to_string(),
+            calls: restart_calls.clone(),
+            before_return: None,
+            wait_for_release: Some(restart_release.clone()),
+            failure: None,
+            resume_missing_once: None,
+        }),
+    );
+    restarted.ctx.runners = Arc::new(restart_runners);
+    restarted
+        .tick_fake(vec![
+            message(2, "me@icloud.com", "", true, "queued"),
+            message(3, "me@icloud.com", "", true, "/stop"),
+        ])
+        .await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while restart_calls.lock().unwrap().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("queued request should restart before the stop acknowledgement is retried");
+    restart_release.notify_one();
+    restarted.queues.clear();
+    restarted.drain_workers().await;
+
+    let replies = restarted.ctx.sent_replies.lock().unwrap();
+    assert_eq!(
+        replies
+            .iter()
+            .filter(|(_, reply)| reply.starts_with("Stopped the current request"))
+            .count(),
+        0
+    );
+    assert!(replies
+        .iter()
+        .any(|(_, reply)| reply.contains("Stop requested")));
+    assert!(replies.iter().any(|(_, reply)| reply.contains("queued")));
+    assert_eq!(restart_calls.lock().unwrap().len(), 1);
+    assert_eq!(restarted.store.lock().unwrap().last_row(), 3);
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn failed_stop_acknowledgement_does_not_block_later_messages() {
     let state_path = temp_state_path();
     let sessions_dir = temp_path("stop-delivery-failure-sessions");

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -987,6 +987,7 @@ async fn missing_backend_session_rotates_and_rehydrates_once() {
             session_id: "fake-session".to_string(),
             calls: calls.clone(),
             before_return: None,
+            wait_for_release: None,
             failure: None,
             resume_missing_once: Some(missing),
         }),
@@ -1060,6 +1061,7 @@ async fn backend_switch_and_clear_start_fresh_sessions_with_history() {
             session_id: "codex-session".to_string(),
             calls: codex_calls.clone(),
             before_return: None,
+            wait_for_release: None,
             failure: None,
             resume_missing_once: None,
         }),
@@ -1071,6 +1073,7 @@ async fn backend_switch_and_clear_start_fresh_sessions_with_history() {
             session_id: "claude-session".to_string(),
             calls: claude_calls.clone(),
             before_return: None,
+            wait_for_release: None,
             failure: None,
             resume_missing_once: None,
         }),
@@ -1696,6 +1699,227 @@ async fn slow_voice_transcription_does_not_block_another_telegram_thread() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn closed_worker_queue_is_recovered_without_another_message() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("closed-worker-sessions");
+    let assistant_dir = temp_path("closed-worker-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let mut gateway = Gateway::new(test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    ))
+    .unwrap();
+    gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+
+    let thread = "imessage:self:me@icloud.com";
+    let lost_inbound_id = gateway
+        .ctx
+        .history
+        .lock()
+        .unwrap()
+        .record_inbound("imessage", thread, "imessage:1", "recover older")
+        .unwrap();
+    gateway.ack.lock().unwrap().in_flight.insert(1);
+    let lost_job = Job {
+        row_id: 1,
+        inbound_id: lost_inbound_id,
+        thread: thread.to_string(),
+        target: "me@icloud.com".to_string(),
+        backend: AgentBackend::Codex,
+        approval_origin: AnswerOrigin {
+            channel: "imessage".to_string(),
+            thread_key: thread.to_string(),
+            sender_key: "me@icloud.com".to_string(),
+            chat_key: "me@icloud.com".to_string(),
+        },
+        text: "recover older".to_string(),
+        reply_with_voice: false,
+        voice_attachment: None,
+    };
+
+    let (jobs, rx) = mpsc::channel(QUEUE_DEPTH);
+    drop(rx);
+    let (cancel, _) = watch::channel(0);
+    gateway.queues.insert(
+        thread.to_string(),
+        WorkerQueue {
+            jobs,
+            pending: Arc::new(Mutex::new(VecDeque::from([lost_job]))),
+            cancel_generation: Arc::new(AtomicU64::new(0)),
+            cancel,
+            active: Arc::new(AtomicBool::new(false)),
+        },
+    );
+
+    gateway.process_messages(Vec::new()).await;
+    gateway.queues.clear();
+    gateway.drain_workers().await;
+
+    let prompts = calls
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|call| call.prompt.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(prompts.len(), 1);
+    assert_eq!(prompts[0], "recover older");
+    assert_eq!(gateway.store.lock().unwrap().last_row(), 1);
+    let events = audit_events(&format!("{state_path}.audit.jsonl"));
+    assert!(events
+        .iter()
+        .any(|event| event.event == "message_queue_recovered"));
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn stop_interrupts_active_run_and_preserves_queued_messages() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("interrupt-sessions");
+    let assistant_dir = temp_path("interrupt-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let release = Arc::new(tokio::sync::Notify::new());
+    let mut gateway = Gateway::new(test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    ))
+    .unwrap();
+    let mut runners = HashMap::new();
+    runners.insert(
+        AgentBackend::Codex,
+        Runner::Fake(FakeRunner {
+            backend: AgentBackend::Codex,
+            session_id: "fake-session".to_string(),
+            calls: calls.clone(),
+            before_return: None,
+            wait_for_release: Some(release.clone()),
+            failure: None,
+            resume_missing_once: None,
+        }),
+    );
+    gateway.ctx.runners = Arc::new(runners);
+
+    gateway
+        .tick_fake(vec![message(1, "me@icloud.com", "", true, "slow")])
+        .await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if gateway
+                .queues
+                .get("imessage:self:me@icloud.com")
+                .is_some_and(|worker| worker.active.load(Ordering::SeqCst))
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("first run should become active");
+
+    gateway
+        .tick_fake(vec![
+            message(2, "me@icloud.com", "", true, "queued"),
+            message(3, "me@icloud.com", "", true, "/stop"),
+        ])
+        .await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let interrupted = gateway
+                .ctx
+                .sent_replies
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(_, reply)| reply.contains("Stopped the current request"));
+            if interrupted && calls.lock().unwrap().len() == 2 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("active run should stop before the queued run starts");
+    release.notify_one();
+    gateway.queues.clear();
+    gateway.drain_workers().await;
+
+    let prompts = calls
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|call| call.prompt.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(prompts[0], "slow");
+    assert!(prompts[1].contains(r#"{"role":"user","content":"queued"}"#));
+    let replies = gateway.ctx.sent_replies.lock().unwrap();
+    assert!(replies
+        .iter()
+        .any(|(_, reply)| reply.contains("Stop requested")));
+    assert!(replies
+        .iter()
+        .any(|(_, reply)| reply.contains("Stopped the current request")));
+    assert!(replies
+        .iter()
+        .any(|(_, reply)| reply.contains(r#"{"role":"user","content":"queued"}"#)));
+    assert_eq!(gateway.store.lock().unwrap().last_row(), 3);
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn failed_stop_acknowledgement_does_not_block_later_messages() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("stop-delivery-failure-sessions");
+    let assistant_dir = temp_path("stop-delivery-failure-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let mut gateway = Gateway::new(test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    ))
+    .unwrap();
+    gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+    *gateway.ctx.send_failures_remaining.lock().unwrap() = 1;
+
+    gateway
+        .tick_fake(vec![message(1, "me@icloud.com", "", true, "/stop")])
+        .await;
+    run_messages(
+        &mut gateway,
+        vec![message(2, "me@icloud.com", "", true, "still works")],
+    )
+    .await;
+
+    assert_eq!(calls.lock().unwrap().len(), 1);
+    assert_eq!(gateway.store.lock().unwrap().last_row(), 2);
+    let events = audit_events(&format!("{state_path}.audit.jsonl"));
+    assert!(events.iter().any(|event| {
+        event.event == "reply_failed"
+            && event.error.as_deref() == Some("stop acknowledgement delivery failed")
+    }));
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn primary_delivery_is_scoped_validated_and_non_fatal_when_missing_or_invalid() {
     let state_path = temp_state_path();
     let sessions_dir = temp_path("primary-sessions");
@@ -2079,6 +2303,7 @@ async fn failed_run_and_recovered_outbound_still_reconcile_origin_drafts() {
             session_id: "failed-session".to_string(),
             calls: calls.clone(),
             before_return: Some(hook),
+            wait_for_release: None,
             failure: Some("boom".to_string()),
             resume_missing_once: None,
         }),
@@ -2272,6 +2497,7 @@ fn fake_runners_with_hook(
             session_id: "fake-session".to_string(),
             calls,
             before_return,
+            wait_for_release: None,
             failure: None,
             resume_missing_once: None,
         }),

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -1,10 +1,8 @@
 //! Per-thread worker: runs one message through an agent backend, records the
 //! outcome in canonical history, and delivers the reply.
 
-use std::collections::VecDeque;
 use std::future::{pending, Future};
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -20,7 +18,7 @@ use crate::soul;
 use crate::util::now_ms;
 use crate::voice::MAX_AUDIO_BYTES;
 
-use super::{audit, complete_row, reply_to, Ctx, Job};
+use super::{audit, complete_row, reply_to, Ctx, Job, WorkerState};
 
 const TYPING_REFRESH: Duration = Duration::from_secs(4);
 pub(super) const DELIVERY_ATTEMPTS: usize = 3;
@@ -33,29 +31,35 @@ pub(super) const DRAFT_SETUP_FAILURE: &str =
 pub(super) async fn run(
     ctx: Ctx,
     mut rx: mpsc::Receiver<Job>,
-    mut cancel: watch::Receiver<u64>,
-    active: Arc<AtomicBool>,
-    pending_jobs: Arc<std::sync::Mutex<VecDeque<Job>>>,
+    mut cancel: watch::Receiver<i64>,
+    state: Arc<std::sync::Mutex<WorkerState>>,
 ) {
     while let Some(job) = rx.recv().await {
         let row_id = job.row_id;
-        let generation = *cancel.borrow_and_update();
-        handle_with_interrupt(&ctx, job, interrupt(&mut cancel, generation), &active).await;
-        if !ctx.ack.lock().unwrap().in_flight.contains(&row_id) {
-            pending_jobs
-                .lock()
-                .unwrap()
-                .retain(|job| job.row_id != row_id);
+        {
+            let mut state = state.lock().unwrap();
+            state.current_row = Some(row_id);
+            state.retained_rows.remove(&row_id);
+        }
+        handle_with_interrupt(&ctx, job, interrupt(&mut cancel, row_id)).await;
+        let completed = !ctx.ack.lock().unwrap().in_flight.contains(&row_id);
+        let mut state = state.lock().unwrap();
+        state.current_row = None;
+        if completed {
+            state.pending.retain(|job| job.row_id != row_id);
+            state.retained_rows.remove(&row_id);
+        } else {
+            state.retained_rows.insert(row_id);
         }
     }
 }
 
 #[cfg(test)]
 pub(super) async fn handle(ctx: &Ctx, job: Job) {
-    handle_with_interrupt(ctx, job, pending(), &Arc::new(AtomicBool::new(false))).await;
+    handle_with_interrupt(ctx, job, pending()).await;
 }
 
-async fn handle_with_interrupt<I>(ctx: &Ctx, mut job: Job, interrupt: I, active: &Arc<AtomicBool>)
+async fn handle_with_interrupt<I>(ctx: &Ctx, mut job: Job, interrupt: I)
 where
     I: Future<Output = ()>,
 {
@@ -407,14 +411,12 @@ where
             run.await
         }
     };
-    let _active = ActiveRun::new(active);
     tokio::pin!(run);
     tokio::pin!(interrupt);
     let result = tokio::select! {
         result = &mut run => Some(result),
         _ = &mut interrupt => None,
     };
-    drop(_active);
 
     match result {
         Some(Ok(out)) => {
@@ -574,23 +576,8 @@ where
     }
 }
 
-struct ActiveRun<'a>(&'a AtomicBool);
-
-impl<'a> ActiveRun<'a> {
-    fn new(active: &'a AtomicBool) -> Self {
-        active.store(true, Ordering::SeqCst);
-        Self(active)
-    }
-}
-
-impl Drop for ActiveRun<'_> {
-    fn drop(&mut self) {
-        self.0.store(false, Ordering::SeqCst);
-    }
-}
-
-async fn interrupt(cancel: &mut watch::Receiver<u64>, generation: u64) {
-    while *cancel.borrow() == generation {
+async fn interrupt(cancel: &mut watch::Receiver<i64>, row_id: i64) {
+    while *cancel.borrow() != row_id {
         if cancel.changed().await.is_err() {
             pending::<()>().await;
         }

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -1,12 +1,15 @@
 //! Per-thread worker: runs one message through an agent backend, records the
 //! outcome in canonical history, and delivers the reply.
 
-use std::future::Future;
+use std::collections::VecDeque;
+use std::future::{pending, Future};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tracing::{error, info, warn};
 
 use crate::agent::{Request, RunError};
@@ -27,13 +30,35 @@ pub(super) const DRAFT_SETUP_FAILURE: &str =
     "Push could not prepare its draft workspace. Check the local logs, then resend.";
 
 /// Processes one thread's jobs strictly in order, exiting when the queue closes.
-pub(super) async fn run(ctx: Ctx, mut rx: mpsc::Receiver<Job>) {
+pub(super) async fn run(
+    ctx: Ctx,
+    mut rx: mpsc::Receiver<Job>,
+    mut cancel: watch::Receiver<u64>,
+    active: Arc<AtomicBool>,
+    pending_jobs: Arc<std::sync::Mutex<VecDeque<Job>>>,
+) {
     while let Some(job) = rx.recv().await {
-        handle(&ctx, job).await;
+        let row_id = job.row_id;
+        let generation = *cancel.borrow_and_update();
+        handle_with_interrupt(&ctx, job, interrupt(&mut cancel, generation), &active).await;
+        if !ctx.ack.lock().unwrap().in_flight.contains(&row_id) {
+            pending_jobs
+                .lock()
+                .unwrap()
+                .retain(|job| job.row_id != row_id);
+        }
     }
 }
 
-pub(super) async fn handle(ctx: &Ctx, mut job: Job) {
+#[cfg(test)]
+pub(super) async fn handle(ctx: &Ctx, job: Job) {
+    handle_with_interrupt(ctx, job, pending(), &Arc::new(AtomicBool::new(false))).await;
+}
+
+async fn handle_with_interrupt<I>(ctx: &Ctx, mut job: Job, interrupt: I, active: &Arc<AtomicBool>)
+where
+    I: Future<Output = ()>,
+{
     let existing_outbound = match ctx.history.lock().unwrap().outbound_for(job.inbound_id) {
         Ok(outbound) => outbound,
         Err(error) => {
@@ -362,27 +387,37 @@ pub(super) async fn handle(ctx: &Ctx, mut job: Job) {
         }
         result
     };
-    let result = if ctx.channel.supports_typing() {
-        let channel = ctx.channel.clone();
-        let target = job.target.clone();
-        let thread = job.thread.clone();
-        run_with_periodic_activity(run, TYPING_REFRESH, move || {
-            let channel = channel.clone();
-            let target = target.clone();
-            let thread = thread.clone();
-            async move {
-                if let Err(e) = channel.send_typing(&target).await {
-                    warn!("[{thread}] Telegram typing update failed: {e}");
+    let run = async {
+        if ctx.channel.supports_typing() {
+            let channel = ctx.channel.clone();
+            let target = job.target.clone();
+            let thread = job.thread.clone();
+            run_with_periodic_activity(run, TYPING_REFRESH, move || {
+                let channel = channel.clone();
+                let target = target.clone();
+                let thread = thread.clone();
+                async move {
+                    if let Err(e) = channel.send_typing(&target).await {
+                        warn!("[{thread}] Telegram typing update failed: {e}");
+                    }
                 }
-            }
-        })
-        .await
-    } else {
-        run.await
+            })
+            .await
+        } else {
+            run.await
+        }
     };
+    let _active = ActiveRun::new(active);
+    tokio::pin!(run);
+    tokio::pin!(interrupt);
+    let result = tokio::select! {
+        result = &mut run => Some(result),
+        _ = &mut interrupt => None,
+    };
+    drop(_active);
 
     match result {
-        Ok(out) => {
+        Some(Ok(out)) => {
             info!(
                 "[{}] {} completed; reply_chars={}",
                 job.thread,
@@ -456,7 +491,7 @@ pub(super) async fn handle(ctx: &Ctx, mut job: Job) {
                 "deliver backend reply",
             );
         }
-        Err(RunError::Timeout) => {
+        Some(Err(RunError::Timeout)) => {
             warn!("[{}] {} run timed out", job.thread, runner.label());
             audit(
                 ctx,
@@ -483,7 +518,33 @@ pub(super) async fn handle(ctx: &Ctx, mut job: Job) {
             )
             .await;
         }
-        Err(RunError::Failed(msg) | RunError::SessionMissing(msg)) => {
+        None => {
+            warn!("[{}] {} run interrupted", job.thread, runner.label());
+            audit(
+                ctx,
+                ctx.audit.failed(
+                    "backend_run_interrupted",
+                    job.row_id,
+                    &job.thread,
+                    Some(job.backend),
+                    format!("{} run interrupted by user", runner.label()),
+                ),
+            );
+            finish_run_with_gateway_reply(
+                ctx,
+                &job,
+                draft_directory.as_deref(),
+                "Stopped the current request.",
+                ReplyLabels {
+                    record: "record interrupted reply",
+                    present: "present interrupted run drafts",
+                    deliver: "deliver interrupted reply",
+                    completion: "interrupted",
+                },
+            )
+            .await;
+        }
+        Some(Err(RunError::Failed(msg) | RunError::SessionMissing(msg))) => {
             error!("[{}] {} error: {msg}", job.thread, runner.label());
             audit(
                 ctx,
@@ -509,6 +570,29 @@ pub(super) async fn handle(ctx: &Ctx, mut job: Job) {
                 },
             )
             .await;
+        }
+    }
+}
+
+struct ActiveRun<'a>(&'a AtomicBool);
+
+impl<'a> ActiveRun<'a> {
+    fn new(active: &'a AtomicBool) -> Self {
+        active.store(true, Ordering::SeqCst);
+        Self(active)
+    }
+}
+
+impl Drop for ActiveRun<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+}
+
+async fn interrupt(cancel: &mut watch::Receiver<u64>, generation: u64) {
+    while *cancel.borrow() == generation {
+        if cancel.changed().await.is_err() {
+            pending::<()>().await;
         }
     }
 }
@@ -810,9 +894,10 @@ fn command(ctx: &Ctx, job: &Job) -> Option<String> {
             Ok(()) => Some("Started a fresh conversation.".to_string()),
             Err(_) => Some("Couldn't reset the conversation.".to_string()),
         },
-        "/help" => {
-            Some("Commands:\n/clear - start a fresh conversation\n/help - this message".to_string())
-        }
+        "/help" => Some(
+            "Commands:\n/clear - start a fresh conversation\n/stop - stop the active request\n/help - this message"
+                .to_string(),
+        ),
         _ => None,
     }
 }
@@ -836,6 +921,35 @@ pub(super) async fn record_and_deliver(
         text,
     )?;
     deliver_stored(ctx, job, &outbound).await
+}
+
+/// Records an outbound reply and tries delivery once. Control-path replies use
+/// this so a channel outage cannot block the polling loop indefinitely.
+pub(super) async fn record_and_deliver_once(
+    ctx: &Ctx,
+    job: &Job,
+    origin: OutboundOrigin,
+    text: &str,
+) -> Result<bool> {
+    let outbound = ctx.history.lock().unwrap().record_outbound(
+        job.inbound_id,
+        origin,
+        Some(job.backend.as_str()),
+        text,
+    )?;
+    if outbound.status == DeliveryStatus::Delivered {
+        return Ok(true);
+    }
+    let delivered = reply_to(ctx, &job.target, &outbound.content).await;
+    ctx.history.lock().unwrap().mark_delivery(
+        outbound.id,
+        if delivered {
+            DeliveryStatus::Delivered
+        } else {
+            DeliveryStatus::Failed
+        },
+    )?;
+    Ok(delivered)
 }
 
 async fn deliver_stored(

--- a/src/history.rs
+++ b/src/history.rs
@@ -13,7 +13,7 @@ use crate::approval::{
     NormalizedAnswer, Question,
 };
 
-const SCHEMA_VERSION: i64 = 7;
+const SCHEMA_VERSION: i64 = 8;
 const MAX_HISTORY_READ_BYTES: usize = 8 * 1024;
 const READ_TRUNCATED: &str = "\n[truncated by push while reading history]";
 
@@ -184,6 +184,37 @@ impl History {
         tx.commit()
             .with_context(|| format!("commit outbound message to {database_path}"))?;
         Ok(message)
+    }
+
+    pub fn record_stop_target(
+        &mut self,
+        inbound_id: i64,
+        target_row_id: Option<i64>,
+    ) -> Result<Option<i64>> {
+        let database_path = self.path.display().to_string();
+        let tx = self
+            .conn
+            .transaction()
+            .with_context(|| format!("begin stop target transaction in {database_path}"))?;
+        tx.execute(
+            "INSERT INTO gateway_control_actions (inbound_id, action, target_row_id)
+             VALUES (?1, 'stop', ?2)
+             ON CONFLICT(inbound_id) DO NOTHING",
+            params![inbound_id, target_row_id],
+        )
+        .with_context(|| format!("insert stop target into {database_path}"))?;
+        let target_row_id = tx
+            .query_row(
+                "SELECT target_row_id
+                 FROM gateway_control_actions
+                 WHERE inbound_id = ?1 AND action = 'stop'",
+                [inbound_id],
+                |row| row.get(0),
+            )
+            .with_context(|| format!("read stop target from {database_path}"))?;
+        tx.commit()
+            .with_context(|| format!("commit stop target to {database_path}"))?;
+        Ok(target_row_id)
     }
 
     pub fn replace_inbound_content(&mut self, inbound_id: i64, content: &str) -> Result<()> {
@@ -935,6 +966,17 @@ fn migrate(conn: &Connection) -> Result<()> {
              PRAGMA user_version = 7;",
         )?;
     }
+    if version <= 7 {
+        conn.execute_batch(
+            "CREATE TABLE gateway_control_actions (
+                 inbound_id INTEGER PRIMARY KEY REFERENCES messages(id),
+                 action TEXT NOT NULL CHECK(action = 'stop'),
+                 target_row_id INTEGER,
+                 created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+             );
+             PRAGMA user_version = 8;",
+        )?;
+    }
     conn.execute_batch("COMMIT;")?;
     Ok(())
 }
@@ -1051,7 +1093,7 @@ mod tests {
             .record_inbound("imessage", "imessage:self:me", "imessage:1", "hello")
             .unwrap();
         history.execute_batch_for_test(
-            "DROP TABLE job_draft_proposals; DROP TABLE job_runs; DROP TABLE approval_questions; PRAGMA user_version = 1;",
+            "DROP TABLE gateway_control_actions; DROP TABLE job_draft_proposals; DROP TABLE job_runs; DROP TABLE approval_questions; PRAGMA user_version = 1;",
         );
         drop(history);
 
@@ -1076,7 +1118,7 @@ mod tests {
         let question = question(2_000);
         history.create_question(&question, 1_000).unwrap();
         history.execute_batch_for_test(
-            "DROP TABLE job_draft_proposals; DROP TABLE job_runs; PRAGMA user_version = 2;",
+            "DROP TABLE gateway_control_actions; DROP TABLE job_draft_proposals; DROP TABLE job_runs; PRAGMA user_version = 2;",
         );
         drop(history);
 
@@ -1133,6 +1175,7 @@ mod tests {
              ALTER TABLE job_runs DROP COLUMN evaluation_error;
              ALTER TABLE job_runs DROP COLUMN evaluation_result;
              ALTER TABLE job_runs DROP COLUMN evaluation_state;
+             DROP TABLE gateway_control_actions;
              PRAGMA user_version = 6;",
         );
         drop(history);


### PR DESCRIPTION
## Summary

- add /stop to interrupt the active backend run while preserving queued messages
- retain and replay active and buffered jobs when a per-thread worker exits
- autonomously recover closed workers on each polling cycle
- keep stop and queue-full delivery failures from blocking the channel poll loop

## Why

Telegram appeared stuck while a long backend run held the per-conversation worker and later messages waited silently. Closed worker senders were also treated as successful enqueues, which could strand in-flight rows and block cursor progress.

## Test plan

- cargo test: 267 unit tests, 10 init CLI tests, and 3 crash-recovery tests passed
- cargo clippy --all-targets -- -D warnings
- git diff --check
- subagent diff review: no remaining actionable findings

## Risks

Cancellation drops the active backend future. The Claude, Codex, and Pi subprocess commands already use kill-on-drop. Interrupted new sessions recover through canonical-history rehydration before the next queued message.

## Related issue

None.