### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "push"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "push"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 description = "A tiny messaging gateway that turns coding agents into a personal assistant you text."

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,15 @@
+# Push v0.7.0
+
+- Render Markdown as Telegram HTML for chat and scheduled-job output, with safe
+  plain-text fallback when Telegram rejects formatting.
+- Add reusable agent evaluations for scheduled jobs and persist evaluation,
+  execution, and delivery state separately.
+- Add `help`, `reload`, `restart`, and `version` commands, including `--help`
+  and `--version` flags that work without loading configuration.
+- Recover stalled message queues, support `/stop`, and harden scheduled delivery
+  with durable chunk progress, bounded retries, and impossible-cron validation.
+- Add configurable voice credentials and voices. Removed runtime settings now
+  fail with migration guidance, backend commands resolve from `PATH`, and
+  Telegram environment credentials use `TELEGRAM_BOT_TOKEN`.
+
+**Full changelog:** https://github.com/owainlewis/push/compare/v0.6.0...v0.7.0


### PR DESCRIPTION
## Summary

- bump the crate and lockfile package version to 0.7.0
- add concise curated release notes for changes since v0.6.0
- keep tagging, publication, and release workflow changes out of this preparation PR

## Why

Prepare the tested main branch for the v0.7.0 release. The existing workflow and installer asset naming were verified against the current repository and v0.6.0 assets.

After merge, the coordinator will create v0.7.0 using the merged RELEASE_NOTES.md as the GitHub release body, then verify the published assets. The workflow intentionally remains unchanged.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` (321 tests passed)
- `cargo build --locked --release`
- `bash tests/install.sh`
- `mkdocs build --strict`
- `cargo metadata --locked --no-deps --format-version 1` reports 0.7.0
- `cargo run --locked --quiet -- --version` prints `push 0.7.0`
- fresh subagent diff review and re-review: no remaining findings

## Risks

Low. This PR changes version metadata and release notes only. The release workflow auto-generates notes, so the coordinator must apply RELEASE_NOTES.md as the release body during the documented post-merge release step.

## Related issue

Closes #119.