### PR TITLE
fix(gateway): resume Telegram delivery chunks

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1004,37 +1004,55 @@ fn audit(ctx: &Ctx, event: AuditEvent) {
 
 async fn reply_to(ctx: &Ctx, target: &str, text: &str) -> bool {
     let chunks = ctx.channel.outbound_chunks(text, &ctx.reply_marker);
-    #[cfg(test)]
-    {
-        let mut failures = ctx.send_failures_remaining.lock().unwrap();
-        if *failures > 0 {
-            *failures -= 1;
+    for chunk in chunks {
+        if let Err(error) = send_reply_chunk(ctx, target, &chunk).await {
+            error!("send error to {target}: {error}");
             return false;
         }
-        drop(failures);
-        ctx.sent_replies.lock().unwrap().extend(
-            chunks
-                .into_iter()
-                .map(|chunk| (target.to_string(), chunk.text)),
-        );
-        true
     }
-    #[cfg(not(test))]
+    true
+}
+
+async fn send_reply_chunk(
+    ctx: &Ctx,
+    target: &str,
+    chunk: &crate::channel::OutboundChunk,
+) -> Result<()> {
+    #[cfg(test)]
     {
-        for chunk in chunks {
-            match tokio::time::timeout(SEND_TIMEOUT, ctx.channel.send_chunk(target, &chunk)).await {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => {
-                    error!("send error to {target}: {e}");
-                    return false;
-                }
-                Err(_) => {
-                    error!("send to {target} timed out");
-                    return false;
+        let should_fail = {
+            let mut failures = ctx.send_failures_remaining.lock().unwrap();
+            if *failures > 0 {
+                *failures -= 1;
+                true
+            } else {
+                let mut after = ctx.send_failure_after.lock().unwrap();
+                match after.as_mut() {
+                    Some(remaining) if *remaining == 0 => {
+                        *after = None;
+                        true
+                    }
+                    Some(remaining) => {
+                        *remaining -= 1;
+                        false
+                    }
+                    None => false,
                 }
             }
+        };
+        if should_fail {
+            anyhow::bail!("send failed");
         }
-        true
+        ctx.sent_replies
+            .lock()
+            .unwrap()
+            .push((target.to_string(), chunk.text.clone()));
+        Ok(())
+    }
+    #[cfg(not(test))]
+    match tokio::time::timeout(SEND_TIMEOUT, ctx.channel.send_chunk(target, chunk)).await {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!("send timed out"),
     }
 }
 
@@ -1069,44 +1087,7 @@ async fn send_scheduled_chunk(
     target: &str,
     chunk: &crate::channel::OutboundChunk,
 ) -> Result<()> {
-    #[cfg(test)]
-    {
-        let should_fail = {
-            let mut failures = ctx.send_failures_remaining.lock().unwrap();
-            if *failures > 0 {
-                *failures -= 1;
-                true
-            } else {
-                let mut after = ctx.send_failure_after.lock().unwrap();
-                match after.as_mut() {
-                    Some(remaining) if *remaining == 0 => {
-                        *after = None;
-                        true
-                    }
-                    Some(remaining) => {
-                        *remaining -= 1;
-                        false
-                    }
-                    None => false,
-                }
-            }
-        };
-        if should_fail {
-            anyhow::bail!("scheduled send failed");
-        }
-        ctx.sent_replies
-            .lock()
-            .unwrap()
-            .push((target.to_string(), chunk.text.clone()));
-        Ok(())
-    }
-    #[cfg(not(test))]
-    {
-        match tokio::time::timeout(SEND_TIMEOUT, ctx.channel.send_chunk(target, chunk)).await {
-            Ok(result) => result,
-            Err(_) => anyhow::bail!("send timed out"),
-        }
-    }
+    send_reply_chunk(ctx, target, chunk).await
 }
 
 fn complete_row(store: &Arc<Mutex<Store>>, ack: &Arc<Mutex<AckState>>, channel: &str, row_id: i64) {

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -2440,6 +2440,51 @@ async fn scheduled_telegram_retry_resumes_at_the_first_unsent_rich_chunk() {
     let _ = std::fs::remove_dir_all(assistant_dir);
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn ordinary_telegram_retry_resumes_at_the_first_unsent_chunk() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("ordinary-rich-retry-sessions");
+    let assistant_dir = temp_path("ordinary-rich-retry-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let mut cfg = test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    );
+    cfg.channel = "telegram".to_string();
+    cfg.self_handles.clear();
+    cfg.allow_from.clear();
+    cfg.telegram_bot_token = Some("secret".to_string());
+    cfg.telegram_allow_user_ids = vec![7];
+    let mut gateway = Gateway::new(cfg).unwrap();
+    gateway.ctx.runners = Arc::new(fake_runners(Arc::new(Mutex::new(Vec::new()))));
+    *gateway.ctx.send_failure_after.lock().unwrap() = Some(1);
+    let prompt = "x".repeat(crate::telegram::TEXT_LIMIT + 1);
+    let expected = crate::telegram::split_text(&format!("fake reply: {prompt}"));
+
+    gateway
+        .tick_fake(vec![telegram_message(1, 7, 7, false, &prompt)])
+        .await;
+    gateway.queues.clear();
+    gateway.drain_workers().await;
+
+    let delivered = gateway
+        .ctx
+        .sent_replies
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|(_, text)| text.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(delivered, expected);
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
 #[tokio::test]
 async fn missing_primary_disables_new_schedules_without_stopping_gateway() {
     let state_path = temp_state_path();

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -918,7 +918,7 @@ pub(super) async fn record_and_deliver_once(
     origin: OutboundOrigin,
     text: &str,
 ) -> Result<bool> {
-    let outbound = ctx.history.lock().unwrap().record_outbound(
+    let mut outbound = ctx.history.lock().unwrap().record_outbound(
         job.inbound_id,
         origin,
         Some(job.backend.as_str()),
@@ -927,7 +927,7 @@ pub(super) async fn record_and_deliver_once(
     if outbound.status == DeliveryStatus::Delivered {
         return Ok(true);
     }
-    let delivered = reply_to(ctx, &job.target, &outbound.content).await;
+    let delivered = deliver_outbound_once(ctx, &job.target, &mut outbound).await?;
     ctx.history.lock().unwrap().mark_delivery(
         outbound.id,
         if delivered {
@@ -947,10 +947,11 @@ async fn deliver_stored(
     if outbound.status == DeliveryStatus::Delivered {
         return Ok(DeliveryOutcome::AlreadyDelivered);
     }
+    let mut outbound = outbound.clone();
     let mut attempt = 0;
     loop {
         attempt += 1;
-        let delivered = reply_to(ctx, &job.target, &outbound.content).await;
+        let delivered = deliver_outbound_once(ctx, &job.target, &mut outbound).await?;
         let status = if delivered {
             DeliveryStatus::Delivered
         } else {
@@ -989,6 +990,44 @@ async fn deliver_stored(
         #[cfg(test)]
         tokio::task::yield_now().await;
     }
+}
+
+async fn deliver_outbound_once(
+    ctx: &Ctx,
+    target: &str,
+    outbound: &mut OutboundMessage,
+) -> Result<bool> {
+    let chunks = ctx
+        .channel
+        .outbound_chunks(&outbound.content, &ctx.reply_marker);
+    if outbound.delivery_chunk_index > chunks.len() {
+        anyhow::bail!(
+            "outbound {} has invalid delivery chunk index {} for {} chunks",
+            outbound.id,
+            outbound.delivery_chunk_index,
+            chunks.len()
+        );
+    }
+    for (index, chunk) in chunks
+        .iter()
+        .enumerate()
+        .skip(outbound.delivery_chunk_index)
+    {
+        if let Err(error) = super::send_reply_chunk(ctx, target, chunk).await {
+            error!(
+                "outbound {} chunk {index} send error to {target}: {error}",
+                outbound.id
+            );
+            return Ok(false);
+        }
+        let next_chunk = index + 1;
+        ctx.history
+            .lock()
+            .unwrap()
+            .checkpoint_delivery(outbound.id, next_chunk)?;
+        outbound.delivery_chunk_index = next_chunk;
+    }
+    Ok(true)
 }
 
 async fn deliver_voice_reply(ctx: &Ctx, job: &Job, text: &str) {

--- a/src/history.rs
+++ b/src/history.rs
@@ -13,7 +13,7 @@ use crate::approval::{
     NormalizedAnswer, Question,
 };
 
-const SCHEMA_VERSION: i64 = 8;
+const SCHEMA_VERSION: i64 = 9;
 const MAX_HISTORY_READ_BYTES: usize = 8 * 1024;
 const READ_TRUNCATED: &str = "\n[truncated by push while reading history]";
 
@@ -63,6 +63,7 @@ pub struct OutboundMessage {
     pub id: i64,
     pub content: String,
     pub status: DeliveryStatus,
+    pub delivery_chunk_index: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -259,6 +260,24 @@ impl History {
             .with_context(|| {
                 format!("update outbound delivery status in {}", self.path.display())
             })?;
+        if changed != 1 {
+            bail!("outbound message {message_id} does not exist");
+        }
+        Ok(())
+    }
+
+    pub fn checkpoint_delivery(&mut self, message_id: i64, next_chunk: usize) -> Result<()> {
+        let next_chunk = i64::try_from(next_chunk).context("delivery chunk index is too large")?;
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE messages
+                 SET delivery_chunk_index = MAX(delivery_chunk_index, ?2),
+                     updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                 WHERE id = ?1 AND direction = 'outbound'",
+                params![message_id, next_chunk],
+            )
+            .with_context(|| format!("checkpoint outbound delivery in {}", self.path.display()))?;
         if changed != 1 {
             bail!("outbound message {message_id} does not exist");
         }
@@ -977,6 +996,13 @@ fn migrate(conn: &Connection) -> Result<()> {
              PRAGMA user_version = 8;",
         )?;
     }
+    if version <= 8 {
+        conn.execute_batch(
+            "ALTER TABLE messages ADD COLUMN delivery_chunk_index INTEGER NOT NULL DEFAULT 0
+                 CHECK(delivery_chunk_index >= 0);
+             PRAGMA user_version = 9;",
+        )?;
+    }
     conn.execute_batch("COMMIT;")?;
     Ok(())
 }
@@ -1011,20 +1037,22 @@ fn conversation(tx: &Transaction<'_>, channel: &str, thread_key: &str) -> Result
 
 fn outbound_for_query(conn: &Connection, inbound_id: i64) -> Result<Option<OutboundMessage>> {
     conn.query_row(
-        "SELECT id, content, delivery_status
+        "SELECT id, content, delivery_status, delivery_chunk_index
              FROM messages WHERE in_reply_to_id = ?1",
         [inbound_id],
         |row| {
             let status: String = row.get(2)?;
-            Ok((row.get(0)?, row.get(1)?, status))
+            Ok((row.get(0)?, row.get(1)?, status, row.get::<_, i64>(3)?))
         },
     )
     .optional()?
-    .map(|(id, content, status)| {
+    .map(|(id, content, status, delivery_chunk_index)| {
         Ok(OutboundMessage {
             id,
             content,
             status: DeliveryStatus::parse(&status)?,
+            delivery_chunk_index: usize::try_from(delivery_chunk_index)
+                .context("stored delivery chunk index is negative")?,
         })
     })
     .transpose()
@@ -1086,6 +1114,55 @@ mod tests {
     }
 
     #[test]
+    fn migrates_v8_messages_with_delivery_chunk_progress() {
+        let path = temp_path("message-delivery-v8-migration");
+        let history = History::open(path.to_str().unwrap()).unwrap();
+        history.execute_batch_for_test(
+            "ALTER TABLE messages DROP COLUMN delivery_chunk_index; PRAGMA user_version = 8;",
+        );
+        drop(history);
+
+        let reopened = History::open(path.to_str().unwrap()).unwrap();
+        let chunk_column: i64 = reopened
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('messages')
+                 WHERE name = 'delivery_chunk_index'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(chunk_column, 1);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn outbound_delivery_chunk_progress_survives_reopen() {
+        let path = temp_path("outbound-delivery-progress");
+        let mut history = History::open(path.to_str().unwrap()).unwrap();
+        let inbound = history
+            .record_inbound("telegram", "telegram:dm:7", "telegram:1", "hello")
+            .unwrap();
+        let outbound = history
+            .record_outbound(inbound, OutboundOrigin::Backend, Some("codex"), "reply")
+            .unwrap();
+        history.checkpoint_delivery(outbound.id, 1).unwrap();
+        history.checkpoint_delivery(outbound.id, 0).unwrap();
+        drop(history);
+
+        let reopened = History::open(path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            reopened
+                .outbound_for(inbound)
+                .unwrap()
+                .unwrap()
+                .delivery_chunk_index,
+            1
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn migrates_v1_history_database_without_losing_messages() {
         let path = temp_path("approval-v1-migration");
         let mut history = History::open(path.to_str().unwrap()).unwrap();
@@ -1093,7 +1170,12 @@ mod tests {
             .record_inbound("imessage", "imessage:self:me", "imessage:1", "hello")
             .unwrap();
         history.execute_batch_for_test(
-            "DROP TABLE gateway_control_actions; DROP TABLE job_draft_proposals; DROP TABLE job_runs; DROP TABLE approval_questions; PRAGMA user_version = 1;",
+            "DROP TABLE gateway_control_actions;
+             DROP TABLE job_draft_proposals;
+             DROP TABLE job_runs;
+             DROP TABLE approval_questions;
+             ALTER TABLE messages DROP COLUMN delivery_chunk_index;
+             PRAGMA user_version = 1;",
         );
         drop(history);
 
@@ -1118,7 +1200,11 @@ mod tests {
         let question = question(2_000);
         history.create_question(&question, 1_000).unwrap();
         history.execute_batch_for_test(
-            "DROP TABLE gateway_control_actions; DROP TABLE job_draft_proposals; DROP TABLE job_runs; PRAGMA user_version = 2;",
+            "DROP TABLE gateway_control_actions;
+             DROP TABLE job_draft_proposals;
+             DROP TABLE job_runs;
+             ALTER TABLE messages DROP COLUMN delivery_chunk_index;
+             PRAGMA user_version = 2;",
         );
         drop(history);
 
@@ -1176,6 +1262,7 @@ mod tests {
              ALTER TABLE job_runs DROP COLUMN evaluation_result;
              ALTER TABLE job_runs DROP COLUMN evaluation_state;
              DROP TABLE gateway_control_actions;
+             ALTER TABLE messages DROP COLUMN delivery_chunk_index;
              PRAGMA user_version = 6;",
         );
         drop(history);


### PR DESCRIPTION
## Summary

- persist the next ordinary outbound delivery chunk in canonical history
- resume Telegram retries from the first unsent chunk instead of replaying accepted chunks
- add v8-to-v9 migration and regression coverage for retry and persisted progress

## Why

A reproduced two-chunk Telegram delivery accepted chunk 0, failed chunk 1, then retried as `[chunk0, chunk0, chunk1]`. Whole-message delivery status had no durable chunk checkpoint. This change records progress after each accepted chunk and resumes from it.

Out-of-scope audit findings are tracked in #125, #126, #127, and #128.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` (324 tests passed)
- `cargo build --locked --release`
- focused retry and schema migration regressions

Fresh-agent review found one diagnostic regression in the initial diff. The send error detail was restored, and affected checks were rerun. No other actionable findings remained.

## Risks

The conversation database schema advances from v8 to v9. Migration and reopen behavior are covered by tests. Delivery cannot provide strict exactly-once semantics if the process dies between remote acceptance and the local checkpoint, but retries no longer replay chunks after a successfully persisted checkpoint.

## Related issue

Closes #121