### PR TITLE
docs: audit shipped guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Push keeps conversations, run history, schedules, and delivery routes durable.
   [Pi](https://pi.dev/) installed, authenticated, and runnable by the user that
   will run Push
 - Git for the assistant repository created by `push init`
-- `curl` and `tar` for the release installer
+- `curl`, `tar`, and either `shasum` or `sha256sum` for the release installer
 
 First confirm that your chosen backend works. For example:
 
@@ -146,6 +146,7 @@ Chat commands:
 | Message | Effect |
 | --- | --- |
 | `/clear`, `/new`, `/reset` | Start a fresh backend session for this conversation |
+| `/stop` | Stop the active request; queued messages continue in order |
 | `/help` | Show available chat commands |
 
 Jobs are Markdown runbooks stored in the assistant repository. Common commands

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,6 +85,7 @@ flowchart LR
     sender -->|osascript| db
     sender -->|sendMessage| tg
     db -->|reply| user
+    tg -->|reply| user
 ```
 
 ## Message Lifecycle
@@ -92,19 +93,20 @@ flowchart LR
 ```mermaid
 sequenceDiagram
     participant U as User
-    participant DB as chat.db
+    participant C as iMessage or Telegram
     participant P as Poller
     participant G as Gateway
     participant W as Worker
+    participant H as push.db
     participant A as Agent backend
     participant S as Sender
 
-    U->>DB: send message
-    P->>DB: read rows newer than last_row_id
-    DB-->>P: messages
+    U->>C: send message
+    P->>C: poll after channel cursor
+    C-->>P: messages
     P->>G: Message values
-    G->>G: filter sender and reply marker
-    G->>G: persist accepted inbound message
+    G->>G: apply channel allowlist and filters
+    G->>H: persist accepted inbound message
     alt slash command
         G->>S: handle command locally
     else assistant turn
@@ -116,12 +118,12 @@ sequenceDiagram
         end
         W->>A: run new message or rehydrated prompt
         A-->>W: reply and optional backend session id
-        W->>W: persist generated outbound message
+        W->>H: persist generated outbound message
         W->>S: send reply
         W->>G: ack completed row
     end
-    S->>DB: osascript send
-    DB->>U: delivered reply
+    S->>C: send through channel adapter
+    C->>U: delivered reply
 ```
 
 ## Backend Boundary
@@ -257,7 +259,7 @@ limit bounds fresh-session job execution. Scheduled and manual processes share
 the per-job advisory lock and SQLite active-run uniqueness boundary.
 
 Scheduled output or bounded failure detail is committed before notification.
-Delivery has its own persisted state and is retried up to three times from that
+Delivery has its own persisted state and is retried up to five times from that
 stored result. Restart recovery resumes queued work and pending delivery, but
 never reruns a backend run that had already started. A running row is marked
 interrupted only after the released advisory lock proves its executor is gone.
@@ -359,9 +361,10 @@ Push does not override sandbox, approval, permission-mode, or tool-list settings
 Chats and jobs use the selected agent's own configuration and must use work
 directories that do not overlap Push-owned state or configuration.
 
-## Extension Points
+## Roadmap
 
-The next extension points should be added in this order:
+The following items are possible future work, not shipped behavior or release
+commitments:
 
 1. More agent adapters.
 2. More channels.

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -52,7 +52,7 @@ can ask the agent to use any capability allowed by that agent's configuration.
 - tapbacks and Messages system rows
 - blank messages
 - messages from handles outside the allowlist
-- Push's own replies containing the configured marker
+- Push's own replies containing the built-in Push reply marker
 
 The channel expects a recent macOS Messages schema. `push doctor` and runtime
 logs report database access or query failures rather than silently accepting
@@ -72,6 +72,10 @@ agent = "claude"
 See [configuration](../configuration.md#routing) for route precedence.
 
 ## Restart behavior
+
+On the first iMessage start, Push records the newest existing Messages row
+without running it. Send a new message after the gateway starts. Later starts
+continue after the last completed row stored in `state.json`.
 
 Push stores the last completed Messages row in `state.json` and accepted
 conversation turns in `push.db`. It advances the cursor only after a row is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,6 +181,39 @@ the selected agent and review [permissions and security](security.md).
 | `poll_interval` | `"3s"` | Delay between channel polls |
 | `run_timeout` | `"10m"` | Maximum chat backend run time |
 
+### iMessage
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `imessage.db_path` | `~/Library/Messages/chat.db` | Messages database read by the macOS channel |
+| `imessage.self_handles` | `[]` | Own handles accepted in one-to-one self chats |
+| `imessage.allow_from` | `[]` | Other trusted one-to-one sender handles |
+
+### Telegram
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `telegram.bot_token` | `TELEGRAM_BOT_TOKEN` fallback | Private Bot API token; the environment value is used when this is omitted |
+| `telegram.allow_user_ids` | `[]` | Trusted numeric sender IDs |
+| `telegram.allow_chat_ids` | `[]` | Trusted numeric private-chat IDs |
+
+### Voice
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `voice.openai_api_key` | `OPENAI_API_KEY` fallback | Optional key for Telegram transcription and spoken replies; the environment value has priority |
+| `voice.name` | `"cedar"` | OpenAI voice used for spoken replies |
+
+### Delivery and routes
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `primary_delivery.channel` | none | Enabled channel used for scheduled job results |
+| `primary_delivery.target` | none | Allowlisted destination on the primary channel |
+| `routes[].thread` | none | Exact channel-qualified thread key to match |
+| `routes[].channel` | none | Enabled provider to match when no exact thread route wins |
+| `routes[].agent` | required per route | Backend selected by the matching route |
+
 ### Local state
 
 | Setting | Default | Purpose |

--- a/docs/core-system/design.md
+++ b/docs/core-system/design.md
@@ -1,6 +1,11 @@
 # Core Assistant System
 
-**Status:** Approved
+**Status:** Historical approved design, substantially implemented
+
+!!! warning "Historical record"
+
+    This file preserves the approved design and rollout sequence. It is not a
+    current roadmap. See [Architecture](../architecture.md) for shipped behavior.
 
 **Author:** Owain Lewis  **Date:** 2026-07-11
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,8 @@ You need:
 - macOS for iMessage, or macOS/Linux for Telegram
 - Claude Code, Codex, or Pi installed, authenticated, and runnable by the same
   user that will run Push
-- `curl` and `tar` for the release installer
+- Git for the assistant repository created by `push init`
+- `curl`, `tar`, and either `shasum` or `sha256sum` for the release installer
 
 Push uses the backend's existing login, settings, tools, MCP servers, skills,
 and backend configuration. Each chat runs from `assistant_root`, so the backend
@@ -63,6 +64,7 @@ Use this path on other Rust-supported architectures or when testing `main`:
 git clone https://github.com/owainlewis/push.git
 cd push
 cargo build --locked --release
+mkdir -p ~/.local/bin
 install -m 755 target/release/push ~/.local/bin/push
 ```
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -47,7 +47,7 @@ Frontmatter fields:
 | `triggers` | no | One or more cron trigger tables |
 
 Unknown fields are errors. A job work directory may not overlap the assistant
-root, Push config, sessions, state, database, audit, drafts, or lock paths.
+root, loaded Push config, state, database, audit log, drafts, or job lock paths.
 
 ## Validate and inspect jobs
 

--- a/docs/jobs/design.md
+++ b/docs/jobs/design.md
@@ -1,6 +1,12 @@
 # Jobs as Runbooks with Separate Triggers
 
-**Status:** Draft
+**Status:** Historical design, implemented and superseded by the current jobs guide
+
+!!! warning "Historical record"
+
+    This file preserves the design proposal and rollout plan. It is not the
+    current jobs documentation or roadmap. See [Jobs and schedules](../jobs.md)
+    for shipped behavior.
 
 **Author:** Owain Lewis  **Date:** 2026-07-12
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,5 +1,15 @@
 # Push v1 PRD
 
+**Status:** Historical product plan, superseded by the current documentation
+
+!!! warning "Historical record"
+
+    This file preserves the original v1 scope and is not a description of the
+    current product or roadmap. Telegram, scheduled jobs, proactive delivery,
+    and release installation have shipped since it was written. Use the
+    [documentation home](index.md) for current behavior and
+    [strategy](strategy.md#roadmap) for possible future work.
+
 ## Summary
 
 Push is a small Rust binary that turns coding-agent runtimes into a personal
@@ -83,7 +93,7 @@ Push takes a narrower bet:
 
 - `src/imessage/poller.rs`: reads Messages rows.
 - `src/imessage/sender.rs`: sends replies through AppleScript.
-- `src/gateway.rs`: poll loop, filtering, commands, queues, worker dispatch.
+- `src/gateway/`: poll loop, filtering, commands, queues, worker dispatch.
 - `src/history.rs`: canonical SQLite conversations and messages.
 - `src/jobs.rs`: validated runbooks, advisory locking, manual execution, and run ledger.
 - `src/assistant.rs`: safe assistant repository scaffolding and root persistence.
@@ -193,9 +203,11 @@ user prompt.
 - Permissive agent settings are powerful local execution modes.
 - iMessage database shape can change across macOS versions.
 
-## Next Scope
+## Original Next Scope
 
-1. A second message channel.
+These items record the plan at the time and are not the current roadmap:
+
+1. A second message channel, completed by Telegram support.
 2. Audited memory write-back.
 3. Richer routing rules, such as task-type routing.
 4. Homebrew formula after the release flow is proven.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,7 +33,9 @@ push job runs repo-review
 ```
 
 Unknown commands and missing values fail with the accepted command forms. The
-CLI does not currently provide shell completion.
+CLI does not currently provide shell completion or separate help pages for
+subcommands. A `--help` flag anywhere in the argument list prints the global
+help shown by `push --help`.
 
 `push reload` and its `push restart` alias target the service definitions documented by Push:
 `com.owainlewis.push` under launchd on macOS and the `push.service` user unit

--- a/docs/services.md
+++ b/docs/services.md
@@ -23,6 +23,7 @@ Use absolute paths in service files. The service user needs:
 - write access to `state_path`
 - write access to `audit_log_path`
 - write access to `database_path`
+- write access to `drafts_dir` and `jobs_run_dir`
 - filesystem access to `assistant_root` as allowed by the selected agent
 - write access to `assistant_root/jobs/` for Push to install approved drafts;
   agent write access can also change installed jobs outside that workflow

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -1,5 +1,12 @@
 # Push Strategy
 
+!!! info "Strategy and shipped behavior"
+
+    This page describes durable product choices and possible future work. It is
+    not a list of shipped features. See the [documentation home](index.md) for
+    current behavior and the [GitHub releases](https://github.com/owainlewis/push/releases)
+    for released versions.
+
 ## The Bet
 
 The agent runtime is becoming the commodity layer.
@@ -137,23 +144,22 @@ This means Push can be smaller and more durable:
 - When another agent becomes better, Push can add an adapter instead of
   rewriting the product.
 
-## Current Direction
+## Durable Direction
 
 Lock in these choices:
 
-- Keep iMessage as the first channel, not the whole product.
-- Keep markdown memory as the first memory model.
-- Support multiple runtimes early so the architecture does not harden around
-  one agent.
+- Keep messaging channels replaceable and channel state isolated.
+- Keep Markdown as the first user-owned context model.
+- Keep multiple runtimes behind a narrow backend contract.
 - Avoid a plugin system in the gateway.
 - Avoid a custom agent loop.
 - Treat runtime config as adapter-specific.
 - Keep the core gateway state backend-neutral.
 
-## Next Actions
+## Roadmap
 
-1. Add a second channel after the backend seam has settled.
-2. Add memory write-back only with an audit trail and explicit user review.
-3. Add richer runtime routing, such as task-type routing.
-4. Publish and test the first binary release.
-5. Add a Homebrew formula after release assets are stable.
+These are possible future additions, not shipped behavior or commitments:
+
+1. Add memory write-back only with an audit trail and explicit user review.
+2. Add richer runtime routing, such as task-type routing.
+3. Add a Homebrew formula after release assets are stable.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Push
-site_description: Turn Claude Code or Codex into an always-on personal assistant.
+site_description: Turn Claude Code, Codex, or Pi into an always-on personal assistant.
 site_url: https://owainlewis.github.io/push/
 repo_url: https://github.com/owainlewis/push
 repo_name: owainlewis/push

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,6 +438,31 @@ mod tests {
     }
 
     #[test]
+    fn cli_reference_covers_every_help_command() {
+        let reference = include_str!("../docs/reference/cli.md").replace(['<', '>'], "");
+        let commands = HELP
+            .split("Commands:\n")
+            .nth(1)
+            .unwrap()
+            .split("\n\nOptions:")
+            .next()
+            .unwrap();
+
+        for line in commands.lines().filter(|line| !line.trim().is_empty()) {
+            let command = line
+                .trim()
+                .split("  ")
+                .next()
+                .unwrap()
+                .replace(['<', '>'], "");
+            assert!(
+                reference.contains(&format!("push {command}")),
+                "docs/reference/cli.md does not document `push {command}`"
+            );
+        }
+    }
+
+    #[test]
     fn parses_all_job_commands_with_config_anywhere() {
         assert_eq!(
             Args::parse(vec!["job".into(), "validate".into()])

--- a/tests/docs.rs
+++ b/tests/docs.rs
@@ -1,0 +1,126 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+
+#[test]
+fn local_documentation_links_resolve() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut markdown = vec![root.join("README.md")];
+    collect_markdown(&root.join("docs"), &mut markdown);
+
+    let mut broken = Vec::new();
+    for file in markdown {
+        let source = fs::read_to_string(&file).unwrap();
+        for event in Parser::new(&source) {
+            let Event::Start(Tag::Link { dest_url, .. }) = event else {
+                continue;
+            };
+            let destination = dest_url.as_ref();
+            if destination.starts_with('#') && destination.len() == 1 {
+                continue;
+            }
+            if destination.starts_with('/')
+                || destination.contains("://")
+                || destination.starts_with("mailto:")
+            {
+                continue;
+            }
+            let (path, fragment) = destination
+                .split_once('#')
+                .map_or((destination, None), |(path, fragment)| {
+                    (path, Some(fragment))
+                });
+            let path = path.split('?').next().unwrap_or_default();
+            let resolved = if path.is_empty() {
+                file.clone()
+            } else {
+                file.parent().unwrap().join(path)
+            };
+            if !resolved.exists() {
+                broken.push(format!(
+                    "{} -> {destination}",
+                    relative(root, &file).display()
+                ));
+            } else if let Some(fragment) = fragment {
+                let target = fs::read_to_string(&resolved).unwrap();
+                if !heading_anchors(&target)
+                    .iter()
+                    .any(|anchor| anchor == fragment)
+                {
+                    broken.push(format!(
+                        "{} -> {destination} (missing anchor)",
+                        relative(root, &file).display()
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        broken.is_empty(),
+        "broken local documentation links:\n{}",
+        broken.join("\n")
+    );
+}
+
+fn heading_anchors(markdown: &str) -> Vec<String> {
+    let mut anchors = Vec::new();
+    let mut heading = None;
+    for event in Parser::new_ext(markdown, Options::ENABLE_HEADING_ATTRIBUTES) {
+        match event {
+            Event::Start(Tag::Heading { id, .. }) => {
+                heading = Some((String::new(), id.map(|id| id.to_string())));
+            }
+            Event::Text(text) | Event::Code(text) => {
+                if let Some((heading, _)) = heading.as_mut() {
+                    heading.push_str(&text);
+                }
+            }
+            Event::SoftBreak | Event::HardBreak => {
+                if let Some((heading, _)) = heading.as_mut() {
+                    heading.push(' ');
+                }
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                if let Some((heading, id)) = heading.take() {
+                    anchors.push(id.unwrap_or_else(|| slug(&heading)));
+                }
+            }
+            _ => {}
+        }
+    }
+    anchors
+}
+
+fn slug(heading: &str) -> String {
+    let mut slug = String::new();
+    let mut separator = false;
+    for character in heading.trim_end_matches('#').trim().chars() {
+        if character.is_alphanumeric() || character == '_' {
+            if separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            separator = false;
+            slug.extend(character.to_lowercase());
+        } else if character.is_whitespace() || character == '-' {
+            separator = true;
+        }
+    }
+    slug
+}
+
+fn collect_markdown(directory: &Path, files: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(directory).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            collect_markdown(&path, files);
+        } else if path.extension().is_some_and(|extension| extension == "md") {
+            files.push(path);
+        }
+    }
+}
+
+fn relative<'a>(root: &Path, path: &'a Path) -> &'a Path {
+    path.strip_prefix(root).unwrap_or(path)
+}


### PR DESCRIPTION
## Summary

- align README and published docs with current CLI, config, release, channel, scheduler, and delivery behavior
- clearly label historical plans and separate possible roadmap work from shipped features
- add automated CLI-reference and local Markdown file/anchor checks

## Why

The documentation had stale shipped-vs-future claims, incomplete configuration and platform requirements, and several channel and delivery details that no longer matched the code.

## Test plan

- `cargo run --locked -- --help` and relevant `--help` forms
- `bash tests/install.sh`
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (323 tests)
- `mkdocs build --strict`
- desktop and 390 px mobile browser verification of navigation, tables, roadmap labels, and Mermaid diagrams
- fresh-agent diff review; all actionable findings fixed and rechecked

## Risks

Low. The product changes are documentation and docs correctness tests only. Roadmap wording and historical status labels deserve normal editorial review.

## Related issue

Closes #122