### PR TITLE
feat(channel): define static channel contract

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,45 @@ flowchart LR
     tg -->|reply| user
 ```
 
+## Channel Boundary
+
+The gateway depends on one closed, compile-time channel contract. iMessage and
+Telegram implement it, and the `Channel` enum provides static dispatch. This is
+an internal Rust boundary, not a dynamic plugin system or a configuration
+extension point.
+
+Each channel implementation owns these semantics:
+
+- **Inbound polling:** read events after an opaque monotonic cursor and report
+  the latest cursor used to skip backlog on first start. A pending poll must be
+  cancellation-safe because shutdown drops its future.
+- **Authorization:** reject unsupported, group, empty, looped-back, or
+  non-allowlisted input according to provider rules before backend dispatch.
+- **Thread identity:** return a stable channel-qualified thread key, the exact
+  reply target, approval sender/chat identity, and ordered route-key groups. Telegram
+  topics inherit a parent-chat route; iMessage retains its legacy unprefixed
+  route aliases.
+- **Outbound delivery:** validate proactive targets, plan durable chunks, and
+  send one chunk to the exact accepted target. Replies never cross from one
+  channel loop to another.
+- **Typing:** declare an optional refresh interval and send best-effort activity
+  updates. Typing failures do not fail an assistant turn.
+- **Rich messages:** choose plain or rich delivery per chunk. iMessage keeps one
+  plain marked reply. Telegram owns Markdown rendering, size limits, splitting,
+  and topic addressing.
+- **Retry:** expose the timeout and bounded retry cadence used for stored chat
+  replies. A send call is one attempt. Generated output is persisted before
+  delivery and retried without rerunning the backend. Scheduled delivery keeps
+  its separate durable attempt ledger and resumes at the first unsent chunk.
+- **Shutdown:** stop polling when its future is cancelled, drop queue senders,
+  drain accepted per-thread work for the contract's grace period, then abort any
+  remaining workers. Transport futures must release their resources when
+  dropped.
+
+Adding another built-in channel therefore requires a concrete contract
+implementation and one enum variant. It does not require channel-name branches
+in the shared polling, routing, worker, retry, or shutdown loops.
+
 ## Message Lifecycle
 
 ```mermaid

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,9 +1,11 @@
 //! Channel-neutral messaging boundary used by the gateway.
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 
+use crate::approval::AnswerOrigin;
 use crate::config::{ChannelKind, Config};
 use crate::imessage::{Poller as IMessagePoller, Sender as IMessageSender};
 use crate::telegram::Telegram;
@@ -49,23 +51,93 @@ pub struct OutboundChunk {
     pub rich_markdown: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeliverySemantics {
+    pub send_timeout: Duration,
+    pub retry_attempts: usize,
+    pub retry_delay: Duration,
+    pub exhausted_retry_delay: Duration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShutdownSemantics {
+    pub worker_grace: Duration,
+}
+
+/// The static contract every gateway channel must satisfy.
+///
+/// Poll futures must be cancellation-safe: the gateway drops an in-progress
+/// poll when shutdown is requested. Accepted messages must return a stable,
+/// channel-qualified thread key and the exact target used for every reply.
+/// Delivery is chunked before sending so rich-message formatting and retry
+/// boundaries remain channel-owned. Implementations must also treat typing as
+/// best-effort and release transport resources when a poll or send future is
+/// dropped.
+#[allow(async_fn_in_trait)]
+trait ChannelContract {
+    fn id(&self) -> &'static str;
+    fn primary_target(&self, configured: &str) -> Result<String>;
+    async fn poll(&self, since: i64) -> Result<Vec<RawMessage>>;
+    async fn latest_cursor(&self) -> Result<i64>;
+    fn accept(&self, message: &RawMessage) -> Option<(String, String)>;
+    fn reject_reason(&self, message: &RawMessage) -> &'static str;
+    fn approval_origin(&self, message: &RawMessage, thread: &str) -> AnswerOrigin;
+    fn route_thread_groups(&self, thread: &str) -> Vec<Vec<String>>;
+    fn outbound_chunks(&self, text: &str, marker: &str) -> Vec<OutboundChunk>;
+
+    fn scheduled_outbound_chunks(&self, text: &str, marker: &str) -> Vec<OutboundChunk> {
+        self.outbound_chunks(text, marker)
+    }
+
+    async fn send_chunk(&self, target: &str, chunk: &OutboundChunk) -> Result<()>;
+
+    fn typing_refresh(&self) -> Option<Duration> {
+        None
+    }
+
+    async fn send_typing(&self, _target: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn download_voice(&self, voice: &InboundVoice) -> Result<AudioClip>;
+    async fn send_voice(&self, target: &str, clip: &AudioClip) -> Result<()>;
+
+    fn delivery_semantics(&self) -> DeliverySemantics {
+        DeliverySemantics {
+            send_timeout: Duration::from_secs(30),
+            retry_attempts: 3,
+            retry_delay: Duration::from_millis(250),
+            exhausted_retry_delay: Duration::from_secs(5),
+        }
+    }
+
+    fn shutdown_semantics(&self) -> ShutdownSemantics {
+        ShutdownSemantics {
+            worker_grace: Duration::from_secs(30),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct IMessageChannel {
+    pub(crate) poller: IMessagePoller,
+    #[cfg_attr(test, allow(dead_code))]
+    pub(crate) sender: IMessageSender,
+    pub(crate) self_set: HashMap<String, String>,
+    pub(crate) allow_set: HashMap<String, String>,
+    pub(crate) reply_marker: String,
+}
+
 #[derive(Clone)]
 pub enum Channel {
-    IMessage {
-        poller: IMessagePoller,
-        #[cfg_attr(test, allow(dead_code))]
-        sender: IMessageSender,
-        self_set: HashMap<String, String>,
-        allow_set: HashMap<String, String>,
-        reply_marker: String,
-    },
+    IMessage(IMessageChannel),
     Telegram(Telegram),
 }
 
 impl Channel {
     pub fn new_for(cfg: &Config, kind: ChannelKind) -> Result<Self> {
         match kind {
-            ChannelKind::IMessage => Ok(Self::IMessage {
+            ChannelKind::IMessage => Ok(Self::IMessage(IMessageChannel {
                 poller: IMessagePoller::new(cfg.db_path.clone()),
                 sender: IMessageSender::new(),
                 self_set: cfg
@@ -79,7 +151,7 @@ impl Channel {
                     .map(|value| (normalize_handle(value), thread_handle(value)))
                     .collect(),
                 reply_marker: REPLY_MARKER.to_string(),
-            }),
+            })),
             ChannelKind::Telegram => Ok(Self::Telegram(Telegram::new(
                 cfg.telegram_token()
                     .ok_or_else(|| anyhow::anyhow!("Telegram bot token is not configured"))?,
@@ -90,247 +162,403 @@ impl Channel {
     }
 
     pub fn primary_target(&self, configured: &str) -> Result<String> {
-        if configured.trim().is_empty() {
-            bail!("primary delivery target cannot be empty");
-        }
         match self {
-            Self::IMessage {
-                self_set,
-                allow_set,
-                ..
-            } => {
-                let normalized = normalize_handle(configured);
-                self_set
-                    .get(&normalized)
-                    .or_else(|| allow_set.get(&normalized))
-                    .cloned()
-                    .with_context(|| {
-                        format!(
-                            "iMessage primary target {configured:?} is not in imessage.self_handles or imessage.allow_from"
-                        )
-                    })
-            }
-            Self::Telegram(telegram) => {
-                let (chat, topic) = configured
-                    .trim()
-                    .split_once(':')
-                    .map_or((configured.trim(), None), |(chat, topic)| {
-                        (chat, Some(topic))
-                    });
-                let chat_id = chat
-                    .parse::<i64>()
-                    .with_context(|| format!("invalid Telegram primary chat id {chat:?}"))?;
-                if !telegram.allows_target(chat_id) {
-                    bail!(
-                        "Telegram primary chat id {chat_id} is not in telegram.allow_user_ids or telegram.allow_chat_ids"
-                    );
-                }
-                match topic {
-                    None => Ok(chat_id.to_string()),
-                    Some(value) => {
-                        if value.contains(':') {
-                            bail!("invalid Telegram primary target {configured:?}");
-                        }
-                        let topic_id = value.parse::<i64>().with_context(|| {
-                            format!("invalid Telegram primary topic id {value:?}")
-                        })?;
-                        if topic_id <= 0 {
-                            bail!("Telegram primary topic id must be positive");
-                        }
-                        Ok(format!("{chat_id}:{topic_id}"))
-                    }
-                }
-            }
+            Self::IMessage(channel) => ChannelContract::primary_target(channel, configured),
+            Self::Telegram(channel) => ChannelContract::primary_target(channel, configured),
         }
     }
 
     pub fn id(&self) -> &'static str {
         match self {
-            Self::IMessage { .. } => "imessage",
-            Self::Telegram(_) => "telegram",
+            Self::IMessage(channel) => ChannelContract::id(channel),
+            Self::Telegram(channel) => ChannelContract::id(channel),
         }
     }
 
     pub async fn poll(&self, since: i64) -> Result<Vec<RawMessage>> {
         match self {
-            Self::IMessage { poller, .. } => {
-                let poller = poller.clone();
-                let messages = tokio::task::spawn_blocking(move || poller.poll(since)).await??;
-                Ok(messages
-                    .into_iter()
-                    .map(|message| RawMessage {
-                        row_id: message.row_id,
-                        channel: "imessage",
-                        handle: message.handle,
-                        chat_identifier: message.chat_identifier,
-                        is_group: message.is_group,
-                        text: message.text,
-                        voice: None,
-                        is_from_me: message.is_from_me,
-                        is_supported: true,
-                        thread_id: None,
-                    })
-                    .collect())
-            }
-            Self::Telegram(telegram) => telegram.poll(since).await,
+            Self::IMessage(channel) => ChannelContract::poll(channel, since).await,
+            Self::Telegram(channel) => ChannelContract::poll(channel, since).await,
         }
     }
 
     pub async fn latest_cursor(&self) -> Result<i64> {
         match self {
-            Self::IMessage { poller, .. } => {
-                let poller = poller.clone();
-                Ok(tokio::task::spawn_blocking(move || poller.max_row_id()).await??)
-            }
-            Self::Telegram(telegram) => telegram.latest_cursor().await,
+            Self::IMessage(channel) => ChannelContract::latest_cursor(channel).await,
+            Self::Telegram(channel) => ChannelContract::latest_cursor(channel).await,
         }
     }
 
     /// Returns `(thread_key, reply_target)` for an accepted message.
     pub fn accept(&self, message: &RawMessage) -> Option<(String, String)> {
-        if !message.is_supported
-            || message.is_group
-            || (message.text.trim().is_empty() && message.voice.is_none())
-        {
-            return None;
-        }
         match self {
-            Self::IMessage {
-                self_set,
-                allow_set,
-                reply_marker,
-                ..
-            } => {
-                if !reply_marker.is_empty() && message.text.contains(reply_marker) {
-                    return None;
-                }
-                let chat = normalize_handle(&message.chat_identifier);
-                let handle = normalize_handle(&message.handle);
-                if let Some(value) = self_set.get(&chat) {
-                    return Some((
-                        format!("imessage:self:{value}"),
-                        message.chat_identifier.clone(),
-                    ));
-                }
-                if !message.is_from_me {
-                    if let Some(value) = allow_set.get(&handle) {
-                        return Some((format!("imessage:dm:{value}"), message.handle.clone()));
-                    }
-                }
-                None
-            }
-            Self::Telegram(telegram) => {
-                telegram
-                    .is_allowed(message)
-                    .then(|| match message.thread_id {
-                        Some(topic) => (
-                            format!("telegram:dm:{}:topic:{topic}", message.chat_identifier),
-                            format!("{}:{topic}", message.chat_identifier),
-                        ),
-                        None => (
-                            format!("telegram:dm:{}", message.chat_identifier),
-                            message.chat_identifier.clone(),
-                        ),
-                    })
-            }
+            Self::IMessage(channel) => ChannelContract::accept(channel, message),
+            Self::Telegram(channel) => ChannelContract::accept(channel, message),
         }
     }
 
     pub fn reject_reason(&self, message: &RawMessage) -> &'static str {
-        if !message.is_supported {
-            "unsupported_update"
-        } else if message.is_group {
-            "group_chat"
-        } else if message.text.trim().is_empty() && message.voice.is_none() {
-            "empty_message"
-        } else {
-            match self {
-                Self::IMessage { reply_marker, .. }
-                    if !reply_marker.is_empty() && message.text.contains(reply_marker) =>
-                {
-                    "reply_marker"
-                }
-                Self::IMessage { .. } if message.is_from_me => "from_me_to_other",
-                _ => "not_allowlisted",
-            }
+        match self {
+            Self::IMessage(channel) => ChannelContract::reject_reason(channel, message),
+            Self::Telegram(channel) => ChannelContract::reject_reason(channel, message),
+        }
+    }
+
+    pub fn approval_origin(&self, message: &RawMessage, thread: &str) -> AnswerOrigin {
+        match self {
+            Self::IMessage(channel) => ChannelContract::approval_origin(channel, message, thread),
+            Self::Telegram(channel) => ChannelContract::approval_origin(channel, message, thread),
+        }
+    }
+
+    pub fn route_thread_groups(&self, thread: &str) -> Vec<Vec<String>> {
+        match self {
+            Self::IMessage(channel) => ChannelContract::route_thread_groups(channel, thread),
+            Self::Telegram(channel) => ChannelContract::route_thread_groups(channel, thread),
         }
     }
 
     pub fn outbound_chunks(&self, text: &str, marker: &str) -> Vec<OutboundChunk> {
-        if text.trim().is_empty() {
-            return Vec::new();
-        }
         match self {
-            Self::IMessage { .. } => vec![OutboundChunk {
-                text: format!("{text}{marker}"),
-                rich_markdown: false,
-            }],
-            Self::Telegram(_) => crate::telegram::split_text(text)
-                .into_iter()
-                .map(|text| OutboundChunk {
-                    text,
-                    rich_markdown: true,
-                })
-                .collect(),
+            Self::IMessage(channel) => ChannelContract::outbound_chunks(channel, text, marker),
+            Self::Telegram(channel) => ChannelContract::outbound_chunks(channel, text, marker),
         }
     }
 
     pub fn scheduled_outbound_chunks(&self, text: &str, marker: &str) -> Vec<OutboundChunk> {
         match self {
-            Self::Telegram(_) => crate::telegram::split_text(text)
-                .into_iter()
-                .map(|text| OutboundChunk {
-                    text,
-                    rich_markdown: true,
-                })
-                .collect(),
-            Self::IMessage { .. } => self.outbound_chunks(text, marker),
+            Self::IMessage(channel) => {
+                ChannelContract::scheduled_outbound_chunks(channel, text, marker)
+            }
+            Self::Telegram(channel) => {
+                ChannelContract::scheduled_outbound_chunks(channel, text, marker)
+            }
         }
     }
 
     #[cfg_attr(test, allow(dead_code))]
     pub async fn send_chunk(&self, target: &str, chunk: &OutboundChunk) -> Result<()> {
         match self {
-            Self::IMessage { sender, .. } => sender.send(target, &chunk.text).await,
-            Self::Telegram(telegram) if chunk.rich_markdown => {
-                telegram.send_rich(target, &chunk.text).await
-            }
-            Self::Telegram(telegram) => telegram.send_plain(target, &chunk.text).await,
+            Self::IMessage(channel) => ChannelContract::send_chunk(channel, target, chunk).await,
+            Self::Telegram(channel) => ChannelContract::send_chunk(channel, target, chunk).await,
         }
     }
 
-    pub fn supports_typing(&self) -> bool {
-        matches!(self, Self::Telegram(_))
+    pub fn typing_refresh(&self) -> Option<Duration> {
+        match self {
+            Self::IMessage(channel) => ChannelContract::typing_refresh(channel),
+            Self::Telegram(channel) => ChannelContract::typing_refresh(channel),
+        }
     }
 
     pub async fn send_typing(&self, target: &str) -> Result<()> {
         match self {
-            Self::IMessage { .. } => Ok(()),
-            Self::Telegram(telegram) => telegram.send_typing(target).await,
+            Self::IMessage(channel) => ChannelContract::send_typing(channel, target).await,
+            Self::Telegram(channel) => ChannelContract::send_typing(channel, target).await,
         }
     }
 
     pub async fn download_voice(&self, voice: &InboundVoice) -> Result<AudioClip> {
-        if let Some(bytes) = &voice.data {
-            return Ok(AudioClip {
-                bytes: bytes.clone(),
-                filename: voice.filename.clone(),
-                mime_type: voice.mime_type.clone(),
-            });
-        }
         match self {
-            Self::Telegram(telegram) => telegram.download_voice(voice).await,
-            Self::IMessage { .. } => bail!("iMessage voice messages are not supported yet"),
+            Self::IMessage(channel) => ChannelContract::download_voice(channel, voice).await,
+            Self::Telegram(channel) => ChannelContract::download_voice(channel, voice).await,
         }
     }
 
     #[cfg_attr(test, allow(dead_code))]
     pub async fn send_voice(&self, target: &str, clip: &AudioClip) -> Result<()> {
         match self {
-            Self::Telegram(telegram) => telegram.send_voice(target, clip).await,
-            Self::IMessage { .. } => bail!("iMessage voice replies are not supported yet"),
+            Self::IMessage(channel) => ChannelContract::send_voice(channel, target, clip).await,
+            Self::Telegram(channel) => ChannelContract::send_voice(channel, target, clip).await,
         }
     }
+
+    pub fn delivery_semantics(&self) -> DeliverySemantics {
+        match self {
+            Self::IMessage(channel) => ChannelContract::delivery_semantics(channel),
+            Self::Telegram(channel) => ChannelContract::delivery_semantics(channel),
+        }
+    }
+
+    pub fn shutdown_semantics(&self) -> ShutdownSemantics {
+        match self {
+            Self::IMessage(channel) => ChannelContract::shutdown_semantics(channel),
+            Self::Telegram(channel) => ChannelContract::shutdown_semantics(channel),
+        }
+    }
+}
+
+impl ChannelContract for IMessageChannel {
+    fn id(&self) -> &'static str {
+        "imessage"
+    }
+
+    fn primary_target(&self, configured: &str) -> Result<String> {
+        if configured.trim().is_empty() {
+            bail!("primary delivery target cannot be empty");
+        }
+        let normalized = normalize_handle(configured);
+        self.self_set
+            .get(&normalized)
+            .or_else(|| self.allow_set.get(&normalized))
+            .cloned()
+            .with_context(|| {
+                format!(
+                    "iMessage primary target {configured:?} is not in imessage.self_handles or imessage.allow_from"
+                )
+            })
+    }
+
+    async fn poll(&self, since: i64) -> Result<Vec<RawMessage>> {
+        let poller = self.poller.clone();
+        let messages = tokio::task::spawn_blocking(move || poller.poll(since)).await??;
+        Ok(messages
+            .into_iter()
+            .map(|message| RawMessage {
+                row_id: message.row_id,
+                channel: self.id(),
+                handle: message.handle,
+                chat_identifier: message.chat_identifier,
+                is_group: message.is_group,
+                text: message.text,
+                voice: None,
+                is_from_me: message.is_from_me,
+                is_supported: true,
+                thread_id: None,
+            })
+            .collect())
+    }
+
+    async fn latest_cursor(&self) -> Result<i64> {
+        let poller = self.poller.clone();
+        tokio::task::spawn_blocking(move || poller.max_row_id()).await?
+    }
+
+    fn accept(&self, message: &RawMessage) -> Option<(String, String)> {
+        if common_reject_reason(message).is_some()
+            || (!self.reply_marker.is_empty() && message.text.contains(&self.reply_marker))
+        {
+            return None;
+        }
+        let chat = normalize_handle(&message.chat_identifier);
+        let handle = normalize_handle(&message.handle);
+        if let Some(value) = self.self_set.get(&chat) {
+            return Some((
+                format!("imessage:self:{value}"),
+                message.chat_identifier.clone(),
+            ));
+        }
+        if !message.is_from_me {
+            if let Some(value) = self.allow_set.get(&handle) {
+                return Some((format!("imessage:dm:{value}"), message.handle.clone()));
+            }
+        }
+        None
+    }
+
+    fn reject_reason(&self, message: &RawMessage) -> &'static str {
+        common_reject_reason(message).unwrap_or_else(|| {
+            if !self.reply_marker.is_empty() && message.text.contains(&self.reply_marker) {
+                "reply_marker"
+            } else if message.is_from_me {
+                "from_me_to_other"
+            } else {
+                "not_allowlisted"
+            }
+        })
+    }
+
+    fn approval_origin(&self, message: &RawMessage, thread: &str) -> AnswerOrigin {
+        let chat_key = normalize_handle(&message.chat_identifier);
+        let sender_key = if thread.starts_with("imessage:self:") {
+            chat_key.clone()
+        } else {
+            normalize_handle(&message.handle)
+        };
+        AnswerOrigin {
+            channel: self.id().to_string(),
+            thread_key: thread.to_string(),
+            sender_key,
+            chat_key,
+        }
+    }
+
+    fn route_thread_groups(&self, thread: &str) -> Vec<Vec<String>> {
+        let mut aliases = vec![thread.to_string()];
+        if let Some(legacy) = thread.strip_prefix("imessage:") {
+            aliases.push(legacy.to_string());
+        }
+        vec![aliases]
+    }
+
+    fn outbound_chunks(&self, text: &str, marker: &str) -> Vec<OutboundChunk> {
+        if text.trim().is_empty() {
+            Vec::new()
+        } else {
+            vec![OutboundChunk {
+                text: format!("{text}{marker}"),
+                rich_markdown: false,
+            }]
+        }
+    }
+
+    async fn send_chunk(&self, target: &str, chunk: &OutboundChunk) -> Result<()> {
+        self.sender.send(target, &chunk.text).await
+    }
+
+    async fn download_voice(&self, voice: &InboundVoice) -> Result<AudioClip> {
+        if let Some(bytes) = &voice.data {
+            return inline_audio(voice, bytes);
+        }
+        bail!("iMessage voice messages are not supported yet")
+    }
+
+    async fn send_voice(&self, _target: &str, _clip: &AudioClip) -> Result<()> {
+        bail!("iMessage voice replies are not supported yet")
+    }
+}
+
+impl ChannelContract for Telegram {
+    fn id(&self) -> &'static str {
+        "telegram"
+    }
+
+    fn primary_target(&self, configured: &str) -> Result<String> {
+        if configured.trim().is_empty() {
+            bail!("primary delivery target cannot be empty");
+        }
+        let (chat, topic) = configured
+            .trim()
+            .split_once(':')
+            .map_or((configured.trim(), None), |(chat, topic)| {
+                (chat, Some(topic))
+            });
+        let chat_id = chat
+            .parse::<i64>()
+            .with_context(|| format!("invalid Telegram primary chat id {chat:?}"))?;
+        if !self.allows_target(chat_id) {
+            bail!(
+                "Telegram primary chat id {chat_id} is not in telegram.allow_user_ids or telegram.allow_chat_ids"
+            );
+        }
+        match topic {
+            None => Ok(chat_id.to_string()),
+            Some(value) => {
+                if value.contains(':') {
+                    bail!("invalid Telegram primary target {configured:?}");
+                }
+                let topic_id = value
+                    .parse::<i64>()
+                    .with_context(|| format!("invalid Telegram primary topic id {value:?}"))?;
+                if topic_id <= 0 {
+                    bail!("Telegram primary topic id must be positive");
+                }
+                Ok(format!("{chat_id}:{topic_id}"))
+            }
+        }
+    }
+
+    async fn poll(&self, since: i64) -> Result<Vec<RawMessage>> {
+        self.poll(since).await
+    }
+
+    async fn latest_cursor(&self) -> Result<i64> {
+        self.latest_cursor().await
+    }
+
+    fn accept(&self, message: &RawMessage) -> Option<(String, String)> {
+        if common_reject_reason(message).is_some() || !self.is_allowed(message) {
+            return None;
+        }
+        Some(match message.thread_id {
+            Some(topic) => (
+                format!("telegram:dm:{}:topic:{topic}", message.chat_identifier),
+                format!("{}:{topic}", message.chat_identifier),
+            ),
+            None => (
+                format!("telegram:dm:{}", message.chat_identifier),
+                message.chat_identifier.clone(),
+            ),
+        })
+    }
+
+    fn reject_reason(&self, message: &RawMessage) -> &'static str {
+        common_reject_reason(message).unwrap_or("not_allowlisted")
+    }
+
+    fn approval_origin(&self, message: &RawMessage, thread: &str) -> AnswerOrigin {
+        AnswerOrigin {
+            channel: self.id().to_string(),
+            thread_key: thread.to_string(),
+            sender_key: message.handle.clone(),
+            chat_key: message.chat_identifier.clone(),
+        }
+    }
+
+    fn route_thread_groups(&self, thread: &str) -> Vec<Vec<String>> {
+        let mut groups = vec![vec![thread.to_string()]];
+        if let Some((parent, _)) = thread.rsplit_once(":topic:") {
+            groups.push(vec![parent.to_string()]);
+        }
+        groups
+    }
+
+    fn outbound_chunks(&self, text: &str, _marker: &str) -> Vec<OutboundChunk> {
+        crate::telegram::split_text(text)
+            .into_iter()
+            .map(|text| OutboundChunk {
+                text,
+                rich_markdown: true,
+            })
+            .collect()
+    }
+
+    async fn send_chunk(&self, target: &str, chunk: &OutboundChunk) -> Result<()> {
+        if chunk.rich_markdown {
+            self.send_rich(target, &chunk.text).await
+        } else {
+            self.send_plain(target, &chunk.text).await
+        }
+    }
+
+    fn typing_refresh(&self) -> Option<Duration> {
+        Some(Duration::from_secs(4))
+    }
+
+    async fn send_typing(&self, target: &str) -> Result<()> {
+        self.send_typing(target).await
+    }
+
+    async fn download_voice(&self, voice: &InboundVoice) -> Result<AudioClip> {
+        if let Some(bytes) = &voice.data {
+            return inline_audio(voice, bytes);
+        }
+        self.download_voice(voice).await
+    }
+
+    async fn send_voice(&self, target: &str, clip: &AudioClip) -> Result<()> {
+        self.send_voice(target, clip).await
+    }
+}
+
+fn common_reject_reason(message: &RawMessage) -> Option<&'static str> {
+    if !message.is_supported {
+        Some("unsupported_update")
+    } else if message.is_group {
+        Some("group_chat")
+    } else if message.text.trim().is_empty() && message.voice.is_none() {
+        Some("empty_message")
+    } else {
+        None
+    }
+}
+
+fn inline_audio(voice: &InboundVoice, bytes: &[u8]) -> Result<AudioClip> {
+    Ok(AudioClip {
+        bytes: bytes.to_vec(),
+        filename: voice.filename.clone(),
+        mime_type: voice.mime_type.clone(),
+    })
 }
 
 pub(crate) fn normalize_handle(value: &str) -> String {
@@ -367,8 +595,39 @@ pub(crate) fn thread_handle(value: &str) -> String {
 mod tests {
     use super::*;
 
+    fn assert_contract<T: ChannelContract>() {}
+
+    fn imessage() -> Channel {
+        Channel::IMessage(IMessageChannel {
+            poller: IMessagePoller::new("fake".to_string()),
+            sender: IMessageSender::new(),
+            self_set: [("me@icloud.com".to_string(), "me@icloud.com".to_string())]
+                .into_iter()
+                .collect(),
+            allow_set: [("15551234567".to_string(), "+15551234567".to_string())]
+                .into_iter()
+                .collect(),
+            reply_marker: REPLY_MARKER.to_string(),
+        })
+    }
+
     fn telegram() -> Channel {
         Channel::Telegram(Telegram::new("secret".to_string(), vec![7], vec![9]))
+    }
+
+    fn imessage_message(chat: &str, handle: &str, is_from_me: bool) -> RawMessage {
+        RawMessage {
+            row_id: 1,
+            channel: "imessage",
+            handle: handle.to_string(),
+            chat_identifier: chat.to_string(),
+            is_group: false,
+            text: "hello".to_string(),
+            voice: None,
+            is_from_me,
+            is_supported: true,
+            thread_id: None,
+        }
     }
 
     fn telegram_message(user: i64, chat: i64, is_group: bool) -> RawMessage {
@@ -387,8 +646,83 @@ mod tests {
     }
 
     #[test]
+    fn both_existing_channels_implement_the_static_contract() {
+        assert_contract::<IMessageChannel>();
+        assert_contract::<Telegram>();
+    }
+
+    #[test]
+    fn imessage_contract_keeps_stable_identity_and_delivery_routing() {
+        let channel = imessage();
+        let message = imessage_message("+1 (555) 123-4567", "+1 (555) 123-4567", false);
+
+        let accepted = channel.accept(&message).unwrap();
+        assert_eq!(channel.accept(&message), Some(accepted.clone()));
+        assert_eq!(accepted.0, "imessage:dm:+15551234567");
+        assert_eq!(accepted.1, "+1 (555) 123-4567");
+        assert_eq!(
+            channel.route_thread_groups(&accepted.0),
+            [vec![
+                "imessage:dm:+15551234567".to_string(),
+                "dm:+15551234567".to_string(),
+            ]]
+        );
+        assert_eq!(
+            channel.approval_origin(&message, &accepted.0),
+            AnswerOrigin {
+                channel: "imessage".to_string(),
+                thread_key: accepted.0,
+                sender_key: "15551234567".to_string(),
+                chat_key: "15551234567".to_string(),
+            }
+        );
+        assert_eq!(
+            channel.outbound_chunks("reply", REPLY_MARKER),
+            [OutboundChunk {
+                text: format!("reply{REPLY_MARKER}"),
+                rich_markdown: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn telegram_contract_keeps_topic_identity_and_delivery_routing() {
+        let channel = telegram();
+        let mut message = telegram_message(7, 7, false);
+        message.thread_id = Some(99);
+
+        let accepted = channel.accept(&message).unwrap();
+        assert_eq!(channel.accept(&message), Some(accepted.clone()));
+        assert_eq!(accepted.0, "telegram:dm:7:topic:99");
+        assert_eq!(accepted.1, "7:99");
+        assert_eq!(
+            channel.route_thread_groups(&accepted.0),
+            [
+                vec!["telegram:dm:7:topic:99".to_string()],
+                vec!["telegram:dm:7".to_string()],
+            ]
+        );
+        assert_eq!(
+            channel.approval_origin(&message, &accepted.0),
+            AnswerOrigin {
+                channel: "telegram".to_string(),
+                thread_key: accepted.0,
+                sender_key: "7".to_string(),
+                chat_key: "7".to_string(),
+            }
+        );
+        assert_eq!(
+            channel.outbound_chunks("reply", REPLY_MARKER),
+            [OutboundChunk {
+                text: "reply".to_string(),
+                rich_markdown: true,
+            }]
+        );
+    }
+
+    #[test]
     fn telegram_accepts_allowlisted_private_user_or_chat() {
-        assert!(telegram().supports_typing());
+        assert_eq!(telegram().typing_refresh(), Some(Duration::from_secs(4)));
         assert_eq!(
             telegram().accept(&telegram_message(7, 7, false)),
             Some(("telegram:dm:7".to_string(), "7".to_string()))
@@ -473,13 +807,7 @@ mod tests {
 
     #[test]
     fn imessage_outbound_reply_remains_one_unsplit_message() {
-        let channel = Channel::IMessage {
-            poller: IMessagePoller::new("fake".to_string()),
-            sender: IMessageSender::new(),
-            self_set: HashMap::new(),
-            allow_set: HashMap::new(),
-            reply_marker: String::new(),
-        };
+        let channel = imessage();
 
         assert_eq!(
             channel.outbound_chunks("hello", "\n\n-- sent by push")[0].text,

--- a/src/config.rs
+++ b/src/config.rs
@@ -347,21 +347,20 @@ impl Config {
             })
     }
 
-    pub fn route_for_message(&self, channel: &str, thread: &str) -> Result<RouteSelection> {
-        for route in self.routes.iter().filter(|route| route.thread.is_some()) {
-            if route.matches_thread(channel, thread) {
-                return self.resolve_route(route);
-            }
-        }
-        if let Some(parent) = telegram_parent_thread(channel, thread) {
+    pub fn route_for_message(
+        &self,
+        channel: &str,
+        route_thread_groups: &[Vec<String>],
+    ) -> Result<RouteSelection> {
+        for aliases in route_thread_groups {
             for route in self.routes.iter().filter(|route| route.thread.is_some()) {
-                if route.matches_thread(channel, parent) {
+                if route.matches_threads(channel, aliases) {
                     return self.resolve_route(route);
                 }
             }
         }
         for route in self.routes.iter().filter(|route| route.thread.is_none()) {
-            if route.matches(channel, thread) {
+            if route.matches(channel) {
                 return self.resolve_route(route);
             }
         }
@@ -724,33 +723,18 @@ impl RouteRule {
         self.channel.as_deref().is_none_or(|value| value == channel)
     }
 
-    fn matches_thread(&self, channel: &str, thread: &str) -> bool {
-        if !self.can_match_channel(channel) {
-            return false;
-        }
-        self.thread.as_deref().is_some_and(|value| {
-            value == thread
-                || (channel == "imessage"
-                    && thread
-                        .strip_prefix("imessage:")
-                        .is_some_and(|legacy| legacy == value))
-        })
-    }
-
-    fn matches(&self, channel: &str, thread: &str) -> bool {
+    fn matches_threads(&self, channel: &str, threads: &[String]) -> bool {
         if !self.can_match_channel(channel) {
             return false;
         }
         self.thread
             .as_deref()
-            .is_none_or(|_| self.matches_thread(channel, thread))
+            .is_some_and(|value| threads.iter().any(|thread| value == thread))
     }
-}
 
-fn telegram_parent_thread<'a>(channel: &str, thread: &'a str) -> Option<&'a str> {
-    (channel == "telegram")
-        .then(|| thread.rsplit_once(":topic:").map(|(parent, _)| parent))
-        .flatten()
+    fn matches(&self, channel: &str) -> bool {
+        self.can_match_channel(channel) && self.thread.is_none()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -904,7 +888,7 @@ mod tests {
         assert_eq!(cfg.agent_backend().unwrap(), AgentBackend::Pi);
         assert_eq!(cfg.jobs_backend().unwrap(), AgentBackend::Pi);
         assert_eq!(
-            cfg.route_for_message("imessage", "imessage:chat:pi")
+            cfg.route_for_message("imessage", &[vec!["imessage:chat:pi".to_string()]])
                 .unwrap()
                 .backend,
             AgentBackend::Pi

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -28,9 +28,6 @@ use crate::util::now_ms;
 use crate::voice::Voice;
 
 const QUEUE_DEPTH: usize = 32;
-#[cfg(not(test))]
-const SEND_TIMEOUT: Duration = Duration::from_secs(30);
-const SHUTDOWN_GRACE: Duration = Duration::from_secs(30);
 
 #[cfg(test)]
 type SentVoiceReplies = Arc<Mutex<Vec<(String, Vec<u8>)>>>;
@@ -465,7 +462,7 @@ impl Gateway {
     }
 
     async fn drain_workers(&mut self) {
-        let deadline = tokio::time::Instant::now() + SHUTDOWN_GRACE;
+        let deadline = tokio::time::Instant::now() + self.channel.shutdown_semantics().worker_grace;
         let mut workers = std::mem::take(&mut self.handles).into_iter();
         while let Some(mut worker) = workers.next() {
             if tokio::time::timeout_at(deadline, &mut worker)
@@ -538,7 +535,7 @@ impl Gateway {
                 } else {
                     m.text.trim().to_string()
                 };
-                let approval_origin = approval_origin(m, &thread);
+                let approval_origin = self.channel.approval_origin(m, &thread);
                 let approval = if reply_with_voice {
                     Ok(AnswerOutcome::NotAnAnswer)
                 } else {
@@ -614,7 +611,8 @@ impl Gateway {
                         return;
                     }
                 };
-                let route = match self.cfg.route_for_message(m.channel, &thread) {
+                let route_threads = self.channel.route_thread_groups(&thread);
+                let route = match self.cfg.route_for_message(m.channel, &route_threads) {
                     Ok(v) => v,
                     Err(e) => {
                         error!("[{thread}] route error: {e}");
@@ -1050,7 +1048,12 @@ async fn send_reply_chunk(
         Ok(())
     }
     #[cfg(not(test))]
-    match tokio::time::timeout(SEND_TIMEOUT, ctx.channel.send_chunk(target, chunk)).await {
+    match tokio::time::timeout(
+        ctx.channel.delivery_semantics().send_timeout,
+        ctx.channel.send_chunk(target, chunk),
+    )
+    .await
+    {
         Ok(result) => result,
         Err(_) => anyhow::bail!("send timed out"),
     }
@@ -1126,30 +1129,6 @@ impl AckState {
             .max()?;
         self.completed.retain(|id| *id > next);
         Some(next)
-    }
-}
-
-fn approval_origin(message: &RawMessage, thread: &str) -> AnswerOrigin {
-    if message.channel == "imessage" {
-        let chat_key = crate::channel::normalize_handle(&message.chat_identifier);
-        let sender_key = if thread.starts_with("imessage:self:") {
-            chat_key.clone()
-        } else {
-            crate::channel::normalize_handle(&message.handle)
-        };
-        AnswerOrigin {
-            channel: message.channel.to_string(),
-            thread_key: thread.to_string(),
-            sender_key,
-            chat_key,
-        }
-    } else {
-        AnswerOrigin {
-            channel: message.channel.to_string(),
-            thread_key: thread.to_string(),
-            sender_key: message.handle.clone(),
-            chat_key: message.chat_identifier.clone(),
-        }
     }
 }
 

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -1,6 +1,5 @@
 use super::worker::{
-    handle, present_drafts, run_with_periodic_activity, DELIVERY_ATTEMPTS, DRAFT_SETUP_FAILURE,
-    SESSION_SETUP_FAILURE,
+    handle, present_drafts, run_with_periodic_activity, DRAFT_SETUP_FAILURE, SESSION_SETUP_FAILURE,
 };
 use super::*;
 use crate::agent::{FakeRunCall, FakeRunner};
@@ -141,7 +140,7 @@ async fn shutdown_cancels_a_pending_poll_operation() {
 }
 
 fn filter() -> Channel {
-    Channel::IMessage {
+    Channel::IMessage(crate::channel::IMessageChannel {
         poller: Poller::new("fake-chat.db".to_string()),
         sender: Sender::new(),
         self_set: [("me@icloud.com".to_string(), "me@icloud.com".to_string())]
@@ -151,7 +150,7 @@ fn filter() -> Channel {
             .into_iter()
             .collect(),
         reply_marker: "\n\n-- sent by push".to_string(),
-    }
+    })
 }
 
 fn msg(chat: &str, handle: &str, from_me: bool, text: &str) -> RawMessage {
@@ -292,7 +291,7 @@ fn formatted_phone_allowlist_matches_normalized_handle() {
 
 #[test]
 fn bare_phone_matches_allowlist_with_plus() {
-    let filter = Channel::IMessage {
+    let filter = Channel::IMessage(crate::channel::IMessageChannel {
         poller: Poller::new("fake-chat.db".to_string()),
         sender: Sender::new(),
         self_set: HashMap::new(),
@@ -301,7 +300,7 @@ fn bare_phone_matches_allowlist_with_plus() {
             .map(|s| (normalize_handle(s), thread_handle(s)))
             .collect(),
         reply_marker: String::new(),
-    };
+    });
 
     let got = filter.accept(&msg("15551234567", "15551234567", false, "hi"));
 
@@ -316,7 +315,7 @@ fn bare_phone_matches_allowlist_with_plus() {
 
 #[test]
 fn plus_phone_matches_bare_allowlist() {
-    let filter = Channel::IMessage {
+    let filter = Channel::IMessage(crate::channel::IMessageChannel {
         poller: Poller::new("fake-chat.db".to_string()),
         sender: Sender::new(),
         self_set: HashMap::new(),
@@ -325,7 +324,7 @@ fn plus_phone_matches_bare_allowlist() {
             .map(|s| (normalize_handle(s), thread_handle(s)))
             .collect(),
         reply_marker: String::new(),
-    };
+    });
 
     let got = filter.accept(&msg("+1 (555) 123-4567", "+1 (555) 123-4567", false, "hi"));
 
@@ -1343,7 +1342,8 @@ async fn exhausted_delivery_batch_retries_without_blocking_cursor() {
     ))
     .unwrap();
     gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
-    *gateway.ctx.send_failures_remaining.lock().unwrap() = DELIVERY_ATTEMPTS;
+    *gateway.ctx.send_failures_remaining.lock().unwrap() =
+        gateway.ctx.channel.delivery_semantics().retry_attempts;
     gateway
         .tick_fake(vec![message(1, "me@icloud.com", "", true, "hello")])
         .await;
@@ -2646,7 +2646,8 @@ async fn route_agent_draft_requires_bound_approval_before_atomic_install() {
     );
     let (thread, _) = gateway.channel.accept(&inbound).unwrap();
     let draft_directory =
-        crate::drafts::origin_directory(&cfg, &approval_origin(&inbound, &thread)).unwrap();
+        crate::drafts::origin_directory(&cfg, &gateway.channel.approval_origin(&inbound, &thread))
+            .unwrap();
     let body = format!(
         "+++\nversion = 1\ntimeout = \"5s\"\nworkdir = {:?}\nbackend = \"codex\"\n+++\n\nPrepare a note.\n",
         workdir.to_string_lossy()
@@ -2792,8 +2793,11 @@ async fn failed_run_and_recovered_outbound_still_reconcile_origin_drafts() {
     let mut gateway = Gateway::new(cfg.clone()).unwrap();
     let failed_message = message(1, "+15551234567", "+15551234567", false, "draft then fail");
     let (thread, _) = gateway.channel.accept(&failed_message).unwrap();
-    let directory =
-        crate::drafts::origin_directory(&cfg, &approval_origin(&failed_message, &thread)).unwrap();
+    let directory = crate::drafts::origin_directory(
+        &cfg,
+        &gateway.channel.approval_origin(&failed_message, &thread),
+    )
+    .unwrap();
     let failed_body = draft_runbook(&workdir, "CREATED BEFORE FAILURE");
     let hook = Arc::new(move || {
         std::fs::write(directory.join("failed-run.md"), &failed_body).unwrap();
@@ -2826,7 +2830,9 @@ async fn failed_run_and_recovered_outbound_still_reconcile_origin_drafts() {
     let (recovered_thread, _) = gateway.channel.accept(&recovered_message).unwrap();
     let recovered_dir = crate::drafts::origin_directory(
         &cfg,
-        &approval_origin(&recovered_message, &recovered_thread),
+        &gateway
+            .channel
+            .approval_origin(&recovered_message, &recovered_thread),
     )
     .unwrap();
     std::fs::write(
@@ -2893,7 +2899,8 @@ async fn failed_draft_delivery_retries_after_restart_before_expiry() {
     .unwrap();
     let job = draft_test_job(1, "+15551234567", origin);
     let gateway = Gateway::new(cfg.clone()).unwrap();
-    *gateway.ctx.send_failures_remaining.lock().unwrap() = DELIVERY_ATTEMPTS;
+    *gateway.ctx.send_failures_remaining.lock().unwrap() =
+        gateway.ctx.channel.delivery_semantics().retry_attempts;
 
     assert!(present_drafts(&gateway.ctx, &job, &directory)
         .await

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -20,8 +20,6 @@ use crate::voice::MAX_AUDIO_BYTES;
 
 use super::{audit, complete_row, reply_to, Ctx, Job, WorkerState};
 
-const TYPING_REFRESH: Duration = Duration::from_secs(4);
-pub(super) const DELIVERY_ATTEMPTS: usize = 3;
 pub(super) const SESSION_SETUP_FAILURE: &str =
     "Push could not prepare this conversation. Check the local logs, then resend.";
 pub(super) const DRAFT_SETUP_FAILURE: &str =
@@ -392,17 +390,18 @@ where
         result
     };
     let run = async {
-        if ctx.channel.supports_typing() {
+        if let Some(refresh) = ctx.channel.typing_refresh() {
             let channel = ctx.channel.clone();
+            let channel_id = channel.id();
             let target = job.target.clone();
             let thread = job.thread.clone();
-            run_with_periodic_activity(run, TYPING_REFRESH, move || {
+            run_with_periodic_activity(run, refresh, move || {
                 let channel = channel.clone();
                 let target = target.clone();
                 let thread = thread.clone();
                 async move {
                     if let Err(e) = channel.send_typing(&target).await {
-                        warn!("[{thread}] Telegram typing update failed: {e}");
+                        warn!("[{thread}] {channel_id} typing update failed: {e}");
                     }
                 }
             })
@@ -948,6 +947,7 @@ async fn deliver_stored(
         return Ok(DeliveryOutcome::AlreadyDelivered);
     }
     let mut outbound = outbound.clone();
+    let semantics = ctx.channel.delivery_semantics();
     let mut attempt = 0;
     loop {
         attempt += 1;
@@ -975,17 +975,18 @@ async fn deliver_stored(
                 "stored outbound delivery attempt failed",
             ),
         );
-        if attempt < DELIVERY_ATTEMPTS {
+        if attempt < semantics.retry_attempts {
             warn!(
-                "delivery attempt {attempt}/{DELIVERY_ATTEMPTS} failed; retrying stored outbound"
+                "delivery attempt {attempt}/{} failed; retrying stored outbound",
+                semantics.retry_attempts
             );
             #[cfg(not(test))]
-            tokio::time::sleep(Duration::from_millis(250)).await;
+            tokio::time::sleep(semantics.retry_delay).await;
         } else {
             warn!("delivery attempts exhausted; stored outbound remains failed and will retry");
             attempt = 0;
             #[cfg(not(test))]
-            tokio::time::sleep(Duration::from_secs(5)).await;
+            tokio::time::sleep(semantics.exhausted_retry_delay).await;
         }
         #[cfg(test)]
         tokio::task::yield_now().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1152,36 +1152,59 @@ allow_user_ids = [7]
                 channel: None,
                 agent: "codex".to_string(),
             },
+            config::RouteRule {
+                thread: Some("imessage:self:me@icloud.com".to_string()),
+                channel: None,
+                agent: "claude".to_string(),
+            },
         ];
 
         assert_eq!(
-            cfg.route_for_message("telegram", "telegram:dm:7")
+            cfg.route_for_message("telegram", &[vec!["telegram:dm:7".to_string()]])
                 .unwrap()
                 .backend,
             config::AgentBackend::Claude
         );
         assert_eq!(
-            cfg.route_for_message("telegram", "telegram:dm:8")
+            cfg.route_for_message("telegram", &[vec!["telegram:dm:8".to_string()]])
                 .unwrap()
                 .backend,
             config::AgentBackend::Codex
         );
         assert_eq!(
-            cfg.route_for_message("telegram", "telegram:dm:7:topic:99")
-                .unwrap()
-                .backend,
+            cfg.route_for_message(
+                "telegram",
+                &[
+                    vec!["telegram:dm:7:topic:99".to_string()],
+                    vec!["telegram:dm:7".to_string()],
+                ],
+            )
+            .unwrap()
+            .backend,
             config::AgentBackend::Codex
         );
         assert_eq!(
-            cfg.route_for_message("telegram", "telegram:dm:7:topic:100")
-                .unwrap()
-                .backend,
+            cfg.route_for_message(
+                "telegram",
+                &[
+                    vec!["telegram:dm:7:topic:100".to_string()],
+                    vec!["telegram:dm:7".to_string()],
+                ],
+            )
+            .unwrap()
+            .backend,
             config::AgentBackend::Claude
         );
         assert_eq!(
-            cfg.route_for_message("imessage", "imessage:self:me@icloud.com")
-                .unwrap()
-                .backend,
+            cfg.route_for_message(
+                "imessage",
+                &[vec![
+                    "imessage:self:me@icloud.com".to_string(),
+                    "self:me@icloud.com".to_string(),
+                ]],
+            )
+            .unwrap()
+            .backend,
             config::AgentBackend::Codex
         );
     }


### PR DESCRIPTION
Closes #120

## Summary

- define a closed, compile-time Rust channel contract for polling, authorization, stable identity, routing, delivery, typing, rich messages, retry, voice, and shutdown
- migrate iMessage and Telegram behind explicit static dispatch without configuration changes or a dynamic plugin system
- move provider-specific approval and route identity out of shared gateway/config branches
- document the channel boundary and lifecycle obligations

## Acceptance proof

- Both existing providers implement the same compile-time contract.
- Focused contract tests cover stable iMessage DM and Telegram topic keys, exact reply targets, approval identities, route precedence, and outbound chunk behavior.
- Existing dual-channel, primary delivery, retry, shutdown, typing, rich-message, and voice tests remain green.
- Legacy iMessage route aliases preserve configuration-order precedence; Telegram exact-topic routes still outrank parent-chat fallback.
- No Slack implementation or configuration format changes are included.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` (324 passed)

## Review

A fresh diff reviewer found one iMessage alias-precedence regression. It was fixed with route-key precedence groups and a regression test. A second fresh review found no remaining actionable issues.
