### PR TITLE
feat(init): add morning AI brief

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,8 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "humantime",
+ "iana-time-zone",
+ "libc",
  "pulldown-cmark",
  "reqwest",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ chrono = "0.4"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 pulldown-cmark = { version = "0.13", default-features = false }
+iana-time-zone = "0.1"
+libc = "0.2"
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ push init ~/Code/assistant
 ```
 
 This creates a Git repository containing `SOUL.md`, `AGENTS.md`, `context/`,
-`evals/`, and `jobs/`, then records its path in `~/.push/config.toml`. New configs use
-Telegram and Codex by default. Edit the config to add your Telegram bot token
-and numeric user ID:
+`evals/`, and `jobs/`, then records its path in `~/.push/config.toml`. It also
+installs a morning AI news brief scheduled for 8:00 each day in your machine's
+local IANA timezone. New configs use Telegram and Codex by default. Edit the
+config to add your Telegram bot token and numeric user ID:
 
 ```toml
 channel = "telegram"
@@ -114,6 +115,10 @@ assistant_root = "~/Code/assistant"
 [telegram]
 bot_token = "token-from-BotFather"
 allow_user_ids = [123456789]
+
+[primary_delivery]
+channel = "telegram"
+target = "123456789"
 ```
 
 For iMessage, use the [iMessage setup guide](docs/channels/imessage.md). For

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,12 +75,16 @@ push init ~/Code/assistant
 ```
 
 Push creates one Git-versioned repository containing `SOUL.md`, `AGENTS.md`,
-`README.md`, `context/`, and empty `evals/` and `jobs/` directories. It records the canonical root in
-the selected config file. A new config starts with Telegram, Codex, and an empty
-`telegram.allow_user_ids` list that you must fill in. Edit `SOUL.md` to define
-identity and operating style, then add durable user context under `context/`.
-Push reads these files at run time and never writes machine-specific paths into
-the repository.
+`README.md`, `context/`, `evals/`, and `jobs/`. It also installs an enabled
+`morning-ai-brief` job scheduled for 8:00 each day in the machine's local IANA
+timezone. The brief opens with a friendly greeting, summarizes the top current
+AI news with source links, and ends with an uplifting message.
+
+Push records the canonical root in the selected config file. A new config
+starts with Telegram, Codex, and an empty `telegram.allow_user_ids` list that
+you must fill in. Edit `SOUL.md` to define identity and operating style, then
+add durable user context under `context/`. Push reads these files at run time
+and keeps runtime state outside the repository.
 
 ## 4. Configure a channel
 
@@ -97,6 +101,10 @@ the repository.
     [telegram]
     bot_token = "token-from-BotFather"
     allow_user_ids = [123456789]
+
+    [primary_delivery]
+    channel = "telegram"
+    target = "123456789"
     ```
 
     Read the [Telegram guide](telegram.md) for token storage, allowlisting,
@@ -114,6 +122,10 @@ the repository.
 
     [imessage]
     self_handles = ["you@icloud.com"]
+
+    [primary_delivery]
+    channel = "imessage"
+    target = "you@icloud.com"
     ```
 
     `self_handles` is for a private conversation with yourself. Use
@@ -128,6 +140,10 @@ If you replace the config file created by `push init`, keep its
 `assistant_root` setting. Running the same init command again is safe for a
 complete assistant repository and restores the setting without overwriting
 user files.
+
+The morning brief starts delivering after you configure `primary_delivery`.
+Edit `jobs/morning-ai-brief.md` if you want a different time, timezone, tone,
+or set of stories.
 
 ## 5. Validate and run
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -47,7 +47,10 @@ settings from the current shell.
 `push init` accepts an empty target, the selected config by itself, or a
 complete existing assistant layout. It refuses unrelated and partial non-empty
 directories, never overwrites an existing assistant file, persists one
-canonical `assistant_root`, and initializes Git when needed.
+canonical `assistant_root`, and initializes Git when needed. A new assistant
+also gets an enabled `morning-ai-brief` job scheduled for 8:00 each day in the
+machine's local IANA timezone. Delivery starts after `primary_delivery` is
+configured.
 
 ## Commands sent in chat
 

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -49,6 +49,31 @@ Store durable facts and working context here when they should be available acros
 Good examples include preferences, active projects, people, recurring processes, and reference notes. Keep secrets out of this repository. Start with small, focused Markdown files and update or remove stale information.
 "#;
 
+const MORNING_BRIEF: &str = r#"+++
+version = 1
+timeout = "__TIMEOUT__"
+workdir = __WORKDIR__
+
+[[triggers]]
+id = "every-morning"
+kind = "cron"
+schedule = "0 8 * * *"
+timezone = "__TIMEZONE__"
+enabled = true
++++
+
+Start with a warm, friendly good-morning greeting.
+
+Use the web research tools available to you to find the most important current
+AI news stories. Select the top three to five stories based on significance,
+not hype. For each story, give a concise summary, explain why it matters, and
+include a direct source link. Prefer recent primary sources and clearly label
+anything uncertain.
+
+Finish with a short, positive, uplifting message wishing the user an amazing
+day. Keep the whole brief useful, calm, and easy to scan.
+"#;
+
 const DEFAULT_CONFIG: &str = r#"# Telegram quick start.
 channel = "telegram"
 agent = "codex"
@@ -58,6 +83,12 @@ agent = "codex"
 bot_token = ""
 # Replace this with your numeric Telegram user ID.
 allow_user_ids = []
+
+# The starter morning job needs a delivery destination. Uncomment this section
+# after replacing the target with the same Telegram user ID.
+# [primary_delivery]
+# channel = "telegram"
+# target = "123456789"
 "#;
 
 #[derive(Debug)]
@@ -80,10 +111,10 @@ pub fn init(requested_path: &str, config_path: &str) -> Result<InitResult> {
     let config_path = absolute_path(Path::new(&expanded_config)).context("resolve config path")?;
     let existing_config = inspect_config(&config_path, &target)?;
 
-    prepare_target(&target, &config_path)?;
+    let target_state = prepare_target(&target, &config_path)?;
     let root = fs::canonicalize(&target)
         .with_context(|| format!("resolve assistant root {}", target.display()))?;
-    scaffold(&root)?;
+    scaffold(&root, &config_path, target_state == TargetState::New)?;
     let git_initialized = initialize_git(&root)?;
     persist_root(&config_path, &root, existing_config)?;
     if inspect_config(&config_path, &root)? != ConfigState::MatchingRoot {
@@ -289,7 +320,13 @@ fn resolve_existing_or_lexical(path: &Path) -> Result<PathBuf> {
     Ok(resolved)
 }
 
-fn prepare_target(target: &Path, config_path: &Path) -> Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetState {
+    New,
+    Existing,
+}
+
+fn prepare_target(target: &Path, config_path: &Path) -> Result<TargetState> {
     if target.exists() {
         if !target.is_dir() {
             bail!("assistant target {} is not a directory", target.display());
@@ -308,7 +345,7 @@ fn prepare_target(target: &Path, config_path: &Path) -> Result<()> {
             if target.join(".git").exists() {
                 verify_git_root(target).context("validate existing Git metadata before init")?;
             }
-            return Ok(());
+            return Ok(TargetState::New);
         }
         if !valid_assistant_structure(target) {
             bail!(
@@ -316,13 +353,14 @@ fn prepare_target(target: &Path, config_path: &Path) -> Result<()> {
                 target.display()
             );
         }
-        return Ok(());
+        return Ok(TargetState::Existing);
     }
     fs::create_dir_all(target)
-        .with_context(|| format!("create assistant directory {}", target.display()))
+        .with_context(|| format!("create assistant directory {}", target.display()))?;
+    Ok(TargetState::New)
 }
 
-fn scaffold(root: &Path) -> Result<()> {
+fn scaffold(root: &Path, config_path: &Path, install_starter: bool) -> Result<()> {
     create_directory(&root.join("context"))?;
     create_directory(&root.join("evals"))?;
     create_directory(&root.join("jobs"))?;
@@ -330,6 +368,164 @@ fn scaffold(root: &Path) -> Result<()> {
     create_file(&root.join("AGENTS.md"), AGENTS)?;
     create_file(&root.join("README.md"), README)?;
     create_file(&root.join("context/README.md"), CONTEXT_README)?;
+    if install_starter {
+        let morning_brief = starter_morning_brief(config_path, root)?;
+        create_file(&root.join("jobs/morning-ai-brief.md"), &morning_brief)?;
+    }
+    Ok(())
+}
+
+fn starter_morning_brief(config_path: &Path, root: &Path) -> Result<String> {
+    let config = match fs::read_to_string(config_path) {
+        Ok(raw) => Some(
+            toml::from_str::<toml::Value>(&raw)
+                .with_context(|| format!("parse config {}", config_path.display()))?
+                .as_table()
+                .context("config must be a TOML table")?
+                .clone(),
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(error).with_context(|| format!("read config {}", config_path.display()))
+        }
+    };
+    let max_timeout = match config
+        .as_ref()
+        .and_then(|table| table.get("jobs_max_timeout"))
+    {
+        Some(value) => humantime::parse_duration(
+            value
+                .as_str()
+                .context("jobs_max_timeout must be a string")?,
+        )
+        .context("invalid jobs_max_timeout")?,
+        None => std::time::Duration::from_secs(30 * 60),
+    };
+    if max_timeout.is_zero() {
+        bail!("jobs_max_timeout must be positive");
+    }
+    let timeout = std::cmp::min(max_timeout, std::time::Duration::from_secs(10 * 60));
+
+    let mut protected = vec![
+        ("assistant_root", root.to_path_buf()),
+        (
+            "config file",
+            resolve_existing_or_lexical(config_path).context("resolve config path")?,
+        ),
+    ];
+    for (key, default) in [
+        ("drafts_dir", "~/.push/drafts"),
+        ("jobs_run_dir", "~/.push/run"),
+        ("state_path", "~/.push/state.json"),
+        ("database_path", "~/.push/push.db"),
+        ("audit_log_path", "~/.push/audit.jsonl"),
+    ] {
+        protected.push((key, configured_runtime_path(config.as_ref(), key, default)?));
+    }
+    let config_parent = resolve_existing_or_lexical(config_path)?
+        .parent()
+        .context("config path has no parent directory")?
+        .to_path_buf();
+    let primary_workdir = config_parent.join("workdirs/morning-ai-brief");
+    let fallback_workdir = fallback_workdir(root)?;
+    let workdir = [primary_workdir, fallback_workdir]
+        .into_iter()
+        .find_map(|candidate| {
+            let resolved = resolve_existing_or_lexical(&candidate).ok()?;
+            (!protected
+                .iter()
+                .any(|(_, path)| paths_overlap(&resolved, path)))
+            .then_some(candidate)
+        })
+        .context("no safe starter job workdir is available outside Push-owned paths")?;
+    create_private_directory(&workdir)?;
+
+    Ok(MORNING_BRIEF
+        .replace(
+            "__TIMEOUT__",
+            &humantime::format_duration(timeout).to_string(),
+        )
+        .replace(
+            "__WORKDIR__",
+            &toml::Value::String(workdir.to_string_lossy().into_owned()).to_string(),
+        )
+        .replace("__TIMEZONE__", &local_timezone()?))
+}
+
+fn local_timezone() -> Result<String> {
+    let candidate = std::env::var("TZ")
+        .ok()
+        .and_then(|candidate| parse_timezone_candidate(&candidate))
+        .map(Ok)
+        .unwrap_or_else(|| {
+            iana_time_zone::get_timezone().context(
+                "detect local IANA timezone for starter job; set TZ to a valid IANA timezone",
+            )
+        })?;
+    parse_timezone_candidate(&candidate).with_context(|| {
+        format!("local timezone {candidate:?} is not supported by the scheduler; set TZ to a valid IANA timezone")
+    })
+}
+
+fn parse_timezone_candidate(candidate: &str) -> Option<String> {
+    candidate
+        .trim()
+        .trim_start_matches(':')
+        .parse::<chrono_tz::Tz>()
+        .ok()
+        .map(|timezone| timezone.name().to_string())
+}
+
+fn paths_overlap(left: &Path, right: &Path) -> bool {
+    left.starts_with(right) || right.starts_with(left)
+}
+
+fn fallback_workdir(root: &Path) -> Result<PathBuf> {
+    let name = root
+        .file_name()
+        .context("assistant root has no directory name")?
+        .to_string_lossy();
+    Ok(root
+        .parent()
+        .context("assistant root has no parent directory")?
+        .join(format!(".{name}-push-workdirs/morning-ai-brief")))
+}
+
+fn create_private_directory(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.file_type().is_dir() {
+                bail!(
+                    "starter job workdir {} must be a real directory, not a file or symlink",
+                    path.display()
+                );
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::MetadataExt;
+                if metadata.uid() != unsafe { libc::geteuid() } {
+                    bail!(
+                        "starter job workdir {} is not owned by the current user",
+                        path.display()
+                    );
+                }
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir_all(path)
+                .with_context(|| format!("create starter job workdir {}", path.display()))?;
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspect starter job workdir {}", path.display()))
+        }
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("restrict starter job workdir {}", path.display()))?;
+    }
     Ok(())
 }
 
@@ -545,7 +741,12 @@ mod tests {
         assert!(target.join("context/README.md").is_file());
         assert!(target.join("evals").is_dir());
         assert!(target.join("jobs").is_dir());
-        assert_eq!(fs::read_dir(target.join("jobs")).unwrap().count(), 0);
+        let morning_brief = fs::read_to_string(target.join("jobs/morning-ai-brief.md")).unwrap();
+        assert!(morning_brief.contains("schedule = \"0 8 * * *\""));
+        assert!(morning_brief.contains("enabled = true"));
+        assert!(morning_brief.contains("top three to five stories"));
+        assert!(morning_brief.contains("amazing\nday"));
+        assert!(!morning_brief.contains("__TIMEZONE__"));
         assert!(target.join(".git").exists());
         let raw = fs::read_to_string(config).unwrap();
         assert!(raw.contains(&format!(
@@ -563,6 +764,11 @@ mod tests {
         init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
         fs::write(target.join("SOUL.md"), "My identity\n").unwrap();
         fs::write(target.join("context/private.md"), "Keep me\n").unwrap();
+        fs::write(
+            target.join("jobs/morning-ai-brief.md"),
+            "My custom morning job\n",
+        )
+        .unwrap();
         let config_before = fs::read_to_string(&config).unwrap();
 
         let result = init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
@@ -576,7 +782,115 @@ mod tests {
             fs::read_to_string(target.join("context/private.md")).unwrap(),
             "Keep me\n"
         );
+        assert_eq!(
+            fs::read_to_string(target.join("jobs/morning-ai-brief.md")).unwrap(),
+            "My custom morning job\n"
+        );
         assert_eq!(fs::read_to_string(config).unwrap(), config_before);
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[test]
+    fn parses_system_timezone_candidates() {
+        assert_eq!(
+            parse_timezone_candidate("Europe/London\n").as_deref(),
+            Some("Europe/London")
+        );
+        assert_eq!(
+            parse_timezone_candidate("America/New_York").as_deref(),
+            Some("America/New_York")
+        );
+        assert_eq!(
+            parse_timezone_candidate(":Asia/Tokyo").as_deref(),
+            Some("Asia/Tokyo")
+        );
+        assert_eq!(parse_timezone_candidate("localtime"), None);
+    }
+
+    #[test]
+    fn starter_morning_job_is_valid_for_a_new_assistant() {
+        let parent = temp_dir("assistant-starter-job");
+        let target = parent.join("assistant");
+        let config = parent.join("push.toml");
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+        let raw = fs::read_to_string(&config)
+            .unwrap()
+            .replace("allow_user_ids = []", "allow_user_ids = [1]")
+            .replace("bot_token = \"\"", "bot_token = \"test-token\"");
+        fs::write(&config, raw).unwrap();
+
+        let cfg = crate::config::Config::load(config.to_str().unwrap()).unwrap();
+        let catalog = crate::jobs::Catalog::load(&cfg).unwrap();
+
+        assert!(catalog.errors.is_empty());
+        let job = catalog.jobs.get("morning-ai-brief").unwrap();
+        assert_eq!(job.triggers.len(), 1);
+        assert!(job.triggers[0].enabled);
+        assert_eq!(
+            job.workdir,
+            fs::canonicalize(parent.join("workdirs/morning-ai-brief")).unwrap()
+        );
+        assert!(job.workdir.is_dir());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&job.workdir).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[test]
+    fn starter_job_respects_a_lower_configured_timeout() {
+        let parent = temp_dir("assistant-starter-timeout");
+        let target = parent.join("assistant");
+        let config = parent.join("push.toml");
+        fs::write(&config, "jobs_max_timeout = '30s'\n").unwrap();
+
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+
+        let job = fs::read_to_string(target.join("jobs/morning-ai-brief.md")).unwrap();
+        assert!(job.contains("timeout = \"30s\""));
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[test]
+    fn reinit_does_not_add_a_starter_job_to_an_existing_assistant() {
+        let parent = temp_dir("assistant-existing-without-starter");
+        let target = parent.join("assistant");
+        let config = parent.join("push.toml");
+        fs::create_dir_all(target.join("context")).unwrap();
+        fs::create_dir_all(target.join("jobs")).unwrap();
+        for relative in ["SOUL.md", "AGENTS.md", "README.md", "context/README.md"] {
+            fs::write(target.join(relative), "Existing\n").unwrap();
+        }
+
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+
+        assert!(!target.join("jobs/morning-ai-brief.md").exists());
+        assert!(target.join(".git").exists());
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_a_symlinked_starter_workdir() {
+        use std::os::unix::fs::symlink;
+
+        let parent = temp_dir("assistant-starter-workdir-symlink");
+        let target = parent.join("assistant");
+        let config = parent.join("push.toml");
+        let attacker_dir = parent.join("attacker-controlled");
+        fs::create_dir_all(parent.join("workdirs")).unwrap();
+        fs::create_dir(&attacker_dir).unwrap();
+        symlink(&attacker_dir, parent.join("workdirs/morning-ai-brief")).unwrap();
+
+        let error = init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("file or symlink"));
+        assert!(!target.join("jobs/morning-ai-brief.md").exists());
         let _ = fs::remove_dir_all(parent);
     }
 
@@ -725,6 +1039,7 @@ mod tests {
         let target = temp_path("assistant-dot");
         fs::create_dir_all(&target).unwrap();
         let config = target.join("config.toml");
+        let fallback = fallback_workdir(&target).unwrap();
 
         init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
 
@@ -732,6 +1047,7 @@ mod tests {
             .unwrap()
             .contains("assistant_root = \".\""));
         let _ = fs::remove_dir_all(target);
+        let _ = fs::remove_dir_all(fallback.parent().unwrap());
     }
 
     #[test]
@@ -739,6 +1055,7 @@ mod tests {
         let target = temp_path("assistant-dot-config");
         fs::create_dir_all(&target).unwrap();
         let config = target.join("config.toml");
+        let fallback = fallback_workdir(&target).unwrap();
         fs::write(&config, "channel = 'telegram'\n").unwrap();
 
         init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
@@ -750,6 +1067,7 @@ mod tests {
         assert!(!raw.contains("allow_user_ids"));
         assert!(target.join("SOUL.md").is_file());
         let _ = fs::remove_dir_all(target);
+        let _ = fs::remove_dir_all(fallback.parent().unwrap());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,11 +79,18 @@ async fn main() -> Result<()> {
                 println!("Initialized Git repository.");
             }
             println!("\nNext:");
-            println!("  Review or configure the channel and its allowlist:");
+            println!("  Configure the channel, allowlist, and primary delivery:");
             println!("    $EDITOR {}", result.config_path.display());
             println!("  Customize the assistant:");
             println!("    $EDITOR {}/SOUL.md", result.root.display());
             println!("    $EDITOR {}/context/README.md", result.root.display());
+            if result.root.join("jobs/morning-ai-brief.md").is_file() {
+                println!("  Review the daily 8:00 AI news brief:");
+                println!(
+                    "    $EDITOR {}/jobs/morning-ai-brief.md",
+                    result.root.display()
+                );
+            }
             println!("  Validate and run:");
             if args.config_path == DEFAULT_CONFIG_PATH {
                 println!("    push doctor");

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -86,6 +86,11 @@ fn init_without_path_creates_assistant_in_current_directory() {
     assert!(assistant.join("context/README.md").is_file());
     assert!(assistant.join("evals").is_dir());
     assert!(assistant.join("jobs").is_dir());
+    let morning_brief =
+        std::fs::read_to_string(assistant.join("jobs/morning-ai-brief.md")).unwrap();
+    assert!(morning_brief.contains("schedule = \"0 8 * * *\""));
+    assert!(morning_brief.contains("enabled = true"));
+    assert!(morning_brief.contains("AI news stories"));
     assert!(assistant.join(".git").exists());
     let config_path = home.join(".push/config.toml");
     let config = std::fs::read_to_string(&config_path).unwrap();
@@ -95,6 +100,8 @@ fn init_without_path_creates_assistant_in_current_directory() {
     assert!(config.contains("[telegram]"));
     assert!(config.contains("allow_user_ids = []"));
     assert!(config.contains("bot_token = \"\""));
+    assert!(config.contains("# [primary_delivery]"));
+    assert!(config.contains("# target = \"123456789\""));
     assert!(config.contains(
         &assistant
             .canonicalize()
@@ -115,7 +122,7 @@ fn init_without_path_creates_assistant_in_current_directory() {
         );
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Review or configure the channel and its allowlist:"));
+    assert!(stdout.contains("Configure the channel, allowlist, and primary delivery:"));
     assert!(stdout.contains("push doctor"));
     assert!(!stdout.contains("push doctor --config"));
     assert!(stdout.contains(&format!("$EDITOR {}", config_path.display())));
@@ -126,6 +133,8 @@ fn init_without_path_creates_assistant_in_current_directory() {
             < stdout.find("push doctor").unwrap()
     );
     assert!(stdout.contains("SOUL.md"));
+    assert!(stdout.contains("Review the daily 8:00 AI news brief:"));
+    assert!(stdout.contains("jobs/morning-ai-brief.md"));
 
     let run_output = Command::new(env!("CARGO_BIN_EXE_push"))
         .current_dir(&workdir)


### PR DESCRIPTION
## Summary

- scaffold an enabled daily 8:00 AI news brief for new assistants
- detect the local IANA timezone and create a private, validated job workdir
- guide users to configure primary delivery and customize the starter job

## Why

New Push users should receive useful proactive behavior immediately after setup, with a friendly morning greeting, current AI news, and an uplifting close.

## Test plan

- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `uv run --with mkdocs --with mkdocs-material mkdocs build --strict`
- rendered Quickstart and CLI docs checked at 1280x800 and 390x844 with no overflow or console errors
- subagent diff review completed with no remaining findings

## Risks

Platform-specific timezone and filesystem behavior may differ outside the tested macOS environment. Init fails with actionable errors when it cannot detect a supported timezone or create a safe private workdir. Existing assistant repositories do not receive the enabled job on re-init.

## Related issue

None.