### PR TITLE
feat(init): unify assistant instructions and document design

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ and schedule work with plain Markdown runbooks.
 
 It can review repositories before you wake up, watch pull requests, prepare a
 daily brief, or pick up a conversation from your phone. You own one portable,
-Git-versioned assistant repository containing identity, context, and jobs. Push
-owns channels, schedule evaluation, history, approvals, security, and result
-delivery. Each job file owns its schedule definition.
-Your coding agent owns the intelligence and tools.
+Git-versioned assistant repository containing identity, context, jobs, and
+optional project skills. Push owns channels, schedule evaluation, history,
+approvals, security, and result delivery. Each job file owns its schedule
+definition. Your coding agent owns the intelligence and execution.
 
 [Read the documentation](https://owainlewis.github.io/push/) ·
 [Get started](#quickstart) ·
@@ -26,16 +26,18 @@ Your coding agent owns the intelligence and tools.
 - **An assistant that is actually available.** Push runs continuously under
   `launchd` or `systemd`, not only while a terminal window is open.
 - **The agents you already use.** Keep Claude Code, Codex, or Pi, including
-  their model access, tools, MCP servers, skills, login, and backend
+  their model access, tools, MCP servers, global skills, login, and backend
   configuration.
 - **Conversations from your phone.** Use private iMessage, Telegram, or Slack app DMs.
   Each thread keeps its own backend session and canonical history.
 - **Work that starts without you.** A five-field cron trigger can run a
   Markdown job and send the stored result back to your primary chat.
-- **State you own.** `SOUL.md`, durable context, and installed jobs live in
-  one assistant repository. History is local SQLite and configuration is TOML.
+- **State you own.** `SOUL.md`, durable context, installed jobs, and optional
+  project skills live in one assistant repository. History is local SQLite and
+  configuration is TOML.
 - **A small local control layer.** Sender allowlists constrain chat access.
-  Agent permissions, tools, and MCP servers stay in the agent configuration.
+  Agent permissions, skill execution, tools, and MCP servers stay in the agent
+  configuration.
   Telegram uses outbound long polling and Slack uses outbound Socket Mode. Neither opens a port.
 
 ## The model
@@ -211,6 +213,7 @@ builds the [Push documentation site](https://owainlewis.github.io/push/) on
 every documentation change to `main`.
 
 - [Quickstart](docs/getting-started.md)
+- [Designing an assistant](docs/designing-an-assistant.md)
 - [Configuration](docs/configuration.md)
 - [Jobs and schedules](docs/jobs.md)
 - [Permissions and security](docs/security.md)

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ Create the assistant repository and default config:
 push init ~/Code/assistant
 ```
 
-This creates a Git repository containing `SOUL.md`, `AGENTS.md`, `context/`,
-`evals/`, and `jobs/`, then records its path in `~/.push/config.toml`. New configs use
+This creates a Git repository containing `SOUL.md`, shared instructions in
+`AGENTS.md`, a `CLAUDE.md` reference to those instructions, `context/`, `evals/`,
+and `jobs/`, then records its path in `~/.push/config.toml`. New configs use
 Telegram and Codex by default. Edit the config to add your Telegram bot token
 and numeric user ID:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,8 +15,9 @@ Ownership is split deliberately:
 
 ```text
 Push runtime         = channels, scheduling, history, security, delivery
-Assistant repository = SOUL.md, context, jobs
-Agent runtime        = reasoning, tools, skills, MCP, authentication
+Assistant repository = SOUL.md, context, jobs, optional project skills
+Agent runtime        = reasoning, tool and skill execution, permissions,
+                       global skills, MCP, authentication
 ```
 
 ## Principles
@@ -74,7 +75,7 @@ flowchart LR
         gateway --> worker[Per-thread worker]
         store[(state.json)] <--> gateway
         history[(push.db)] <--> gateway
-        assistant[/assistant repo: SOUL.md, context, jobs/] --> worker
+        assistant[/assistant repo: SOUL.md, context, jobs, project skills/] --> worker
         worker --> adapter[Agent adapter]
     end
     adapter -->|claude -p| claude[Claude Code]
@@ -389,7 +390,9 @@ and its configuration decide what to inspect. Instructions include the absolute
 
 Sessions, databases, drafts, audit logs, delivery state, locks, config secrets,
 and other runtime state stay outside the Git-versioned assistant repository.
-The backend still owns tools, skills, MCP, authentication, and execution.
+Project-scoped skills and their helper scripts may live in the assistant
+repository. The backend still owns skill discovery and execution, global
+skills, permissions, MCP, and authentication.
 
 ## Concurrency
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,8 +1,8 @@
 # Contributing
 
 Push is a small Rust gateway. Changes should preserve that shape: durable
-assistant infrastructure belongs in Push; model reasoning, tools, MCP, skills,
-and coding workflows belong in the selected backend.
+assistant infrastructure belongs in Push; model reasoning, tool and skill
+execution, MCP, and coding workflows belong in the selected backend.
 
 ## Set up the repository
 

--- a/docs/core-system/design.md
+++ b/docs/core-system/design.md
@@ -15,8 +15,8 @@ Push is a local personal-assistant gateway. It owns channels, conversation
 history, routing, scheduling, approvals, and delivery while
 delegating reasoning and tool use to disposable agent runtimes such as Claude
 Code and Codex. The durable assistant is one user-owned Git repository with
-`SOUL.md`, `context/`, and `jobs/`. Push stores the canonical conversation
-history in SQLite outside that repository.
+`SOUL.md`, `context/`, `jobs/`, and optional project skills. Push stores the
+canonical conversation history in SQLite outside that repository.
 
 ## Goals
 
@@ -57,9 +57,9 @@ history in SQLite outside that repository.
 ### Ownership boundary
 
 ```text
-Push runtime                    Assistant repository          Agent runtime
-channels, scheduling, history   SOUL.md, context, jobs         reasoning, tools,
-security, delivery              user-owned and Git-versioned   skills, MCP, auth
+Push runtime                    Assistant repository            Agent runtime
+channels, scheduling, history   SOUL.md, context, jobs, skills   reasoning, tools,
+security, delivery              user-owned and Git-versioned     execution, global skills, MCP, auth
 ```
 
 The gateway owns durable runtime state. The user owns the assistant repository.
@@ -179,7 +179,8 @@ backend session id. The request separates:
 - working directory and timeout.
 
 Conversation history storage happens around this boundary and is independent
-of the selected backend. Agent tools, skills, MCP servers, model choice, and
+of the selected backend. Agent tools, skill discovery and execution, MCP
+servers, model choice, and
 execution loops remain backend-owned.
 
 ## Alternatives and tradeoffs

--- a/docs/designing-an-assistant.md
+++ b/docs/designing-an-assistant.md
@@ -1,0 +1,224 @@
+# Designing an assistant
+
+An assistant repository is the durable, portable part of your setup. It should
+explain who the assistant is, what it knows, how recurring work runs, and how
+to judge good results. Keep it small enough that you can inspect and version
+every important instruction.
+
+Push creates the starting structure:
+
+```text
+assistant/
+├── SOUL.md
+├── AGENTS.md
+├── CLAUDE.md
+├── README.md
+├── context/
+├── evals/
+└── jobs/
+```
+
+`AGENTS.md` is the shared instruction source. `CLAUDE.md` contains only
+`@AGENTS.md`, so Claude Code and Codex receive the same repository guidance
+without maintaining two copies.
+
+## Start with identity, not a long prompt
+
+Use `SOUL.md` for stable identity and working style:
+
+```markdown
+# SOUL
+
+You are my personal assistant. Be direct, practical, and honest.
+
+## Working style
+
+- State uncertainty instead of guessing.
+- Confirm before external side effects.
+- Prefer short answers with enough evidence to trust them.
+```
+
+Write rules that should apply to almost every conversation. Project details,
+temporary priorities, contact information, and task procedures belong
+elsewhere. A short identity file is easier to reason about and less likely to
+contain conflicting instructions.
+
+Push supplies `SOUL.md` to every conversation and job. It appends its own
+gateway safety rules in memory and does not rewrite the file.
+
+## Organize durable context
+
+Use `context/` for information that should survive across conversations:
+
+```text
+context/
+├── README.md
+├── preferences.md
+├── people.md
+├── projects/
+│   ├── push.md
+│   └── website.md
+└── processes/
+    └── publishing.md
+```
+
+Keep each file focused. Record facts, decisions, preferences, and current state,
+not complete chat transcripts. Include dates when information will become
+stale, and remove obsolete notes rather than accumulating contradictions.
+
+`context/README.md` should act as the index. Push tells the backend to begin
+there when user context is relevant, but it does not inject every context file
+into every prompt.
+
+## Put reusable capabilities in skills
+
+A skill packages one repeatable workflow. Keep its instructions, helper
+scripts, references, examples, and assets together:
+
+```text
+skills/
+└── youtube/
+    ├── SKILL.md
+    ├── scripts/
+    ├── references/
+    └── assets/
+```
+
+Tooling that exists only to support the workflow belongs under the skill's
+`scripts/` directory. Shared external capabilities such as an email connector
+or issue tracker remain configured through the selected agent's MCP or tool
+configuration. Never put credentials in `SKILL.md` or a helper script.
+
+Every skill needs a `SKILL.md` with a name, a description that explains when it
+should run, and the workflow instructions. For example:
+
+```markdown
+---
+name: youtube
+description: Plan and prepare a technical YouTube video from a topic, transcript, or rough notes.
+---
+
+# YouTube
+
+1. Identify the one useful lesson for the intended viewer.
+2. Produce a clear title, opening script, lesson outline, and recording plan.
+3. Use scripts and references in this skill only when the task needs them.
+```
+
+Save that file as `skills/youtube/SKILL.md`. Keep the description specific
+because both Codex and Claude use it to decide when the skill is relevant.
+
+### Share one skill between Codex and Claude
+
+Codex discovers repository skills under `.agents/skills/`. Claude Code uses
+`.claude/skills/`. Both support skill directories that are symbolic links, so
+one canonical skill can serve both backends. See the official [Codex skills
+guide](https://learn.chatgpt.com/docs/build-skills.md) and [Claude Code skills
+guide](https://code.claude.com/docs/en/skills) for their discovery rules.
+
+```text
+assistant/
+├── skills/
+│   └── youtube/
+├── .agents/
+│   └── skills/
+│       └── youtube -> ../../skills/youtube
+└── .claude/
+    └── skills/
+        └── youtube -> ../../skills/youtube
+```
+
+After creating the canonical skill, expose it to both agents from the assistant
+root:
+
+```sh
+mkdir -p .agents/skills .claude/skills
+ln -s ../../skills/youtube .agents/skills/youtube
+ln -s ../../skills/youtube .claude/skills/youtube
+```
+
+Use relative links so the repository remains portable when cloned elsewhere.
+Commit the canonical skill and the links. `push init` does not currently create
+or synchronize skill links, and Pi skill discovery remains controlled by Pi's
+own configuration.
+
+## Use jobs for scheduled outcomes
+
+A skill describes how to perform a reusable workflow. A job describes one
+specific manual or scheduled outcome:
+
+```text
+skills/youtube/          reusable publishing workflow
+jobs/morning-brief.md    scheduled request with timeout and delivery
+```
+
+Keep job bodies self-contained because every job starts a fresh backend
+session without conversation history. Chat turns start in `assistant_root`, but
+jobs start in the job's configured work directory, which must stay outside the
+assistant repository. A job therefore does not automatically discover skills
+linked under the assistant root. Keep required procedures in the job body, or
+make the skill available through the backend's global skill location or the
+job work directory.
+
+Put stable preferences in `SOUL.md` or `context/`, and put the schedule, work
+directory, constraints, required procedure, and requested output in the job.
+See [Jobs and schedules](jobs.md) for the complete runbook format.
+
+## Define what good looks like
+
+Use `evals/` for reusable checks applied to completed jobs:
+
+```markdown
+# Writing quality
+
+Fail work that contains unsupported claims, missing source links, or needlessly
+complex language.
+```
+
+Good evals describe observable properties of the result. Avoid vague goals such
+as "make it excellent." A job can assign several focused evals, such as factual
+support, writing style, and task completion.
+
+## Keep credentials out of the repository
+
+Commit an `.env.example` only when it helps document required variable names:
+
+```dotenv
+YOUTUBE_API_KEY=
+```
+
+Provide real values through the service environment, the selected agent's
+authentication store, or another local secret manager. Push does not load an
+assistant-root `.env` file automatically. A gitignored `.env` used directly by
+a helper tool is still sensitive local state; restrict it to the service user
+and do not assume `.gitignore` prevents accidental disclosure.
+
+Never commit tokens, OAuth data, session state, conversation databases, audit
+logs, or Push configuration containing credentials. Read [Permissions and
+security](security.md) before running an assistant unattended.
+
+## Grow the assistant deliberately
+
+Use this order when adding a capability:
+
+1. Try the task in a normal conversation.
+2. Record stable personal or project facts under `context/`.
+3. Extract a repeated workflow into one skill.
+4. Add a job only when the outcome should run manually or on a schedule.
+5. Add an eval when success can be checked consistently.
+6. Review the repository diff before committing the change.
+
+This keeps identity stable and prevents one large instruction file from
+becoming a mixture of preferences, procedures, schedules, and secrets.
+
+## Design checklist
+
+- `SOUL.md` contains only durable identity and working style.
+- `AGENTS.md` is the shared repository guidance.
+- `CLAUDE.md` references `AGENTS.md` instead of copying it.
+- `context/README.md` indexes focused, current context files.
+- each skill owns its instructions and supporting tooling.
+- each job requests one self-contained outcome.
+- evals describe observable pass or fail conditions.
+- credentials and runtime state stay outside version control.
+- agent permissions match the side effects an allowed sender may request.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,10 +74,12 @@ install -m 755 target/release/push ~/.local/bin/push
 push init ~/Code/assistant
 ```
 
-Push creates one Git-versioned repository containing `SOUL.md`, `AGENTS.md`,
-`README.md`, `context/`, and empty `evals/` and `jobs/` directories. It records the canonical root in
-the selected config file. A new config starts with Telegram, Codex, and an empty
-`telegram.allow_user_ids` list that you must fill in. Edit `SOUL.md` to define
+Push creates one Git-versioned repository containing `SOUL.md`, shared
+instructions in `AGENTS.md`, a `CLAUDE.md` reference to those instructions,
+`README.md`, `context/`, and empty `evals/` and `jobs/` directories. It records
+the canonical root in the selected config file. A new config starts with
+Telegram, Codex, and an empty `telegram.allow_user_ids` list that you must fill
+in. Edit `SOUL.md` to define
 identity and operating style, then add durable user context under `context/`.
 Push reads these files at run time and never writes machine-specific paths into
 the repository.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,11 +15,11 @@ You need:
 - Git for the assistant repository created by `push init`
 - `curl`, `tar`, and either `shasum` or `sha256sum` for the release installer
 
-Push uses the backend's existing login, settings, tools, MCP servers, skills,
-and backend configuration. Each chat runs from `assistant_root`, so the backend
-can discover project instructions such as `AGENTS.md` and work with the
-assistant's context directly. Confirm the selected command works before
-starting Push:
+Push uses the backend's existing login, settings, tools, MCP servers, global
+skills, and backend configuration. Each chat runs from `assistant_root`, so the
+backend can discover project instructions and repository-scoped skills and work
+with the assistant's context directly. Confirm the selected command works
+before starting Push:
 
 === "Codex"
 
@@ -79,10 +79,11 @@ instructions in `AGENTS.md`, a `CLAUDE.md` reference to those instructions,
 `README.md`, `context/`, and empty `evals/` and `jobs/` directories. It records
 the canonical root in the selected config file. A new config starts with
 Telegram, Codex, and an empty `telegram.allow_user_ids` list that you must fill
-in. Edit `SOUL.md` to define
-identity and operating style, then add durable user context under `context/`.
+in. Edit `SOUL.md` to define identity and operating style, then add durable
+user context under `context/`.
 Push reads these files at run time and never writes machine-specific paths into
-the repository.
+the repository. Read [Designing an assistant](designing-an-assistant.md) for a
+practical structure for identity, context, shared skills, jobs, and evals.
 
 ## 4. Configure a channel
 
@@ -176,6 +177,7 @@ a Telegram- or Slack-only Linux host.
 
 ## Next steps
 
+- [Design your assistant repository](designing-an-assistant.md)
 - [Configure both channels and per-thread routes](configuration.md)
 - [Create a manual or scheduled job](jobs.md)
 - [Inspect every CLI command](reference/cli.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,15 @@ to iMessage, Telegram, or Slack.
 
     [:octicons-arrow-right-24: Configure channels](configuration.md#channels)
 
+-   :material-account-cog-outline:{ .lg .middle } **Design your assistant**
+
+    ---
+
+    Shape identity, durable context, reusable skills, jobs, and evaluation
+    criteria without duplicating instructions or committing secrets.
+
+    [:octicons-arrow-right-24: Design the repository](designing-an-assistant.md)
+
 -   :material-calendar-clock:{ .lg .middle } **Automate recurring work**
 
     ---
@@ -74,16 +83,18 @@ Claude Code, Codex, or Pi: reason → use tools → produce result
 ```
 
 You own one Git-versioned assistant repository containing identity, context,
-and jobs. Push owns channels, history, scheduling, approvals, security, and
-delivery. The selected backend owns models, tools, MCP servers, skills, and
-authentication. That boundary keeps Push small and lets the backend change
-without rebuilding your assistant.
+jobs, and optional project skills. Push owns channels, history, scheduling,
+approvals, security, and delivery. The selected backend owns models, skill and
+tool execution, global skills, MCP servers, permissions, and authentication.
+That boundary keeps Push small and lets the backend change without rebuilding
+your assistant.
 
 ## Documentation map
 
 | If you need to… | Read… |
 | --- | --- |
 | install and run one working channel | [Quickstart](getting-started.md) |
+| design identity, context, skills, and jobs | [Designing an assistant](designing-an-assistant.md) |
 | understand every TOML setting | [Configuration](configuration.md) |
 | add recurring or manual work | [Jobs and schedules](jobs.md) |
 | choose backend permissions safely | [Permissions and security](security.md) |

--- a/docs/security.md
+++ b/docs/security.md
@@ -52,7 +52,7 @@ service environment using the narrowest policy that works.
 | Path | Contains |
 | --- | --- |
 | `config.toml` | allowlists, routes, paths, and possibly credentials |
-| `<assistant_root>/` | Git-versioned `SOUL.md`, durable context, evals, and installed jobs |
+| `<assistant_root>/` | Git-versioned identity, context, evals, jobs, and optional project skills |
 | `~/.push/state.json` | channel cursors and backend session IDs |
 | `~/.push/push.db` | conversation history, approvals, and job runs |
 | `~/.push/audit.jsonl` | metadata, errors, handles, and optional content |

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -20,8 +20,8 @@ Push should not compete there.
 
 Push should own the durable gateway layer: messages, routing, scheduling,
 history, security, and delivery. The user should own one portable assistant
-repository with identity, context, and jobs. The agent runtime should be
-replaceable.
+repository with identity, context, jobs, and optional project skills. The agent
+runtime should be replaceable.
 
 ## Product Thesis
 
@@ -60,10 +60,10 @@ A personal assistant needs:
 - Permission and routing rules that match the user's life.
 
 Push supports exactly one assistant. `push init [path]` creates its user-owned,
-Git-versioned repository with `SOUL.md`, `context/`, and `jobs/`. One canonical
-root is configured; the other paths are derived. There are no assistant names,
-IDs, registries, or selection flows. This stays small, legible, and stable
-across backends and machines.
+Git-versioned repository with `SOUL.md`, `context/`, and `jobs/`; the user may
+add project-scoped skills. One canonical root is configured; the other paths
+are derived. There are no assistant names, IDs, registries, or selection flows.
+This stays small, legible, and stable across backends and machines.
 
 ## What The Gateway Owns
 
@@ -88,9 +88,10 @@ across backends and machines.
 - Repo context.
 - Long-running task mechanics.
 
-The assistant repository owns `SOUL.md`, editable context, and installed job
-runbooks. The runtime owns skills, tools, MCP, and authentication. Push runtime
-state and secrets remain outside the repository.
+The assistant repository owns `SOUL.md`, editable context, installed job
+runbooks, and optional project-scoped skills. The runtime owns skill discovery
+and execution, global skills, tools, MCP, permissions, and authentication. Push
+runtime state and secrets remain outside the repository.
 
 The gateway should not rebuild these unless there is no reliable backend
 contract for the job.

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -144,7 +144,8 @@ Protect these files as credentials or private assistant data:
 - the bot token and configuration
 - `state.json` and the audit log
 - `push.db`
-- the private `assistant_root` repository, including `SOUL.md`, context, and jobs
+- the private `assistant_root` repository, including identity, context, jobs,
+  and optional project skills
 
 The assistant directory is intended to be versioned in its own private Git
 repository. Never put bot tokens, config secrets, state files, audit logs, or

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
   - Home: index.md
   - Get started:
       - Quickstart: getting-started.md
+      - Design your assistant: designing-an-assistant.md
       - Configuration: configuration.md
       - iMessage: channels/imessage.md
       - Telegram: telegram.md

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -33,11 +33,14 @@ const AGENTS: &str = r#"# Assistant repository instructions
 - Keep secrets, sessions, databases, drafts, logs, and other runtime state outside this repository.
 "#;
 
+const CLAUDE: &str = "@AGENTS.md\n";
+
 const README: &str = r#"# Assistant
 
 This Git repository contains the durable, user-owned parts of one Push assistant.
 
 - `SOUL.md` defines the assistant's identity and working style.
+- `AGENTS.md` contains shared agent instructions; `CLAUDE.md` references it.
 - `context/` contains durable context the assistant may read and update.
 - `evals/` contains reusable agent evaluation criteria.
 - `jobs/` contains installed Push job runbooks.
@@ -346,6 +349,7 @@ fn scaffold(root: &Path) -> Result<()> {
     create_directory(&root.join("jobs"))?;
     create_file(&root.join("SOUL.md"), SOUL)?;
     create_file(&root.join("AGENTS.md"), AGENTS)?;
+    create_file(&root.join("CLAUDE.md"), CLAUDE)?;
     create_file(&root.join("README.md"), README)?;
     create_file(&root.join("context/README.md"), CONTEXT_README)?;
     Ok(())
@@ -559,6 +563,10 @@ mod tests {
         assert!(result.git_initialized);
         assert!(target.join("SOUL.md").is_file());
         assert!(target.join("AGENTS.md").is_file());
+        assert_eq!(
+            fs::read_to_string(target.join("CLAUDE.md")).unwrap(),
+            CLAUDE
+        );
         assert!(target.join("README.md").is_file());
         assert!(target.join("context/README.md").is_file());
         assert!(target.join("evals").is_dir());
@@ -581,6 +589,7 @@ mod tests {
         init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
         fs::write(target.join("SOUL.md"), "My identity\n").unwrap();
         fs::write(target.join("context/private.md"), "Keep me\n").unwrap();
+        fs::remove_file(target.join("CLAUDE.md")).unwrap();
         let config_before = fs::read_to_string(&config).unwrap();
 
         let result = init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
@@ -593,6 +602,10 @@ mod tests {
         assert_eq!(
             fs::read_to_string(target.join("context/private.md")).unwrap(),
             "Keep me\n"
+        );
+        assert_eq!(
+            fs::read_to_string(target.join("CLAUDE.md")).unwrap(),
+            CLAUDE
         );
         assert_eq!(fs::read_to_string(config).unwrap(), config_before);
         let _ = fs::remove_dir_all(parent);

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -45,7 +45,7 @@ This Git repository contains the durable, user-owned parts of one Push assistant
 - `evals/` contains reusable agent evaluation criteria.
 - `jobs/` contains installed Push job runbooks.
 
-Push owns channels, scheduling, history, security, approvals, and delivery outside this repository. The configured agent runtime owns reasoning, tools, skills, MCP servers, and authentication.
+Push owns channels, scheduling, history, security, approvals, and delivery outside this repository. Project skills may live here, while the configured agent runtime owns discovery, execution, permissions, global skills, MCP servers, and authentication.
 "#;
 
 const CONTEXT_README: &str = r#"# Context

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -83,6 +83,10 @@ fn init_without_path_creates_assistant_in_current_directory() {
     );
     let assistant = workdir.join("assistant");
     assert!(assistant.join("SOUL.md").is_file());
+    assert_eq!(
+        std::fs::read_to_string(assistant.join("CLAUDE.md")).unwrap(),
+        "@AGENTS.md\n"
+    );
     assert!(assistant.join("context/README.md").is_file());
     assert!(assistant.join("evals").is_dir());
     assert!(assistant.join("jobs").is_dir());


### PR DESCRIPTION
## Summary

- generate a minimal `CLAUDE.md` containing `@AGENTS.md`
- keep `AGENTS.md` as the shared cross-agent instruction source
- add a practical guide to designing identity, context, skills, jobs, evals, and secrets
- document one canonical skill shared with Codex and Claude through relative symlinks
- clarify that agents own skill discovery, execution, permissions, MCP, and authentication

## Why

A personal assistant should have one portable source of identity, context, and reusable workflows without duplicating backend instructions. The documentation previously explained operating Push but not how to design the assistant repository itself.

## Test plan

- `cargo fmt --check`
- `cargo test assistant::tests`
- `cargo test`
- `cargo test --test docs`
- `cargo clippy --all-targets -- -D warnings`
- `mkdocs build --strict`
- independent diff review; migration, job skill discovery, ownership, navigation, and skill authoring findings addressed

## Risks

Low. Existing `CLAUDE.md` files are preserved. Re-running init only creates the pointer when it is missing. Shared skill links are documented as an optional manual pattern; `push init` does not claim to create them yet.

## Related issue

None.