### PR TITLE
feat: add portable assistant skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ and schedule work with plain Markdown runbooks.
 
 It can review repositories before you wake up, watch pull requests, prepare a
 daily brief, or pick up a conversation from your phone. You own one portable,
-Git-versioned assistant repository containing identity, context, and jobs. Push
-owns channels, schedule evaluation, history, approvals, security, and result
-delivery. Each job file owns its schedule definition.
-Your coding agent owns the intelligence and tools.
+Git-versioned assistant repository containing identity, context, skills, and
+jobs. Push owns channels, schedule evaluation, history, approvals, security,
+and result delivery. Each job file owns its schedule definition. Your coding
+agent owns reasoning and execution.
 
 [Read the documentation](https://owainlewis.github.io/push/) ·
 [Get started](#quickstart) ·
@@ -26,14 +26,15 @@ Your coding agent owns the intelligence and tools.
 - **An assistant that is actually available.** Push runs continuously under
   `launchd` or `systemd`, not only while a terminal window is open.
 - **The agents you already use.** Keep Claude Code, Codex, or Pi, including
-  their model access, tools, MCP servers, skills, login, and backend
+  their model access, tools, MCP servers, global skills, login, and backend
   configuration.
 - **Conversations from your phone.** Use private iMessage, Telegram, or Slack app DMs.
   Each thread keeps its own backend session and canonical history.
 - **Work that starts without you.** A five-field cron trigger can run a
   Markdown job and send the stored result back to your primary chat.
-- **State you own.** `SOUL.md`, durable context, and installed jobs live in
-  one assistant repository. History is local SQLite and configuration is TOML.
+- **State you own.** `SOUL.md`, durable context, reusable project skills, and
+  installed jobs live in one assistant repository. History is local SQLite and
+  configuration is TOML.
 - **A small local control layer.** Sender allowlists constrain chat access.
   Agent permissions, tools, and MCP servers stay in the agent configuration.
   Telegram uses outbound long polling and Slack uses outbound Socket Mode. Neither opens a port.
@@ -102,9 +103,9 @@ push init ~/Code/assistant
 ```
 
 This creates a Git repository containing `SOUL.md`, `AGENTS.md`, `context/`,
-`evals/`, and `jobs/`, then records its path in `~/.push/config.toml`. New configs use
-Telegram and Codex by default. Edit the config to add your Telegram bot token
-and numeric user ID:
+portable `skills/`, `evals/`, and `jobs/`, then records its path in
+`~/.push/config.toml`. New configs use Telegram and Codex by default. Edit the
+config to add your Telegram bot token and numeric user ID:
 
 ```toml
 channel = "telegram"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,8 +15,8 @@ Ownership is split deliberately:
 
 ```text
 Push runtime         = channels, scheduling, history, security, delivery
-Assistant repository = SOUL.md, context, jobs
-Agent runtime        = reasoning, tools, skills, MCP, authentication
+Assistant repository = SOUL.md, context, project skills, jobs
+Agent runtime        = reasoning, execution, permissions, tools, MCP, authentication
 ```
 
 ## Principles
@@ -74,7 +74,7 @@ flowchart LR
         gateway --> worker[Per-thread worker]
         store[(state.json)] <--> gateway
         history[(push.db)] <--> gateway
-        assistant[/assistant repo: SOUL.md, context, jobs/] --> worker
+        assistant[/assistant repo: SOUL.md, context, skills, jobs/] --> worker
         worker --> adapter[Agent adapter]
     end
     adapter -->|claude -p| claude[Claude Code]
@@ -373,14 +373,14 @@ content logging.
 ## Assistant Repository
 
 Push supports one assistant and stores one canonical `assistant_root`. It
-derives `SOUL.md`, `context/`, and `jobs/` from that root. `push init [path]`
+derives `SOUL.md`, `context/`, `skills/`, and `jobs/` from that root. `push init [path]`
 creates the conventional structure, initializes Git when needed, and persists
 the root through the selected `--config` file. There are no assistant IDs,
 registries, active selections, or multi-assistant commands.
 
 For every conversation and scheduled or manual job run, Push reads `SOUL.md`
 and appends a gateway-owned footer in memory containing the resolved absolute
-assistant, context, and jobs paths. The footer directs the backend to begin
+assistant, context, skills, and jobs paths. The footer directs the backend to begin
 with `context/README.md` when useful, protect `SOUL.md` and installed jobs, and
 use the job draft approval flow. Push does not write the footer to the
 repository or inject all context files into each prompt. The selected backend
@@ -389,7 +389,11 @@ and its configuration decide what to inspect. Instructions include the absolute
 
 Sessions, databases, drafts, audit logs, delivery state, locks, config secrets,
 and other runtime state stay outside the Git-versioned assistant repository.
-The backend still owns tools, skills, MCP, authentication, and execution.
+Project skills and their workflow-specific scripts live in the assistant
+repository. The backend still owns discovery and execution, permissions,
+shared tools, MCP, and authentication. Push exposes the canonical `skills/`
+directory through backend-specific discovery paths rather than implementing a
+second skill or tool runtime.
 
 ## Concurrency
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,10 +21,10 @@ push init ~/Code/assistant
 
 For a new file, init writes a private, owner-only Telegram and Codex starting
 point with empty `telegram.bot_token` and `telegram.allow_user_ids` values.
-Fill both in before running Push. Push derives `SOUL.md`, `context/`, `evals/`, and `jobs/` from
-`assistant_root`. At run time it appends their resolved absolute locations to
-the user-owned `SOUL.md` instructions in memory. It does not write machine
-paths into the repository.
+Fill both in before running Push. Push derives `SOUL.md`, `context/`, `skills/`,
+`evals/`, and `jobs/` from `assistant_root`. At run time it appends their
+resolved absolute locations to the user-owned `SOUL.md` instructions in
+memory. It does not write machine paths into the repository.
 
 Root configuration, route, and primary-delivery tables do not
 yet reject every unknown key. Use the documented names, then run `push doctor`;
@@ -239,7 +239,7 @@ the selected agent and review [permissions and security](security.md).
 
 | Setting | Default | Purpose |
 | --- | --- | --- |
-| `assistant_root` | required for new setups | Canonical root of the one assistant repository; `SOUL.md`, `context/`, `evals/`, and `jobs/` are derived |
+| `assistant_root` | required for new setups | Canonical root of the one assistant repository; `SOUL.md`, `context/`, `skills/`, `evals/`, and `jobs/` are derived |
 | `state_path` | `~/.push/state.json` | Channel cursors and backend session IDs |
 | `database_path` | `~/.push/push.db` | Canonical conversation, approval, and job history |
 | `audit_log_path` | `~/.push/audit.jsonl` | Structured local audit log |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,8 +1,9 @@
 # Contributing
 
 Push is a small Rust gateway. Changes should preserve that shape: durable
-assistant infrastructure belongs in Push; model reasoning, tools, MCP, skills,
-and coding workflows belong in the selected backend.
+assistant infrastructure and project skills belong in the assistant
+repository; model reasoning, execution, permissions, shared tools, MCP, and
+global skills belong in the selected backend.
 
 ## Set up the repository
 

--- a/docs/core-system/design.md
+++ b/docs/core-system/design.md
@@ -58,8 +58,9 @@ history in SQLite outside that repository.
 
 ```text
 Push runtime                    Assistant repository          Agent runtime
-channels, scheduling, history   SOUL.md, context, jobs         reasoning, tools,
-security, delivery              user-owned and Git-versioned   skills, MCP, auth
+channels, scheduling, history   SOUL.md, context, jobs,        reasoning, tools,
+security, delivery              project skills                execution, global
+                                user-owned and Git-versioned   skills, MCP, auth
 ```
 
 The gateway owns durable runtime state. The user owns the assistant repository.
@@ -179,8 +180,9 @@ backend session id. The request separates:
 - working directory and timeout.
 
 Conversation history storage happens around this boundary and is independent
-of the selected backend. Agent tools, skills, MCP servers, model choice, and
-execution loops remain backend-owned.
+of the selected backend. Project skill definitions and their supporting files
+may live in the assistant repository. Agent tool and skill execution, global
+skills, MCP servers, model choice, and execution loops remain backend-owned.
 
 ## Alternatives and tradeoffs
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,10 +15,10 @@ You need:
 - Git for the assistant repository created by `push init`
 - `curl`, `tar`, and either `shasum` or `sha256sum` for the release installer
 
-Push uses the backend's existing login, settings, tools, MCP servers, skills,
-and backend configuration. Each chat runs from `assistant_root`, so the backend
-can discover project instructions such as `AGENTS.md` and work with the
-assistant's context directly. Confirm the selected command works before
+Push uses the backend's existing login, settings, tools, MCP servers, global
+skills, and backend configuration. Each chat runs from `assistant_root`, so the
+backend can discover project instructions and repository skills and work with
+the assistant's context directly. Confirm the selected command works before
 starting Push:
 
 === "Codex"
@@ -75,12 +75,15 @@ push init ~/Code/assistant
 ```
 
 Push creates one Git-versioned repository containing `SOUL.md`, `AGENTS.md`,
-`README.md`, `context/`, and empty `evals/` and `jobs/` directories. It records the canonical root in
+`README.md`, `context/`, portable `skills/`, and empty `evals/` and `jobs/`
+directories. It records the canonical root in
 the selected config file. A new config starts with Telegram, Codex, and an empty
 `telegram.allow_user_ids` list that you must fill in. Edit `SOUL.md` to define
 identity and operating style, then add durable user context under `context/`.
 Push reads these files at run time and never writes machine-specific paths into
 the repository.
+See [Skills](skills.md) to add reusable workflows with scripts, references,
+and assets without duplicating them between backends.
 
 ## 4. Configure a channel
 
@@ -175,6 +178,7 @@ a Telegram- or Slack-only Linux host.
 ## Next steps
 
 - [Configure both channels and per-thread routes](configuration.md)
+- [Add reusable assistant skills](skills.md)
 - [Create a manual or scheduled job](jobs.md)
 - [Inspect every CLI command](reference/cli.md)
 - [Understand durable state and recovery](architecture.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,16 +74,18 @@ Claude Code, Codex, or Pi: reason → use tools → produce result
 ```
 
 You own one Git-versioned assistant repository containing identity, context,
-and jobs. Push owns channels, history, scheduling, approvals, security, and
-delivery. The selected backend owns models, tools, MCP servers, skills, and
-authentication. That boundary keeps Push small and lets the backend change
-without rebuilding your assistant.
+project skills, and jobs. Push owns channels, history, scheduling, approvals,
+security, and delivery. The selected backend owns models, execution,
+permissions, shared tools, MCP servers, global skills, and authentication. That
+boundary keeps Push small while preserving the assistant's reusable workflows
+across backends.
 
 ## Documentation map
 
 | If you need to… | Read… |
 | --- | --- |
 | install and run one working channel | [Quickstart](getting-started.md) |
+| add reusable workflows and supporting scripts | [Skills](skills.md) |
 | understand every TOML setting | [Configuration](configuration.md) |
 | add recurring or manual work | [Jobs and schedules](jobs.md) |
 | choose backend permissions safely | [Permissions and security](security.md) |

--- a/docs/security.md
+++ b/docs/security.md
@@ -52,7 +52,7 @@ service environment using the narrowest policy that works.
 | Path | Contains |
 | --- | --- |
 | `config.toml` | allowlists, routes, paths, and possibly credentials |
-| `<assistant_root>/` | Git-versioned `SOUL.md`, durable context, evals, and installed jobs |
+| `<assistant_root>/` | Git-versioned identity, context, project skills, evals, and installed jobs |
 | `~/.push/state.json` | channel cursors and backend session IDs |
 | `~/.push/push.db` | conversation history, approvals, and job runs |
 | `~/.push/audit.jsonl` | metadata, errors, handles, and optional content |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,102 @@
+# Skills
+
+Skills are the assistant's reusable workflows. They belong in the assistant
+repository when they capture how this assistant performs a task across
+conversations and scheduled jobs.
+
+Push uses the open [Agent Skills specification](https://agentskills.io/specification/).
+Each skill is a directory with a required `SKILL.md` and optional scripts,
+references, and assets:
+
+```text
+skills/
+└── youtube-research/
+    ├── SKILL.md
+    ├── scripts/
+    │   ├── fetch-videos.py
+    │   └── rank-videos.py
+    ├── references/
+    │   └── ranking-method.md
+    └── assets/
+        └── report-template.md
+```
+
+For a new repository, `push init` creates `skills/` as the canonical source. It
+also creates `.agents/skills` and `.claude/skills` links so Codex and Claude
+Code discover the same files without duplicate copies. Push passes the
+canonical directory to Pi explicitly.
+
+Re-running init never replaces an existing backend-specific skills directory
+or a link to another location. It stops before writing and explains how to
+consolidate those skills into `skills/`. Remove the old discovery path only
+after checking that the canonical directory contains everything you need.
+
+## Skills and tools
+
+A skill is a reusable procedure. A tool is a capability the procedure uses.
+Keep a script inside a skill when it exists only for that workflow. For
+example, `youtube-research/scripts/rank-videos.py` can normalize metrics and
+rank results deterministically instead of asking the model to do arithmetic.
+
+Use a shared CLI or MCP server when several skills need the same capability,
+or when the integration needs its own lifecycle, authentication, or service.
+The selected backend remains responsible for executing scripts and tools,
+enforcing permissions, and providing authenticated integrations. Push does not
+implement another tool runner or plugin system.
+
+## Write a skill
+
+Create one directory beneath `skills/`:
+
+```sh
+mkdir -p skills/youtube-research/scripts
+```
+
+Add `skills/youtube-research/SKILL.md`:
+
+```markdown
+---
+name: youtube-research
+description: Find and rank YouTube videos for content research. Use when comparing topics, channels, titles, or recent video performance.
+compatibility: Requires Python 3, network access, and YOUTUBE_API_KEY.
+---
+
+# YouTube research
+
+1. Read the current content priorities from `context/`.
+2. Run `scripts/fetch-videos.py` for the requested channels or searches.
+3. Run `scripts/rank-videos.py` on the returned JSON.
+4. Check unusual results against the source data.
+5. Return the ranked opportunities and one recommendation.
+```
+
+Keep `SKILL.md` focused on the workflow. Put deterministic fetching,
+normalization, validation, and ranking in scripts. Put detailed methodology in
+`references/` and output templates in `assets/`.
+
+## Use a skill from a job
+
+A job defines a particular outcome and schedule. A skill defines the reusable
+method:
+
+```markdown
+Research high-performing AI engineering videos published this week.
+
+Use the `youtube-research` skill. Return the five strongest opportunities and
+recommend one video to make next.
+```
+
+Jobs start fresh backend sessions. Name the skill explicitly when the job
+depends on it, and keep the requested outcome and constraints in the job. See
+[Jobs and schedules](jobs.md) for the runbook format.
+
+## Dependencies and secrets
+
+Document required commands, network access, and environment variable names in
+the skill's `compatibility` field or instructions. Keep actual credentials out
+of the assistant repository.
+
+Push does not load an assistant-root `.env` automatically. Supply secrets
+through the service environment, the backend's authentication store, or a
+local secret manager. An `.env.example` may document variable names, but it
+must never contain real values.

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -20,8 +20,8 @@ Push should not compete there.
 
 Push should own the durable gateway layer: messages, routing, scheduling,
 history, security, and delivery. The user should own one portable assistant
-repository with identity, context, and jobs. The agent runtime should be
-replaceable.
+repository with identity, context, project skills, and jobs. The agent runtime
+should be replaceable.
 
 ## Product Thesis
 
@@ -60,10 +60,10 @@ A personal assistant needs:
 - Permission and routing rules that match the user's life.
 
 Push supports exactly one assistant. `push init [path]` creates its user-owned,
-Git-versioned repository with `SOUL.md`, `context/`, and `jobs/`. One canonical
-root is configured; the other paths are derived. There are no assistant names,
-IDs, registries, or selection flows. This stays small, legible, and stable
-across backends and machines.
+Git-versioned repository with `SOUL.md`, `context/`, `skills/`, and `jobs/`.
+One canonical root is configured; the other paths are derived. There are no
+assistant names, IDs, registries, or selection flows. This stays small,
+legible, and stable across backends and machines.
 
 ## What The Gateway Owns
 
@@ -83,13 +83,14 @@ across backends and machines.
 - Coding workflow.
 - Tool execution.
 - MCP servers.
-- Plugins and skills.
+- Skill discovery and execution.
 - Shell permissions.
 - Repo context.
 - Long-running task mechanics.
 
-The assistant repository owns `SOUL.md`, editable context, and installed job
-runbooks. The runtime owns skills, tools, MCP, and authentication. Push runtime
+The assistant repository owns `SOUL.md`, editable context, project skills, and
+installed job runbooks. The runtime owns reasoning, skill and tool execution,
+permissions, shared tools, MCP, global skills, and authentication. Push runtime
 state and secrets remain outside the repository.
 
 The gateway should not rebuild these unless there is no reliable backend
@@ -103,7 +104,7 @@ The backend seam should stay small:
 input:
   user message
   assistant context
-  resolved assistant, context, and jobs locations
+  resolved assistant, context, skills, and jobs locations
   conversation/session id if one exists
   working directory
   timeout

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -144,7 +144,8 @@ Protect these files as credentials or private assistant data:
 - the bot token and configuration
 - `state.json` and the audit log
 - `push.db`
-- the private `assistant_root` repository, including `SOUL.md`, context, and jobs
+- the private `assistant_root` repository, including identity, context, skills,
+  and jobs
 
 The assistant directory is intended to be versioned in its own private Git
 repository. Never put bot tokens, config secrets, state files, audit logs, or

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
   - Home: index.md
   - Get started:
       - Quickstart: getting-started.md
+      - Skills: skills.md
       - Configuration: configuration.md
       - iMessage: channels/imessage.md
       - Telegram: telegram.md

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -28,6 +28,7 @@ const AGENTS: &str = r#"# Assistant repository instructions
 
 - Treat `SOUL.md` as user-owned identity. Do not edit it unless the user asks.
 - Use `context/` for durable user context and working notes.
+- Use `skills/` for reusable workflows. Keep workflow-specific scripts, references, and assets inside the skill directory.
 - Treat `evals/` as user-owned evaluation criteria. Do not edit them during evaluation.
 - Treat `jobs/` as installed runbooks. Propose job changes through Push's approval workflow.
 - Keep secrets, sessions, databases, drafts, logs, and other runtime state outside this repository.
@@ -39,10 +40,11 @@ This Git repository contains the durable, user-owned parts of one Push assistant
 
 - `SOUL.md` defines the assistant's identity and working style.
 - `context/` contains durable context the assistant may read and update.
+- `skills/` contains reusable workflows and their supporting scripts and resources.
 - `evals/` contains reusable agent evaluation criteria.
 - `jobs/` contains installed Push job runbooks.
 
-Push owns channels, scheduling, history, security, approvals, and delivery outside this repository. The configured agent runtime owns reasoning, tools, skills, MCP servers, and authentication.
+Push owns channels, scheduling, history, security, approvals, and delivery outside this repository. The configured agent runtime discovers and executes project skills, and owns reasoning, permissions, external tools, MCP servers, and authentication.
 "#;
 
 const CONTEXT_README: &str = r#"# Context
@@ -50,6 +52,26 @@ const CONTEXT_README: &str = r#"# Context
 Store durable facts and working context here when they should be available across conversations.
 
 Good examples include preferences, active projects, people, recurring processes, and reference notes. Keep secrets out of this repository. Start with small, focused Markdown files and update or remove stale information.
+"#;
+
+const SKILLS_README: &str = r#"# Skills
+
+Store reusable workflows here using the Agent Skills format. Each skill is a directory containing a required `SKILL.md` file and optional supporting resources:
+
+```text
+skills/
+└── example-skill/
+    ├── SKILL.md
+    ├── scripts/
+    ├── references/
+    └── assets/
+```
+
+Keep scripts here when they exist only to support one skill. Use an external CLI or MCP integration when several skills share the same capability or it needs an independently managed service.
+
+Document required commands, network access, and environment variable names in `SKILL.md`. Keep credentials and other secret values outside this repository.
+
+In a new assistant repository, the `.agents/skills` and `.claude/skills` paths expose this canonical directory to Codex and Claude Code. Push passes it explicitly to Pi. Init never replaces an existing backend-specific directory or non-canonical link; consolidate its skills manually and rerun init.
 "#;
 
 const DEFAULT_CONFIG: &str = r#"# Telegram quick start.
@@ -86,6 +108,7 @@ pub fn init(requested_path: &str, config_path: &str) -> Result<InitResult> {
     prepare_target(&target, &config_path)?;
     let root = fs::canonicalize(&target)
         .with_context(|| format!("resolve assistant root {}", target.display()))?;
+    validate_skill_discovery_paths(&root)?;
     scaffold(&root)?;
     let git_initialized = initialize_git(&root)?;
     persist_root(&config_path, &root, existing_config)?;
@@ -344,11 +367,127 @@ fn scaffold(root: &Path) -> Result<()> {
     create_directory(&root.join("context"))?;
     create_directory(&root.join("evals"))?;
     create_directory(&root.join("jobs"))?;
+    create_directory(&root.join("skills"))?;
+    create_directory(&root.join(".agents"))?;
+    create_directory(&root.join(".claude"))?;
     create_file(&root.join("SOUL.md"), SOUL)?;
     create_file(&root.join("AGENTS.md"), AGENTS)?;
     create_file(&root.join("README.md"), README)?;
     create_file(&root.join("context/README.md"), CONTEXT_README)?;
+    create_file(&root.join("skills/README.md"), SKILLS_README)?;
+    create_skill_discovery_path(&root.join(".agents/skills"), &root.join("skills"))?;
+    create_skill_discovery_path(&root.join(".claude/skills"), &root.join("skills"))?;
     Ok(())
+}
+
+fn validate_skill_discovery_paths(root: &Path) -> Result<()> {
+    for path in [root.join(".agents"), root.join(".claude")] {
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_dir() => {}
+            Ok(_) => bail!(
+                "{} must be a real directory inside the assistant repository, not a file or symlink",
+                path.display()
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("inspect skill discovery parent {}", path.display()))
+            }
+        }
+    }
+    match fs::symlink_metadata(root.join("skills")) {
+        Ok(metadata) if metadata.file_type().is_dir() => {}
+        Ok(_) => bail!(
+            "{} must be a real directory inside the assistant repository, not a file or symlink",
+            root.join("skills").display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "inspect canonical skills directory {}",
+                    root.join("skills").display()
+                )
+            })
+        }
+    }
+    let skills = resolve_existing_or_lexical(&root.join("skills"))?;
+    for path in [root.join(".agents/skills"), root.join(".claude/skills")] {
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                let target = fs::read_link(&path)
+                    .with_context(|| format!("read skill discovery path {}", path.display()))?;
+                let target = if target.is_absolute() {
+                    target
+                } else {
+                    path.parent()
+                        .context("skill discovery path has no parent")?
+                        .join(target)
+                };
+                if resolve_existing_or_lexical(&target)? != skills {
+                    bail_skill_discovery_migration(&path, root)?;
+                }
+            }
+            Ok(_) => bail_skill_discovery_migration(&path, root)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("inspect skill discovery path {}", path.display()))
+            }
+        }
+    }
+    Ok(())
+}
+
+fn bail_skill_discovery_migration(path: &Path, root: &Path) -> Result<()> {
+    bail!(
+        "{} already exists and does not expose the canonical skills directory. Move its skills into {}, remove the old discovery path, then rerun push init; Push will not move or delete skill files automatically.",
+        path.display(),
+        root.join("skills").display()
+    )
+}
+
+fn create_skill_discovery_path(path: &Path, skills: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let resolved = fs::canonicalize(path)
+                .with_context(|| format!("resolve skill discovery path {}", path.display()))?;
+            let expected = fs::canonicalize(skills)
+                .with_context(|| format!("resolve canonical skills path {}", skills.display()))?;
+            if resolved == expected {
+                Ok(())
+            } else {
+                bail!(
+                    "cannot use skill discovery path {} because it points outside {}",
+                    path.display(),
+                    skills.display()
+                )
+            }
+        }
+        Ok(_) => bail_skill_discovery_migration(
+            path,
+            skills
+                .parent()
+                .context("skills path has no assistant root")?,
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            create_skill_symlink(path, skills)
+        }
+        Err(error) => {
+            Err(error).with_context(|| format!("inspect skill discovery path {}", path.display()))
+        }
+    }
+}
+
+#[cfg(unix)]
+fn create_skill_symlink(path: &Path, _skills: &Path) -> Result<()> {
+    std::os::unix::fs::symlink("../skills", path)
+        .with_context(|| format!("create skill discovery path {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn create_skill_symlink(path: &Path, _skills: &Path) -> Result<()> {
+    create_directory(path)
 }
 
 fn create_directory(path: &Path) -> Result<()> {
@@ -561,9 +700,23 @@ mod tests {
         assert!(target.join("AGENTS.md").is_file());
         assert!(target.join("README.md").is_file());
         assert!(target.join("context/README.md").is_file());
+        assert!(target.join("skills/README.md").is_file());
+        assert!(target.join(".agents/skills").is_dir());
+        assert!(target.join(".claude/skills").is_dir());
         assert!(target.join("evals").is_dir());
         assert!(target.join("jobs").is_dir());
         assert_eq!(fs::read_dir(target.join("jobs")).unwrap().count(), 0);
+        #[cfg(unix)]
+        {
+            assert!(fs::symlink_metadata(target.join(".agents/skills"))
+                .unwrap()
+                .file_type()
+                .is_symlink());
+            assert!(fs::symlink_metadata(target.join(".claude/skills"))
+                .unwrap()
+                .file_type()
+                .is_symlink());
+        }
         assert!(target.join(".git").exists());
         let raw = fs::read_to_string(config).unwrap();
         assert!(raw.contains(&format!(
@@ -595,6 +748,85 @@ mod tests {
             "Keep me\n"
         );
         assert_eq!(fs::read_to_string(config).unwrap(), config_before);
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn repeat_initialization_rejects_backend_specific_skills_before_writing() {
+        let parent = temp_dir("assistant-existing-skills");
+        let target = parent.join("assistant");
+        let config = parent.join("push.toml");
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+        fs::remove_file(target.join(".agents/skills")).unwrap();
+        fs::remove_file(target.join(".claude/skills")).unwrap();
+        fs::remove_dir_all(target.join("skills")).unwrap();
+        fs::create_dir(target.join(".agents/skills")).unwrap();
+        fs::write(
+            target.join(".agents/skills/custom.md"),
+            "existing backend skill",
+        )
+        .unwrap();
+
+        let error = init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("Move its skills"));
+        assert_eq!(
+            fs::read_to_string(target.join(".agents/skills/custom.md")).unwrap(),
+            "existing backend skill"
+        );
+        assert!(!target.join("skills").exists());
+        assert!(!target.join(".claude/skills").exists());
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn repeat_initialization_rejects_external_skill_symlink_before_writing() {
+        let parent = temp_dir("assistant-external-skills");
+        let target = parent.join("assistant");
+        let external = parent.join("external-skills");
+        let config = parent.join("push.toml");
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+        fs::remove_file(target.join(".agents/skills")).unwrap();
+        fs::remove_file(target.join(".claude/skills")).unwrap();
+        fs::remove_dir_all(target.join("skills")).unwrap();
+        fs::create_dir(&external).unwrap();
+        fs::write(external.join("keep.md"), "keep").unwrap();
+        std::os::unix::fs::symlink(&external, target.join(".agents/skills")).unwrap();
+
+        let error = init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("Move its skills"));
+        assert_eq!(
+            fs::read_to_string(external.join("keep.md")).unwrap(),
+            "keep"
+        );
+        assert!(!target.join("skills").exists());
+        assert!(!target.join(".claude/skills").exists());
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn repeat_initialization_rejects_symlinked_discovery_parent_before_writing() {
+        let parent = temp_dir("assistant-external-skill-parent");
+        let target = parent.join("assistant");
+        let external = parent.join("external-agent-config");
+        let config = parent.join("push.toml");
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+        fs::remove_file(target.join(".agents/skills")).unwrap();
+        fs::remove_dir(target.join(".agents")).unwrap();
+        fs::remove_file(target.join(".claude/skills")).unwrap();
+        fs::remove_dir_all(target.join("skills")).unwrap();
+        fs::create_dir(&external).unwrap();
+        std::os::unix::fs::symlink(&external, target.join(".agents")).unwrap();
+
+        let error = init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("must be a real directory"));
+        assert!(!target.join("skills").exists());
+        assert_eq!(fs::read_dir(&external).unwrap().count(), 0);
         let _ = fs::remove_dir_all(parent);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ async fn main() -> Result<()> {
             println!("  Customize the assistant:");
             println!("    $EDITOR {}/SOUL.md", result.root.display());
             println!("    $EDITOR {}/context/README.md", result.root.display());
+            println!("    $EDITOR {}/skills/README.md", result.root.display());
             println!("  Validate and run:");
             if args.config_path == DEFAULT_CONFIG_PATH {
                 println!("    push doctor");

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -1,5 +1,6 @@
 //! Runs the Pi coding agent headlessly for a single message.
 
+use std::path::Path;
 use std::time::Duration;
 use std::{io, process::Stdio};
 
@@ -107,6 +108,11 @@ impl Runner {
                 .arg("--no-prompt-templates")
                 .arg("--no-context-files")
                 .arg("--no-session");
+        } else {
+            let skills = Path::new(req.work_dir).join("skills");
+            if skills.is_dir() {
+                cmd.arg("--skill").arg(skills);
+            }
         }
         if !req.instructions.trim().is_empty() {
             cmd.arg("--append-system-prompt")
@@ -318,6 +324,27 @@ mod tests {
         let args = read_args(&args_path);
         assert_arg_pair(&args, "--session", "pi-session");
         assert!(!args.contains(&"--tools".to_string()));
+    }
+
+    #[tokio::test]
+    async fn loads_assistant_skills_from_the_canonical_directory() {
+        let args_path = temp_path("pi-skills-args");
+        let work_dir = temp_dir("pi-skills-work");
+        std::fs::create_dir(work_dir.join("skills")).unwrap();
+        let cli = FakeCli::new("pi", &success_script(&args_path, "pi-session", "hello"));
+        let runner = Runner { bin: cli.bin() };
+
+        runner
+            .run(
+                request(work_dir.to_str().unwrap(), true),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        let args = read_args(&args_path);
+        assert_arg_pair(&args, "--skill", work_dir.join("skills").to_str().unwrap());
+        let _ = std::fs::remove_dir_all(work_dir);
     }
 
     #[tokio::test]

--- a/src/soul.rs
+++ b/src/soul.rs
@@ -22,9 +22,10 @@ pub fn load(dir: &str) -> Result<String> {
     .filter(|contents| !contents.is_empty());
 
     let footer = format!(
-        "Assistant root: {}\nContext: {}\nEvals: {}\nJobs: {}\n\n{POLICY}",
+        "Assistant root: {}\nContext: {}\nSkills: {}\nEvals: {}\nJobs: {}\n\n{POLICY}",
         root.display(),
         root.join("context").display(),
+        root.join("skills").display(),
         root.join("evals").display(),
         root.join("jobs").display()
     );
@@ -52,6 +53,7 @@ mod tests {
         assert!(instructions.starts_with("Be calm, direct, and curious."));
         assert!(instructions.contains(&format!("Assistant root: {}", canonical.display())));
         assert!(instructions.contains(&format!("Context: {}", canonical.join("context").display())));
+        assert!(instructions.contains(&format!("Skills: {}", canonical.join("skills").display())));
         assert!(instructions.contains(&format!("Evals: {}", canonical.join("evals").display())));
         assert!(instructions.contains(&format!("Jobs: {}", canonical.join("jobs").display())));
         assert!(instructions.ends_with(POLICY));

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -84,6 +84,9 @@ fn init_without_path_creates_assistant_in_current_directory() {
     let assistant = workdir.join("assistant");
     assert!(assistant.join("SOUL.md").is_file());
     assert!(assistant.join("context/README.md").is_file());
+    assert!(assistant.join("skills/README.md").is_file());
+    assert!(assistant.join(".agents/skills").is_dir());
+    assert!(assistant.join(".claude/skills").is_dir());
     assert!(assistant.join("evals").is_dir());
     assert!(assistant.join("jobs").is_dir());
     assert!(assistant.join(".git").exists());
@@ -126,6 +129,7 @@ fn init_without_path_creates_assistant_in_current_directory() {
             < stdout.find("push doctor").unwrap()
     );
     assert!(stdout.contains("SOUL.md"));
+    assert!(stdout.contains("skills/README.md"));
 
     let run_output = Command::new(env!("CARGO_BIN_EXE_push"))
         .current_dir(&workdir)


### PR DESCRIPTION
## Summary

- add a canonical skills directory to repositories created by push init
- expose one skill tree to Codex, Claude Code, and Pi without duplicate copies
- document the boundary between project skills, bundled scripts, shared tools, jobs, and secrets
- reject legacy discovery paths before mutation with actionable migration guidance

## Why

The assistant repository already owned identity, context, jobs, and evals, but reusable task workflows were left entirely to backend configuration. That made the portable-assistant boundary incomplete and encouraged duplicated backend-specific skills.

## Test plan

- cargo fmt --all --check
- cargo clippy --locked --all-targets -- -D warnings
- cargo build --locked
- cargo test --locked: 331 unit tests plus docs and integration tests passed
- mkdocs build --strict
- live discovery probe passed with installed Codex, Claude Code, and Pi backends
- independent diff review completed with no remaining actionable findings

## Risks

Skill discovery uses relative symlinks on the currently supported macOS and Linux platforms. Existing backend-specific directories or non-canonical links are never replaced automatically; init stops before writing and gives migration guidance.

## Related issue

None.