### PR TITLE
docs: turn README into a project poster

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: Report a problem that can be reproduced
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Push. Do not include tokens, messages, or other private data. Report security problems through the private process in SECURITY.md.
+  - type: input
+    id: version
+    attributes:
+      label: Push version
+      description: Run `push --version`.
+    validations:
+      required: true
+  - type: dropdown
+    id: system
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Tell us what you expected and what happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Give the smallest set of steps that shows the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Remove secrets and private data. This field is optional.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/owainlewis/push/security/advisories/new
+    about: Report a suspected vulnerability in private.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest a focused improvement
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the need before the proposed feature.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like Push to do?
+      description: Explain the smallest useful outcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What have you tried?
+      description: Share current workarounds or other options. This field is optional.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of conduct
+
+## Our standard
+
+Be kind, clear, and constructive. Respect different backgrounds, identities,
+skills, and points of view.
+
+Helpful behavior includes:
+
+- giving useful feedback with care
+- accepting correction and taking responsibility
+- keeping discussion focused on the project
+- making space for people who are new to the project
+
+Harassment, threats, insults, discrimination, sexual attention, and sharing
+someone else's private information are not acceptable.
+
+## Scope
+
+This code applies in project spaces and when someone represents the project in
+public.
+
+## Enforcement
+
+Report a conduct problem privately to
+[owain@owainlewis.com](mailto:owain@owainlewis.com). Do not open a public
+issue. Reports will be reviewed fairly and kept private where possible. The
+maintainer may edit or remove contributions, issue a warning, or temporarily
+or permanently exclude someone from project spaces.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+Thank you for helping improve Push.
+
+Start with the [developer contribution guide](docs/contributing.md). It covers
+local setup, the code map, required checks, and the documentation workflow.
+
+Before opening a pull request:
+
+1. Keep the change focused.
+2. Add or update tests when behavior changes.
+3. Run the checks in the developer guide.
+4. Explain the reason for the change and any risk.
+
+For bugs and feature ideas, use the matching GitHub issue form. Do not report
+security problems in a public issue. Follow the [security policy](SECURITY.md)
+instead.
+
+By taking part, you agree to follow the [code of conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,110 +1,72 @@
+<div align="center">
+
 # Push
 
-**Your coding agent, on call 24/7.**
+### Put your coding agent on call.
+
+Message Claude Code, Codex, or Pi from your phone. Schedule work for later.
+Keep the agent and its data on your own machine.
 
 [![CI](https://github.com/owainlewis/push/actions/workflows/ci.yml/badge.svg)](https://github.com/owainlewis/push/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-read-12756f)](https://owainlewis.github.io/push/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-111417)](LICENSE)
 
-Push turns Claude Code, Codex, or Pi into an always-on personal assistant. Run
-one small process on your own machine, message it over iMessage, Telegram, or Slack,
-and schedule work with plain Markdown runbooks.
+[Get started](#get-started) · [Read the docs](https://owainlewis.github.io/push/) · [View releases](https://github.com/owainlewis/push/releases)
 
-It can review repositories before you wake up, watch pull requests, prepare a
-daily brief, or pick up a conversation from your phone. You own one portable,
-Git-versioned assistant repository containing identity, context, and jobs. Push
-owns channels, schedule evaluation, history, approvals, security, and result
-delivery. Each job file owns its schedule definition.
-Your coding agent owns the intelligence and tools.
+</div>
 
-[Read the documentation](https://owainlewis.github.io/push/) ·
-[Get started](#quickstart) ·
-[View releases](https://github.com/owainlewis/push/releases)
+## The mission
 
-## What Push gives you
+Good coding agents should be useful beyond an open terminal.
 
-- **An assistant that is actually available.** Push runs continuously under
-  `launchd` or `systemd`, not only while a terminal window is open.
-- **The agents you already use.** Keep Claude Code, Codex, or Pi, including
-  their model access, tools, MCP servers, skills, login, and backend
-  configuration.
-- **Conversations from your phone.** Use private iMessage, Telegram, or Slack app DMs.
-  Each thread keeps its own backend session and canonical history.
-- **Work that starts without you.** A five-field cron trigger can run a
-  Markdown job and send the stored result back to your primary chat.
-- **State you own.** `SOUL.md`, durable context, and installed jobs live in
-  one assistant repository. History is local SQLite and configuration is TOML.
-- **A small local control layer.** Sender allowlists constrain chat access.
-  Agent permissions, tools, and MCP servers stay in the agent configuration.
-  Telegram uses outbound long polling and Slack uses outbound Socket Mode. Neither opens a port.
+Push makes the agent you already trust available through iMessage, Telegram,
+or Slack. It can answer a message, continue a conversation, or run a Markdown
+job on a schedule. Your assistant files stay in a Git repository you own.
 
-## The model
+Push is a small bridge, not a new agent. Your coding agent still controls the
+models, tools, permissions, and reasoning.
 
 ```text
-you by iMessage or Telegram ─┐
-                            ├─> Push ─> Claude Code, Codex, or Pi ─> reply to you
-cron-triggered Markdown job ┘
+message or scheduled job
+          ↓
+        Push
+          ↓
+Claude Code, Codex, or Pi
+          ↓
+    reply to your chat
 ```
 
-Push is deliberately not another agent loop. Coding agents are already good
-at reading repositories, running tools, and completing technical work. Push
-makes one of those agents persistent, reachable, schedulable, and accountable.
+## What it does
 
-The backend can change. Your assistant repository remains portable, while
-Push keeps conversations, run history, schedules, and delivery routes durable.
+- Runs on your Mac or Linux machine
+- Connects private iMessage, Telegram, and Slack chats
+- Uses your existing Claude Code, Codex, or Pi setup
+- Keeps conversations and job history between restarts
+- Runs one-off or scheduled Markdown jobs
+- Opens no inbound network port
 
-## Quickstart
+## Get started
 
-### Requirements
+You need Apple Silicon macOS or x86_64 Linux, Git, and one supported coding
+agent installed and signed in. iMessage requires macOS.
 
-- Apple Silicon macOS or x86_64 Linux for the current prebuilt release
-- macOS for iMessage, or macOS/Linux for Telegram
-- [Codex](https://developers.openai.com/codex/cli/),
-  [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), or
-  [Pi](https://pi.dev/) installed, authenticated, and runnable by the user that
-  will run Push
-- Git for the assistant repository created by `push init`
-- `curl`, `tar`, and either `shasum` or `sha256sum` for the release installer
-
-First confirm that your chosen backend works. For example:
-
-```sh
-codex --version
-```
-
-### Install
-
-Install the latest prebuilt release to `~/.local/bin/push`:
+Install the latest release:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/owainlewis/push/main/install.sh | sh
 ```
 
-The installer verifies the release archive against its published SHA-256
-checksum. If `~/.local/bin` is not on `PATH`, add it before continuing.
+The binary goes to `~/.local/bin`. If your shell cannot find `push`, add that
+directory to `PATH` before continuing.
 
-To build from source instead, install the stable Rust toolchain first:
-
-```sh
-git clone https://github.com/owainlewis/push.git
-cd push
-cargo build --locked --release
-mkdir -p ~/.local/bin
-install -m 755 target/release/push ~/.local/bin/push
-```
-
-### Set up an assistant
-
-Create the assistant repository and default config:
+Create a Git-backed home for your assistant:
 
 ```sh
 push init ~/Code/assistant
 ```
 
-This creates a Git repository containing `SOUL.md`, `AGENTS.md`, `context/`,
-`evals/`, and `jobs/`, then records its path in `~/.push/config.toml`. New configs use
-Telegram and Codex by default. Edit the config to add your Telegram bot token
-and numeric user ID:
+Edit `~/.push/config.toml` to connect a chat channel. A small Telegram setup
+looks like this:
 
 ```toml
 channel = "telegram"
@@ -116,123 +78,36 @@ bot_token = "token-from-BotFather"
 allow_user_ids = [123456789]
 ```
 
-For iMessage, use the [iMessage setup guide](docs/channels/imessage.md). For
-Slack, use the [Slack direct-message guide](docs/slack.md). For
-Claude Code or Pi, set `agent = "claude"` or `agent = "pi"` after confirming
-that backend is authenticated for the same user.
-
-Validate the setup, then start the gateway:
+Check the setup and start Push:
 
 ```sh
 push doctor
 push
 ```
 
-Send a new message after the gateway starts. Telegram discards pending updates
-on its first run, so resend any message you used while creating the bot.
+For channel setup, service installation, jobs, permissions, and every config
+option, follow the [developer docs](https://owainlewis.github.io/push/).
 
-## Use Push
+## Build from source
 
-Chat messages go to the configured coding agent with the assistant repository
-as its working directory. Try a read-only first request:
-
-> Summarize `/absolute/path/to/my-project/README.md`. Do not change anything.
-
-Push leaves sandbox, approval, and tool permissions to the selected backend.
-Review [permissions and security](docs/security.md) before allowing unattended
-work.
-
-Chat commands:
-
-| Message | Effect |
-| --- | --- |
-| `/clear`, `/new`, `/reset` | Start a fresh backend session for this conversation |
-| `/stop` | Stop the active request; queued messages continue in order |
-| `/help` | Show available chat commands |
-
-Jobs are Markdown runbooks stored in the assistant repository. Common commands
-are:
+Install the stable Rust toolchain, then run:
 
 ```sh
-push job validate
-push job list
-push job run repo-review
-push job runs repo-review
+git clone https://github.com/owainlewis/push.git
+cd push
+cargo build --locked --release
 ```
 
-See [jobs and schedules](docs/jobs.md) for the runbook format and scheduling,
-and [running as a service](docs/services.md) to keep Push online with `launchd`
-or `systemd`.
+The binary will be at `target/release/push`. See the
+[contributing guide](CONTRIBUTING.md) for development checks and documentation
+setup.
 
-## Push and Hermes Agent
+## Open source
 
-[Hermes Agent](https://hermes-agent.nousresearch.com/docs/) is a broad,
-batteries-included autonomous agent platform. Push is a smaller orchestration
-layer for people who already want Claude Code, Codex, or Pi to do the work.
+Push is early software. Please read the [security policy](SECURITY.md) before
+reporting a vulnerability. Bug reports, ideas, and pull requests are welcome.
 
-| | Push | Hermes Agent |
-| --- | --- | --- |
-| Product shape | Small gateway and scheduler around external coding agents | Full autonomous agent runtime and platform |
-| Agent runtime | Claude Code, Codex, or Pi | Hermes's integrated agent and tool system |
-| Main focus | A durable 24/7 assistant over private chat and Markdown jobs | A broad agent environment with many tools, channels, skills, and deployment modes |
-| Tools and context | Come from your existing backend configuration | Managed as part of the Hermes ecosystem |
-| State | Local TOML, Markdown, JSON, and SQLite owned by Push | Managed by the Hermes runtime |
-| Best fit | You trust a coding agent already and want it always available | You want an all-in-one autonomous agent platform |
-
-The projects are not forks and do not try to solve the same layer. Hermes is a
-useful choice when breadth and an integrated runtime matter. Push is useful
-when you want a narrow, inspectable bridge between your existing coding agent
-and the rest of your day.
-
-## What works today
-
-- iMessage on macOS, plus Telegram private chats and Slack app DMs on macOS or Linux
-- Telegram voice notes with OpenAI transcription and spoken replies
-- Claude Code, Codex, and Pi backends, selectable by channel or conversation
-- One Git-versioned assistant repository containing `SOUL.md`, `context/`, and
-  approved `jobs/`
-- Durable conversation history and backend session recovery
-- Agent-owned permissions with no gateway sandbox or tool overrides
-- Manual and scheduled Markdown jobs with a durable run ledger
-- An agent-drafted job workflow that approves the exact revision in chat
-- Local structured audit logs with message content redacted by default
-
-Push is early software. Its scope is intentionally smaller than a general
-agent platform, and its security depends on a tight sender allowlist plus the
-permissions you give your backend. Push does not override agent permissions, so
-write access to the assistant repository can also change `SOUL.md` or installed
-jobs outside the draft approval workflow.
-
-## Documentation
-
-The Markdown under [`docs/`](docs/) is the canonical documentation source. It
-builds the [Push documentation site](https://owainlewis.github.io/push/) on
-every documentation change to `main`.
-
-- [Quickstart](docs/getting-started.md)
-- [Configuration](docs/configuration.md)
-- [Jobs and schedules](docs/jobs.md)
-- [Permissions and security](docs/security.md)
-- [Running as a service](docs/services.md)
-- [Architecture](docs/architecture.md)
-- [Contributing](docs/contributing.md)
-
-## Contributing
-
-Push is a Rust project. After cloning the repository, run the same core checks
-used by CI:
-
-```sh
-cargo fmt --all --check
-cargo clippy --locked --all-targets -- -D warnings
-cargo build --locked
-cargo test --locked
-```
-
-Documentation changes should also pass `mkdocs build --strict` after installing
-`requirements-docs.txt`. Read the full [contributing guide](docs/contributing.md)
-before submitting a pull request.
-
-## License
-
-Push is available under the [MIT License](LICENSE).
+- [Contributing](CONTRIBUTING.md)
+- [Code of conduct](CODE_OF_CONDUCT.md)
+- [Security policy](SECURITY.md)
+- [MIT license](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security policy
+
+## Supported versions
+
+Push is early software. Security fixes are made on the latest release and the
+`main` branch. Older releases may not receive fixes.
+
+## Report a vulnerability
+
+Do not open a public issue or pull request for a suspected vulnerability.
+
+Use [GitHub private vulnerability reporting](https://github.com/owainlewis/push/security/advisories/new)
+to share the problem, its impact, and steps to reproduce it. Remove secrets,
+tokens, personal messages, and other private data from the report.
+
+The maintainer aims to reply within seven days. Please allow time to investigate
+and prepare a fix before sharing the issue in public.
+
+For advice on running Push safely, read the
+[permissions and security guide](docs/security.md).


### PR DESCRIPTION
## Summary

- replace the dense README with a short project poster and first-run path
- point detailed setup and development work to the existing docs
- add contribution, conduct, security, and issue-reporting entry points
- keep the existing MIT license and enable private vulnerability reporting

## Why

The README had become a second documentation manual. This gives new visitors a clear view of the mission and a small working setup path while keeping deeper instructions in the developer docs.

## Impact

New users get a faster project overview and install path. Contributors get standard community files and structured issue forms. Security reports now have a private GitHub channel.

## Checks

- `mkdocs build --strict`
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked`
- `bash tests/install.sh`
- issue-template YAML parse
- local Markdown link check
- independent diff review

## Risks

Low. Documentation and GitHub community files only. The install steps were checked against the installer and current release assets.