### PR TITLE
fix(gateway): retain acknowledgements until persisted

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -520,6 +520,7 @@ impl Gateway {
 
     async fn process_messages(&mut self, msgs: Vec<RawMessage>) {
         self.recover_closed_workers();
+        persist_cursor(&self.store, &self.ack, self.channel.id());
         let since = self.store.lock().unwrap().cursor(self.channel.id());
         for m in &msgs {
             if m.row_id <= since {
@@ -1096,16 +1097,22 @@ async fn send_scheduled_chunk(
 }
 
 fn complete_row(store: &Arc<Mutex<Store>>, ack: &Arc<Mutex<AckState>>, channel: &str, row_id: i64) {
-    let next = {
+    {
         let mut ack = ack.lock().unwrap();
         ack.in_flight.remove(&row_id);
         ack.completed.insert(row_id);
-        ack.advance_to()
+    }
+    persist_cursor(store, ack, channel);
+}
+
+fn persist_cursor(store: &Arc<Mutex<Store>>, ack: &Arc<Mutex<AckState>>, channel: &str) {
+    let mut ack = ack.lock().unwrap();
+    let Some(row_id) = ack.next_cursor() else {
+        return;
     };
-    if let Some(row_id) = next {
-        if let Err(e) = store.lock().unwrap().set_cursor(channel, row_id) {
-            error!("save state error: {e}");
-        }
+    match store.lock().unwrap().set_cursor(channel, row_id) {
+        Ok(()) => ack.mark_persisted(row_id),
+        Err(e) => error!("save state error: {e}"),
     }
 }
 
@@ -1121,16 +1128,17 @@ impl AckState {
         self.in_flight.contains(&row_id) || self.completed.contains(&row_id)
     }
 
-    fn advance_to(&mut self) -> Option<i64> {
+    fn next_cursor(&self) -> Option<i64> {
         let limit = self.in_flight.first().copied().unwrap_or(i64::MAX);
-        let next = self
-            .completed
+        self.completed
             .iter()
             .copied()
             .take_while(|id| *id < limit)
-            .max()?;
-        self.completed.retain(|id| *id > next);
-        Some(next)
+            .max()
+    }
+
+    fn mark_persisted(&mut self, row_id: i64) {
+        self.completed.retain(|id| *id > row_id);
     }
 }
 

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -394,7 +394,7 @@ fn ack_does_not_advance_past_in_flight_row() {
     ack.in_flight.insert(10);
     ack.completed.insert(11);
 
-    assert_eq!(ack.advance_to(), None);
+    assert_eq!(ack.next_cursor(), None);
 }
 
 #[test]
@@ -405,8 +405,11 @@ fn ack_advances_completed_rows_below_first_in_flight() {
     ack.completed.insert(11);
     ack.completed.insert(13);
 
-    assert_eq!(ack.advance_to(), Some(11));
+    assert_eq!(ack.next_cursor(), Some(11));
     assert!(ack.completed.contains(&13));
+    assert!(ack.completed.contains(&10));
+    assert!(ack.completed.contains(&11));
+    ack.mark_persisted(11);
     assert!(!ack.completed.contains(&10));
     assert!(!ack.completed.contains(&11));
 }
@@ -417,8 +420,55 @@ fn ack_advances_to_highest_completed_when_nothing_in_flight() {
     ack.completed.insert(10);
     ack.completed.insert(14);
 
-    assert_eq!(ack.advance_to(), Some(14));
+    assert_eq!(ack.next_cursor(), Some(14));
+    assert_eq!(ack.completed.len(), 2);
+    ack.mark_persisted(14);
     assert!(ack.completed.is_empty());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cursor_save_failure_retries_without_rerunning_or_redelivering() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("cursor-retry-sessions");
+    let assistant_dir = temp_path("cursor-retry-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let mut gateway = Gateway::new(test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    ))
+    .unwrap();
+    gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+    gateway
+        .store
+        .lock()
+        .unwrap()
+        .fail_next_cursor_save_for_test();
+    let inbound = message(1, "me@icloud.com", "", true, "hello");
+
+    gateway.tick_fake(vec![inbound.clone()]).await;
+    gateway.queues.clear();
+    gateway.drain_workers().await;
+
+    assert_eq!(calls.lock().unwrap().len(), 1);
+    assert_eq!(gateway.ctx.sent_replies.lock().unwrap().len(), 1);
+    assert_eq!(gateway.store.lock().unwrap().cursor("imessage"), 0);
+    assert!(gateway.ack.lock().unwrap().completed.contains(&1));
+
+    gateway.tick_fake(vec![inbound]).await;
+
+    assert_eq!(calls.lock().unwrap().len(), 1);
+    assert_eq!(gateway.ctx.sent_replies.lock().unwrap().len(), 1);
+    assert_eq!(gateway.store.lock().unwrap().cursor("imessage"), 1);
+    assert!(gateway.ack.lock().unwrap().completed.is_empty());
+    assert_eq!(Store::open(&state_path).unwrap().cursor("imessage"), 1);
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
 }
 
 #[test]
@@ -470,7 +520,7 @@ async fn session_lookup_failure_completes_in_flight_row() {
     );
     let ack = ack.lock().unwrap();
     assert!(ack.in_flight.is_empty());
-    assert!(ack.completed.is_empty());
+    assert_eq!(ack.completed.iter().copied().collect::<Vec<_>>(), [10, 11]);
 
     let _ = std::fs::remove_file(blocker);
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -32,6 +32,8 @@ struct State {
 pub struct Store {
     path: PathBuf,
     state: State,
+    #[cfg(test)]
+    cursor_save_failures_remaining: usize,
 }
 
 impl Store {
@@ -42,7 +44,12 @@ impl Store {
             Err(e) if e.kind() == ErrorKind::NotFound => State::default(),
             Err(e) => return Err(anyhow!("read state {path}: {e}")),
         };
-        Ok(Store { path: p, state })
+        Ok(Store {
+            path: p,
+            state,
+            #[cfg(test)]
+            cursor_save_failures_remaining: 0,
+        })
     }
 
     #[cfg(test)]
@@ -69,11 +76,33 @@ impl Store {
         if self.has_cursor(channel) && id <= self.cursor(channel) {
             return Ok(());
         }
-        self.state.cursors.insert(channel.to_string(), id);
+        let previous_cursor = self.state.cursors.insert(channel.to_string(), id);
+        let previous_last_row_id = self.state.last_row_id;
         if channel == "imessage" {
             self.state.last_row_id = id;
         }
-        self.save()
+        #[cfg(test)]
+        let result = if self.cursor_save_failures_remaining > 0 {
+            self.cursor_save_failures_remaining -= 1;
+            Err(anyhow!("injected cursor save failure"))
+        } else {
+            self.save()
+        };
+        #[cfg(not(test))]
+        let result = self.save();
+        if let Err(error) = result {
+            match previous_cursor {
+                Some(previous) => {
+                    self.state.cursors.insert(channel.to_string(), previous);
+                }
+                None => {
+                    self.state.cursors.remove(channel);
+                }
+            }
+            self.state.last_row_id = previous_last_row_id;
+            return Err(error);
+        }
+        Ok(())
     }
 
     /// Returns the agent session id for a thread, creating one if needed. The
@@ -175,6 +204,11 @@ impl Store {
     #[cfg(test)]
     pub fn set_path_for_test(&mut self, path: PathBuf) {
         self.path = path;
+    }
+
+    #[cfg(test)]
+    pub fn fail_next_cursor_save_for_test(&mut self) {
+        self.cursor_save_failures_remaining += 1;
     }
 }
 


### PR DESCRIPTION
## Summary

- keep completed gateway rows in memory until their channel cursor is durably saved
- retry a failed cursor save before processing each later poll batch
- roll back in-memory cursor state when persistence fails
- add a regression test proving recovery does not rerun the backend or redeliver the reply

## Why

A failed cursor write previously discarded the completed acknowledgement first. The next poll could then run and deliver the same inbound message again.

## Test plan

- `cargo test --locked cursor_save_failure_retries_without_rerunning_or_redelivering`
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked` (344 tests passed across all targets)
- `cargo build --locked`
- independent diff review: approved with no findings

## Risks

The persistence path now holds the acknowledgement lock while saving the cursor so concurrent completions cannot reorder cursor writes. Existing lock ordering was reviewed and no inverse nested acquisition was found.

## Related issue

Closes #128