### PR TITLE
fix(imessage): kill cancelled sender processes (#126)

### DIFF
--- a/src/imessage/sender.rs
+++ b/src/imessage/sender.rs
@@ -1,14 +1,26 @@
 //! Sends iMessages through the Messages app via osascript.
 
 use anyhow::{anyhow, Result};
+use std::path::PathBuf;
 use tokio::process::Command;
 
 #[derive(Clone)]
-pub struct Sender;
+pub struct Sender {
+    program: PathBuf,
+}
 
 impl Sender {
     pub fn new() -> Self {
-        Self
+        Self {
+            program: PathBuf::from("osascript"),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_program(program: impl Into<PathBuf>) -> Self {
+        Self {
+            program: program.into(),
+        }
     }
 
     /// Delivers `text` to the given iMessage handle (phone number or email).
@@ -17,7 +29,8 @@ impl Sender {
     /// interpolated into the script, so no escaping is needed.
     #[cfg_attr(test, allow(dead_code))]
     pub async fn send(&self, target: &str, text: &str) -> Result<()> {
-        let out = Command::new("osascript")
+        let mut command = Command::new(&self.program);
+        command
             .args([
                 "-e",
                 "on run argv",
@@ -40,9 +53,9 @@ impl Sender {
                 "--",
             ])
             .arg(text)
-            .arg(target)
-            .output()
-            .await?;
+            .arg(target);
+        command.kill_on_drop(true);
+        let out = command.output().await?;
         if !out.status.success() {
             return Err(anyhow!(
                 "osascript send: {}",
@@ -50,5 +63,75 @@ impl Sender {
             ));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+    use std::process::{Command as StdCommand, Stdio};
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn cancelling_send_kills_in_flight_sender() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "push-imessage-sender-cancellation-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir(&temp_dir).unwrap();
+        let fake_sender = temp_dir.join("fake-osascript");
+        let pid_file = temp_dir.join("pid");
+        fs::write(
+            &fake_sender,
+            "#!/bin/sh\nfor arg do pid_file=$arg; done\necho $$ > \"$pid_file\"\nexec sleep 30\n",
+        )
+        .unwrap();
+        fs::set_permissions(&fake_sender, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let sender = Sender::with_program(&fake_sender);
+        let target = pid_file.to_string_lossy().into_owned();
+        let send = tokio::spawn(async move { sender.send(&target, "hello").await });
+
+        let pid = wait_for_pid(&pid_file).await;
+        assert!(
+            process_is_running(pid),
+            "fake sender did not remain running"
+        );
+
+        send.abort();
+        assert!(send.await.unwrap_err().is_cancelled());
+
+        for _ in 0..50 {
+            if !process_is_running(pid) {
+                fs::remove_dir_all(temp_dir).unwrap();
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        panic!("fake sender process {pid} survived cancellation");
+    }
+
+    async fn wait_for_pid(pid_file: &Path) -> u32 {
+        for _ in 0..250 {
+            if let Ok(pid) = fs::read_to_string(pid_file) {
+                return pid.trim().parse().unwrap();
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        panic!("fake sender did not record its pid");
+    }
+
+    fn process_is_running(pid: u32) -> bool {
+        StdCommand::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
     }
 }


### PR DESCRIPTION
## Summary

- terminate an in-flight osascript process when its send future is cancelled
- inject the sender executable in tests without changing production argv handling
- add a sleeping fake-sender regression test that verifies the recorded PID exits

## Why

Gateway send timeouts drop the send future. Without child cleanup, the original osascript process could continue while durable delivery retried, creating duplicate replies.

## Test plan

- cargo test --locked imessage::sender::tests::cancelling_send_kills_in_flight_sender -- --exact
- cargo fmt --all --check
- cargo clippy --locked --all-targets -- -D warnings
- cargo test --locked: 344 tests passed
- cargo build --locked
- independent diff review: approved with no actionable findings

The regression failed before the fix because the fake sender PID survived cancellation, then passed after the fix.

## Risks

The child-process lifecycle is covered with a fake executable. Real Messages.app and osascript timeout behavior was not exercised manually.

## Related issue

Closes #126