### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Test installer
         run: bash tests/install.sh
 
+      - name: Test release tooling
+        run: bash tests/release-version.sh
+
       - name: Install Rust
         run: |
           rustup toolchain install stable --profile minimal --component rustfmt,clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  validate:
+    name: validate release tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Check tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          if ! git rev-parse --verify --quiet "refs/tags/${RELEASE_TAG}^{commit}"; then
+            echo "release ref '${RELEASE_TAG}' is not an existing Git tag" >&2
+            exit 1
+          fi
+          scripts/check-release-version.sh "${RELEASE_TAG}"
+
   build:
     name: build release (${{ matrix.os }})
+    needs: validate
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,36 @@
+name: Security audit
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/security.yml"
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/security.yml"
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: RustSec advisory audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2.83.4
+        with:
+          tool: cargo-audit@0.22.2
+          fallback: none
+
+      - name: Audit locked dependencies
+        run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "push"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "push"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 description = "A tiny messaging gateway that turns coding agents into a personal assistant you text."

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <release-tag>" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+release_tag="$1"
+package_version="$({
+  python3 - "$repo_root/Cargo.toml" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+manifest = pathlib.Path(sys.argv[1])
+with manifest.open("rb") as file:
+    document = tomllib.load(file)
+
+version = document.get("package", {}).get("version")
+if not isinstance(version, str) or not version:
+    raise SystemExit(f"missing package.version in {manifest}")
+
+print(version)
+PY
+})"
+expected_tag="v${package_version}"
+
+if [ "$release_tag" != "$expected_tag" ]; then
+  echo "release tag '${release_tag}' does not match Cargo.toml package version '${package_version}' (expected '${expected_tag}')" >&2
+  exit 1
+fi
+
+echo "release tag '${release_tag}' matches Cargo.toml package version '${package_version}'"

--- a/tests/release-version.sh
+++ b/tests/release-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+check="$repo_root/scripts/check-release-version.sh"
+
+"$check" v0.8.0
+
+for invalid_tag in 0.8.0 v0.7.0 v0.8.0-rc.1 refs/tags/v0.8.0; do
+  if "$check" "$invalid_tag" >/dev/null 2>&1; then
+    echo "release version check accepted invalid tag: $invalid_tag" >&2
+    exit 1
+  fi
+done
+
+if "$check" >/dev/null 2>&1; then
+  echo "release version check accepted a missing tag" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Bump the Cargo package and lockfile identity to 0.8.0.
- Gate release builds on an existing Git tag that exactly matches the Cargo package version.
- Add tested release-version tooling, weekly RustSec advisory checks, and grouped Dependabot updates for Cargo and GitHub Actions.
- Preserve the existing Ubuntu and macOS release artifact matrix and packaging behavior.

## Why

Release archives must identify the same version as the binary, and locked Rust dependencies need ongoing advisory coverage before the project reaches more users.

## Test plan

- cargo fmt --all --check
- cargo clippy --locked --all-targets -- -D warnings
- cargo test --locked (343 tests passed across all test targets)
- cargo build --locked
- bash tests/install.sh
- bash tests/release-version.sh
- cargo audit 0.22.2 (211 locked dependencies, no vulnerabilities)
- actionlint 1.7.7 on all GitHub Actions workflows
- YAML parse validation for workflows and Dependabot configuration
- cargo metadata and built binary both report 0.8.0
- Release tag guard success and missing-tag failure paths verified in an isolated Git fixture
- Independent review approved with no actionable findings

## Risks

The hosted RustSec installation path and Dependabot behavior require GitHub execution. No release was tagged or published.

## Related issue

None.