### PR TITLE
docs: clarify Push positioning and architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,23 +41,19 @@ schedules to Claude Code, Codex, or Pi.
 ## How it works
 
 ```mermaid
-flowchart LR
-    You["You<br/>iMessage · Telegram · Slack"]
+flowchart TD
+    Message["Message from you<br/>iMessage · Telegram · Slack"]
     Jobs["Scheduled<br/>Markdown jobs"]
     Repo["Assistant repository<br/>SOUL.md · context · jobs"]
+    Push["Push<br/>message gateway · scheduler · history"]
     Agent["Your coding agent<br/>Claude Code · Codex · Pi"]
+    Reply["Push returns the result<br/>to your chat"]
 
-    subgraph Push
-        Gateway["Gateway<br/>filter · route · store"]
-        Delivery["Delivery"]
-    end
-
-    You -->|message| Gateway
-    Jobs -->|trigger| Gateway
-    Gateway -->|dispatch| Agent
+    Message --> Push
+    Jobs --> Push
+    Push -->|dispatch| Agent
     Repo -. context .-> Agent
-    Agent -->|result| Delivery
-    Delivery -->|reply| You
+    Agent --> Reply
 ```
 
 ## What it does

--- a/README.md
+++ b/README.md
@@ -21,19 +21,43 @@ Good coding agents should be useful beyond an open terminal.
 
 Push makes the agent you already trust available through iMessage, Telegram,
 or Slack. It can answer a message, continue a conversation, or run a Markdown
-job on a schedule. Your assistant files stay in a Git repository you own.
+job on a schedule. Give it clear context and a useful set of jobs, and it can
+act as your AI chief of staff. Your assistant files stay in a Git repository
+you own.
 
 Push is a small bridge, not a new agent. Your coding agent still controls the
 models, tools, permissions, and reasoning.
 
-```text
-message or scheduled job
-          ↓
-        Push
-          ↓
-Claude Code, Codex, or Pi
-          ↓
-    reply to your chat
+## A simpler alternative
+
+[OpenClaw](https://github.com/openclaw/openclaw) and
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) are powerful
+assistant platforms with their own agent runtimes, tools, skills, memory, and
+messaging layers.
+
+Push does not replace your agent. One small Rust binary adds messaging and
+schedules to Claude Code, Codex, or Pi.
+
+## How it works
+
+```mermaid
+flowchart LR
+    You["You<br/>iMessage · Telegram · Slack"]
+    Jobs["Scheduled<br/>Markdown jobs"]
+    Repo["Assistant repository<br/>SOUL.md · context · jobs"]
+    Agent["Your coding agent<br/>Claude Code · Codex · Pi"]
+
+    subgraph Push
+        Gateway["Gateway<br/>filter · route · store"]
+        Delivery["Delivery"]
+    end
+
+    You -->|message| Gateway
+    Jobs -->|trigger| Gateway
+    Gateway -->|dispatch| Agent
+    Repo -. context .-> Agent
+    Agent -->|result| Delivery
+    Delivery -->|reply| You
 ```
 
 ## What it does

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Push
 
-### Put your coding agent on call.
+### Turn your coding agent into a 24/7 personal assistant.
 
 Message Claude Code, Codex, or Pi from your phone. Schedule work for later.
 Keep the agent and its data on your own machine.


### PR DESCRIPTION
## Summary

- describe Push as a simpler alternative to OpenClaw and Hermes Agent
- explain that Push adds messaging and schedules to an existing coding agent
- introduce the AI chief of staff use case
- replace the ASCII architecture sketch with a GitHub-rendered Mermaid diagram

## Why

The README explained the features but not the main product choice: Push keeps the useful gateway and scheduler while Claude Code, Codex, or Pi remains the agent. The old ASCII diagram also rendered poorly.

## Checks

- `git diff --check`
- `cargo test --locked --test docs`
- GitHub Markdown API accepted the Mermaid block
- inspected the rendered README and diagram on GitHub
- independent copy and accuracy review

## Risks

Low. README-only change.