### PR TITLE
fix: reject empty backend replies

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -32,6 +32,17 @@ pub enum RunError {
     Failed(String),
 }
 
+pub(crate) fn final_reply(backend: &str, reply: &str) -> Result<String, RunError> {
+    let reply = reply.trim();
+    if reply.is_empty() {
+        Err(RunError::Failed(format!(
+            "{backend} exited without a final reply"
+        )))
+    } else {
+        Ok(reply.to_string())
+    }
+}
+
 pub enum Runner {
     Claude(claude::Runner),
     Codex(codex::Runner),

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use serde::Deserialize;
 use tokio::process::Command;
 
-use crate::agent::{Request, RunError, RunOutput};
+use crate::agent::{final_reply, Request, RunError, RunOutput};
 use crate::util::non_empty_session_id;
 
 /// Runner invokes the `claude` binary in print mode.
@@ -109,13 +109,13 @@ impl Runner {
                 }
             }
             Ok(r) => Ok(RunOutput {
-                reply: r.result.trim().to_string(),
+                reply: final_reply("claude", &r.result)?,
                 session_id: non_empty_session_id(&r.session_id).map(str::to_string),
             }),
             Err(_) => {
                 if out.status.success() {
                     Ok(RunOutput {
-                        reply: String::from_utf8_lossy(&out.stdout).trim().to_string(),
+                        reply: final_reply("claude", &String::from_utf8_lossy(&out.stdout))?,
                         session_id: None,
                     })
                 } else {
@@ -270,6 +270,28 @@ mod tests {
         assert_arg_pair(&args, "--append-system-prompt", "assistant identity");
         assert!(!args.contains(&"--add-dir".to_string()));
         assert_arg_pair(&args, "-p", "continue");
+    }
+
+    #[tokio::test]
+    async fn rejects_successful_empty_replies() {
+        for stdout in [
+            r#"{"result":" \t\n ","session_id":"claude-session"}"#,
+            " \t ",
+        ] {
+            let work_dir = temp_dir("claude-empty-reply-work");
+            let cli = FakeCli::new(
+                "claude",
+                &format!("#!/bin/sh\nprintf '%s\\n' {}\n", sh_arg(stdout.as_ref())),
+            );
+            let runner = Runner { bin: cli.bin() };
+
+            let error = runner
+                .run(request(work_dir.to_str().unwrap()), Duration::from_secs(5))
+                .await
+                .unwrap_err();
+
+            assert_failed(error, "claude exited without a final reply");
+        }
     }
 
     #[tokio::test]

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use tokio::process::Command;
 use uuid::Uuid;
 
-use crate::agent::{Request, RunError, RunOutput};
+use crate::agent::{final_reply, Request, RunError, RunOutput};
 
 /// Runner invokes `codex exec` in non-interactive mode.
 pub struct Runner {
@@ -107,14 +107,8 @@ impl Runner {
                 "codex did not report a session id".to_string(),
             ));
         }
-        if reply.trim().is_empty() {
-            return Err(RunError::Failed(
-                "codex exited without a final reply".to_string(),
-            ));
-        }
-
         Ok(RunOutput {
-            reply: reply.trim().to_string(),
+            reply: final_reply("codex", &reply)?,
             session_id,
         })
     }
@@ -350,6 +344,22 @@ mod tests {
         assert_arg_pair(&args, "-c", &developer_instructions("assistant identity"));
         assert_eq!(args.last().unwrap(), "continue");
         assert!(!args.contains(&"-C".to_string()));
+    }
+
+    #[tokio::test]
+    async fn rejects_successful_whitespace_only_reply() {
+        let args_path = temp_path("codex-empty-reply-args");
+        let work_dir = temp_dir("codex-empty-reply-work");
+        let script = codex_success_script(&args_path, " \t\n ", Some("codex-thread"));
+        let cli = FakeCli::new("codex", &script);
+        let runner = runner(cli.bin());
+
+        let error = runner
+            .run(request(work_dir.to_str().unwrap()), Duration::from_secs(5))
+            .await
+            .unwrap_err();
+
+        assert_failed(error, "codex exited without a final reply");
     }
 
     #[tokio::test]

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1003,6 +1003,10 @@ fn audit(ctx: &Ctx, event: AuditEvent) {
 
 async fn reply_to(ctx: &Ctx, target: &str, text: &str) -> bool {
     let chunks = ctx.channel.outbound_chunks(text, &ctx.reply_marker);
+    if chunks.is_empty() {
+        error!("send error to {target}: channel produced no outbound chunks");
+        return false;
+    }
     for chunk in chunks {
         if let Err(error) = send_reply_chunk(ctx, target, &chunk).await {
             error!("send error to {target}: {error}");
@@ -1072,6 +1076,11 @@ async fn scheduled_reply_to(
     let chunks = ctx
         .channel
         .scheduled_outbound_chunks(text, &ctx.reply_marker);
+    if chunks.is_empty() {
+        let error = "channel produced no outbound chunks";
+        tracing::error!("scheduled send error to {target}: {error}");
+        return jobs::DeliveryAttempt::failed(0, error.to_string());
+    }
     if start_chunk >= chunks.len() {
         return jobs::DeliveryAttempt::delivered(chunks.len());
     }

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -380,6 +380,46 @@ fn empty_text_dropped() {
     );
 }
 
+#[tokio::test]
+async fn delivery_fails_when_channel_produces_no_chunks() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("empty-delivery-sessions");
+    let assistant_dir = temp_path("empty-delivery-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let gateway = Gateway::new(test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    ))
+    .unwrap();
+
+    assert!(!reply_to(&gateway.ctx, "me@icloud.com", " \t\n ").await);
+    assert!(gateway.ctx.sent_replies.lock().unwrap().is_empty());
+
+    let checkpoints = Arc::new(Mutex::new(Vec::new()));
+    let scheduled = scheduled_reply_to(
+        &gateway.ctx,
+        "me@icloud.com",
+        " \t\n ",
+        0,
+        jobs::DeliveryProgress::accepting_for_test(checkpoints.clone()),
+    )
+    .await;
+    assert!(!scheduled.delivered);
+    assert_eq!(scheduled.next_chunk, 0);
+    assert_eq!(
+        scheduled.error.as_deref(),
+        Some("channel produced no outbound chunks")
+    );
+    assert!(checkpoints.lock().unwrap().is_empty());
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
 #[test]
 fn group_chat_dropped_even_from_allowlisted_sender() {
     assert_eq!(

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
-use crate::agent::{Request, RunError, RunOutput};
+use crate::agent::{final_reply, Request, RunError, RunOutput};
 
 /// Runner invokes `pi` in non-interactive JSON event mode.
 pub struct Runner {
@@ -85,14 +85,9 @@ impl Runner {
             ));
         }
         let reply = parsed.reply.unwrap_or_default();
-        if reply.trim().is_empty() {
-            return Err(RunError::Failed(
-                "pi exited without a final assistant reply".to_string(),
-            ));
-        }
 
         Ok(RunOutput {
-            reply: reply.trim().to_string(),
+            reply: final_reply("pi", &reply)?,
             session_id: req.is_new.then_some(parsed.session_id).flatten(),
         })
     }
@@ -371,7 +366,15 @@ mod tests {
             ),
             (
                 "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '{\"type\":\"session\",\"id\":\"id\"}'\n",
-                "without a final assistant reply",
+                "without a final reply",
+            ),
+            (
+                r#"#!/bin/sh
+cat >/dev/null
+printf '%s\n' '{"type":"session","id":"id"}'
+printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":" \t "}],"stopReason":"stop"}}'
+"#,
+                "without a final reply",
             ),
         ] {
             let work_dir = temp_dir("pi-bad-output");


### PR DESCRIPTION
## Summary

- reject trimmed-empty successful output consistently across Claude, Codex, and Pi
- fail ordinary and scheduled delivery when channel chunking produces zero chunks
- add regressions for backend output and zero-chunk delivery while preserving retry/resume coverage

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked` (348 tests passed)
- `cargo build --locked`
- independent diff review: no findings

Closes #127