### PR TITLE
feat(cli): format job list as table

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -259,12 +259,14 @@ async fn run_job_command(config_path: &str, command: JobCommand) -> Result<()> {
         }
         JobCommand::List => {
             let catalog = jobs::Catalog::load(&cfg)?;
+            let mut rows = Vec::new();
             for job in catalog.jobs.values() {
-                println!("{}\tvalid\t{}", job.name, job.backend.as_str());
+                rows.push((job.name.as_str(), "valid", job.backend.as_str()));
             }
-            for error in catalog.errors {
-                println!("{}\tinvalid\t{}", error.name, error.message);
+            for error in &catalog.errors {
+                rows.push((error.name.as_str(), "invalid", error.message.as_str()));
             }
+            print_job_list(&rows);
             Ok(())
         }
         JobCommand::Show(name) => {
@@ -336,6 +338,49 @@ async fn run_job_command(config_path: &str, command: JobCommand) -> Result<()> {
             Ok(())
         }
     }
+}
+
+fn print_job_list(rows: &[(&str, &str, &str)]) {
+    let rows = rows
+        .iter()
+        .map(|(name, status, detail)| {
+            (
+                escape_table_cell(name),
+                escape_table_cell(status),
+                escape_table_cell(detail),
+            )
+        })
+        .collect::<Vec<_>>();
+    let name_width = rows
+        .iter()
+        .map(|(name, _, _)| name.len())
+        .max()
+        .unwrap_or(0)
+        .max("NAME".len());
+    let status_width = rows
+        .iter()
+        .map(|(_, status, _)| status.len())
+        .max()
+        .unwrap_or(0)
+        .max("STATUS".len());
+
+    println!(
+        "{:<name_width$}  {:<status_width$}  BACKEND / ERROR",
+        "NAME", "STATUS"
+    );
+    println!(
+        "{:<name_width$}  {:<status_width$}  {}",
+        "-".repeat(name_width),
+        "-".repeat(status_width),
+        "-".repeat("BACKEND / ERROR".len())
+    );
+    for (name, status, detail) in rows {
+        println!("{name:<name_width$}  {status:<status_width$}  {detail}");
+    }
+}
+
+fn escape_table_cell(value: &str) -> String {
+    value.chars().flat_map(|c| c.escape_default()).collect()
 }
 
 fn report_invalid_jobs(cfg: &config::Config) -> Result<()> {

--- a/tests/manual_job_crash.rs
+++ b/tests/manual_job_crash.rs
@@ -41,7 +41,9 @@ printf '%s\n' '{"type":"thread.started","thread_id":"cli-thread"}'
 
     let list = run_cli(binary, &config, &["job", "list"]);
     assert!(list.status.success());
-    assert!(stdout(&list).contains("crash-test\tvalid\tcodex"));
+    let list_output = stdout(&list);
+    assert!(list_output.contains("NAME        STATUS  BACKEND / ERROR"));
+    assert!(list_output.contains("crash-test  valid   codex"));
 
     let show = run_cli(binary, &config, &["job", "show", "crash-test"]);
     assert!(show.status.success());
@@ -77,6 +79,29 @@ printf '%s\n' '{"type":"thread.started","thread_id":"cli-thread"}'
     assert!(!invalid.status.success());
     assert!(stdout(&invalid).contains("INVALID\tinvalid"));
     assert!(String::from_utf8_lossy(&invalid.stderr).contains("1 invalid job(s)"));
+
+    let list_with_invalid = run_cli(binary, &config, &["job", "list"]);
+    assert!(list_with_invalid.status.success());
+    assert!(stdout(&list_with_invalid)
+        .lines()
+        .any(|line| line.ends_with("invalid  job must start with a +++ frontmatter delimiter")));
+
+    std::fs::write(jobs.join("bad\nname.md"), "not a runbook").unwrap();
+    let list_with_malformed_name = run_cli(binary, &config, &["job", "list"]);
+    assert!(list_with_malformed_name.status.success());
+    let malformed_output = stdout(&list_with_malformed_name);
+    assert_eq!(malformed_output.lines().count(), 5);
+    assert!(malformed_output.contains(r"bad\nname.md  invalid  "));
+
+    std::fs::remove_file(jobs.join("crash-test.md")).unwrap();
+    std::fs::remove_file(jobs.join("invalid.md")).unwrap();
+    std::fs::remove_file(jobs.join("bad\nname.md")).unwrap();
+    let empty_list = run_cli(binary, &config, &["job", "list"]);
+    assert!(empty_list.status.success());
+    assert_eq!(
+        stdout(&empty_list),
+        "NAME  STATUS  BACKEND / ERROR\n----  ------  ---------------\n"
+    );
 
     let _ = std::fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## What changed

- format job list output with labeled, aligned columns
- keep valid backends and invalid errors visually distinct
- escape malformed filenames and control characters before terminal output
- cover valid, invalid, malformed-name, and empty catalogs

## Why

The previous unlabeled tab-separated row could look like three separate jobs instead of one job with status and backend fields.

## Checks

- cargo fmt -- --check
- cargo test
- cargo clippy --all-targets -- -D warnings
- independent diff review: approved