### PR TITLE
docs(site): focus homepage on assistant outcomes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,33 +6,109 @@ hide:
 
 <div class="push-hero" markdown>
 
-<span class="push-kicker">Always-on assistant infrastructure</span>
+<span class="push-kicker">Open source · Runs on your machine</span>
 
-# Your coding agent, always within reach.
+# Your coding agent has a phone now.
 
-Message and schedule Claude Code, Codex, or Pi from iMessage, Telegram, or
-Slack, with durable state on your machine.
+Text Claude Code, Codex, or Pi from iMessage, Telegram, or Slack. Ask for work,
+walk away, and get the result back in chat.
 
 <p class="push-actions">
-  <a class="md-button md-button--primary" href="getting-started/">Get started</a>
-  <a class="md-button" href="architecture/">See how it works&nbsp; →</a>
+  <a class="md-button md-button--primary" href="getting-started/">Build your assistant</a>
+  <a class="md-button" href="#what-can-it-do">See what it can do&nbsp; ↓</a>
 </p>
 
 <p class="push-install">curl -fsSL https://raw.githubusercontent.com/owainlewis/push/main/install.sh | sh</p>
 
 <ul class="push-signals">
-  <li><strong>One small binary</strong>No new agent runtime</li>
-  <li><strong>Your machine</strong>State stays under your control</li>
-  <li><strong>No inbound port</strong>Private by default</li>
+  <li><strong>Use your existing agent</strong>No new model stack</li>
+  <li><strong>Your machine</strong>Push state stays under your control</li>
+  <li><strong>Beyond the terminal</strong>Available from the chat apps you use</li>
 </ul>
 
 </div>
 
+<section class="push-demo" markdown>
+
+<div class="push-section-heading" markdown>
+
+<span class="push-section-label">A task in Push</span>
+
+## Send the work. Get on with your day.
+
+Push carries the conversation between your phone and the coding agent already
+set up on your machine.
+
+</div>
+
+<div class="push-chat" markdown="0">
+<div class="push-chat-bar"><span>Telegram</span><span><i></i> Push is online</span></div>
+<div class="push-chat-body">
+<div class="push-chat-message push-chat-message--user"><span>You · 08:42</span><p>Check why the nightly build failed and send me the likely fix.</p></div>
+<div class="push-chat-status"><span>Push → Codex</span><span>Working on your machine</span></div>
+<div class="push-chat-message push-chat-message--assistant"><span>Push · 08:47</span><p>The failure comes from an expired fixture in the integration suite. I prepared the change and ran the focused tests: 18 passed.</p></div>
+</div>
+<div class="push-chat-footer"><span>Delivered in chat</span><span>Conversation saved</span></div>
+</div>
+
+</section>
+
+<section class="push-outcomes" id="what-can-it-do" markdown>
+
+<span class="push-section-label">Your personal assistant</span>
+
+## Useful work, without reopening the terminal.
+
+<div class="push-use-cases" markdown="0">
+  <article>
+    <span>01</span>
+    <h3>Start work from anywhere</h3>
+    <p>Ask your agent to inspect a repository, investigate a failure, or prepare an update while you are away from your desk.</p>
+  </article>
+  <article>
+    <span>02</span>
+    <h3>Wake up to a useful brief</h3>
+    <p>Run Markdown routines every morning, evening, or week and deliver the result automatically to your primary chat.</p>
+  </article>
+  <article>
+    <span>03</span>
+    <h3>Keep the conversation moving</h3>
+    <p>Continue across messages with durable history instead of rebuilding context every time you open a terminal.</p>
+  </article>
+  <article>
+    <span>04</span>
+    <h3>Bring the tools you trust</h3>
+    <p>Use the MCP servers, skills, permissions, and integrations already configured in Claude Code, Codex, or Pi.</p>
+  </article>
+</div>
+
+</section>
+
+<section class="push-model" markdown>
+
+<span class="push-section-label">How it works</span>
+
+## Your agent leaves the terminal.
+
+<div class="push-steps" markdown="0">
+  <div><span>01</span><strong>Send a message</strong><p>Use iMessage, Telegram, or Slack from wherever you are.</p></div>
+  <div><span>02</span><strong>Your agent does the work</strong><p>Push restores the conversation and hands the task to your chosen coding agent.</p></div>
+  <div><span>03</span><strong>The answer comes back</strong><p>Push saves the result and delivers it to the same chat.</p></div>
+</div>
+
+Push is a gateway, not another agent runtime. You own a Git-versioned assistant
+repository containing identity, context, and jobs. Your backend continues to
+own models, tools, MCP servers, skills, permissions, and authentication.
+
+[See the full architecture](architecture.md){ .push-inline-link }
+
+</section>
+
 <section class="push-paths" markdown>
 
-<span class="push-section-label">Start here</span>
+<span class="push-section-label">Set up Push</span>
 
-## Choose a path
+## Build your assistant
 
 <div class="grid cards" markdown>
 
@@ -82,29 +158,6 @@ Slack, with durable state on your machine.
     [:octicons-arrow-right-24: Operations guide](services.md)
 
 </div>
-
-</section>
-
-<section class="push-model" markdown>
-
-<span class="push-section-label">The mental model</span>
-
-## A gateway, not another agent.
-
-```text
-message or cron trigger
-        ↓
-Push: filter → route → persist → schedule → deliver
-        ↓
-Claude Code, Codex, or Pi: reason → use tools → produce result
-```
-
-You own one Git-versioned assistant repository containing identity, context,
-jobs, and optional project skills. Push owns channels, history, scheduling,
-approvals, security, and delivery. The selected backend owns models, skill and
-tool execution, global skills, MCP servers, permissions, and authentication.
-That boundary keeps Push small and lets the backend change without rebuilding
-your assistant.
 
 </section>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,24 +6,25 @@ hide:
 
 <div class="push-hero" markdown>
 
-<span class="push-kicker">Open source · Runs on your machine</span>
+<span class="push-kicker">Lightweight · Open source · Runs on your machine</span>
 
-# Your coding agent has a phone now.
+# Build your own 24/7 AI chief of staff.
 
-Text Claude Code, Codex, or Pi from iMessage, Telegram, or Slack. Ask for work,
-walk away, and get the result back in chat.
+Push turns Claude Code, Codex, or Pi into an always-on personal assistant.
+Message it from iMessage, Telegram, or Slack, give it recurring jobs, and let it
+handle work in the background.
 
 <p class="push-actions">
-  <a class="md-button md-button--primary" href="getting-started/">Build your assistant</a>
-  <a class="md-button" href="#what-can-it-do">See what it can do&nbsp; ↓</a>
+  <a class="md-button md-button--primary" href="getting-started/">Set up your assistant</a>
+  <a class="md-button" href="#what-can-it-do">What it can do&nbsp; ↓</a>
 </p>
 
 <p class="push-install">curl -fsSL https://raw.githubusercontent.com/owainlewis/push/main/install.sh | sh</p>
 
 <ul class="push-signals">
-  <li><strong>Use your existing agent</strong>No new model stack</li>
-  <li><strong>Your machine</strong>Push state stays under your control</li>
-  <li><strong>Beyond the terminal</strong>Available from the chat apps you use</li>
+  <li><strong>One small binary</strong>No new agent runtime</li>
+  <li><strong>Always available</strong>Handles messages and scheduled jobs</li>
+  <li><strong>You stay in control</strong>Push state stays on your machine</li>
 </ul>
 
 </div>
@@ -32,21 +33,21 @@ walk away, and get the result back in chat.
 
 <div class="push-section-heading" markdown>
 
-<span class="push-section-label">A task in Push</span>
+<span class="push-section-label">Background work</span>
 
-## Send the work. Get on with your day.
+## Give it a task. Get the answer in chat.
 
-Push carries the conversation between your phone and the coding agent already
-set up on your machine.
+Send a message from your phone. Push runs your coding agent on your machine and
+sends the result back when the work is done.
 
 </div>
 
 <div class="push-chat" markdown="0">
 <div class="push-chat-bar"><span>Telegram</span><span><i></i> Push is online</span></div>
 <div class="push-chat-body">
-<div class="push-chat-message push-chat-message--user"><span>You · 08:42</span><p>Check why the nightly build failed and send me the likely fix.</p></div>
-<div class="push-chat-status"><span>Push → Codex</span><span>Working on your machine</span></div>
-<div class="push-chat-message push-chat-message--assistant"><span>Push · 08:47</span><p>The failure comes from an expired fixture in the integration suite. I prepared the change and ran the focused tests: 18 passed.</p></div>
+<div class="push-chat-message push-chat-message--user"><span>You · 18:12</span><p>Every weekday at 8am, run my morning brief and send me the three things that need my attention.</p></div>
+<div class="push-chat-status"><span>Push → Codex</span><span>Draft ready for approval</span></div>
+<div class="push-chat-message push-chat-message--assistant"><span>Push · 18:14</span><p>I drafted your morning brief for weekdays at 8am. Approve it to start the schedule.</p></div>
 </div>
 <div class="push-chat-footer"><span>Delivered in chat</span><span>Conversation saved</span></div>
 </div>
@@ -55,30 +56,30 @@ set up on your machine.
 
 <section class="push-outcomes" id="what-can-it-do" markdown>
 
-<span class="push-section-label">Your personal assistant</span>
+<span class="push-section-label">What it does</span>
 
-## Useful work, without reopening the terminal.
+## A personal assistant that keeps working when you step away.
 
 <div class="push-use-cases" markdown="0">
   <article>
     <span>01</span>
-    <h3>Start work from anywhere</h3>
-    <p>Ask your agent to inspect a repository, investigate a failure, or prepare an update while you are away from your desk.</p>
+    <h3>Handle background work</h3>
+    <p>Ask it to inspect a repository, research a question, or prepare an update. You do not need to keep a terminal open.</p>
   </article>
   <article>
     <span>02</span>
-    <h3>Wake up to a useful brief</h3>
-    <p>Run Markdown routines every morning, evening, or week and deliver the result automatically to your primary chat.</p>
+    <h3>Run your daily routines</h3>
+    <p>Schedule a morning brief, weekly review, or any other Markdown job and receive the result automatically in chat.</p>
   </article>
   <article>
     <span>03</span>
-    <h3>Keep the conversation moving</h3>
-    <p>Continue across messages with durable history instead of rebuilding context every time you open a terminal.</p>
+    <h3>Remember the context</h3>
+    <p>Keep conversation history and assistant context between messages instead of explaining the same work again.</p>
   </article>
   <article>
     <span>04</span>
-    <h3>Bring the tools you trust</h3>
-    <p>Use the MCP servers, skills, permissions, and integrations already configured in Claude Code, Codex, or Pi.</p>
+    <h3>Use your existing tools</h3>
+    <p>Keep the MCP servers, skills, permissions, and integrations already configured in Claude Code, Codex, or Pi.</p>
   </article>
 </div>
 
@@ -88,17 +89,17 @@ set up on your machine.
 
 <span class="push-section-label">How it works</span>
 
-## Your agent leaves the terminal.
+## One lightweight bridge. Your agent does the work.
 
 <div class="push-steps" markdown="0">
-  <div><span>01</span><strong>Send a message</strong><p>Use iMessage, Telegram, or Slack from wherever you are.</p></div>
-  <div><span>02</span><strong>Your agent does the work</strong><p>Push restores the conversation and hands the task to your chosen coding agent.</p></div>
-  <div><span>03</span><strong>The answer comes back</strong><p>Push saves the result and delivers it to the same chat.</p></div>
+  <div><span>01</span><strong>Message your assistant</strong><p>Use iMessage, Telegram, or Slack from wherever you are.</p></div>
+  <div><span>02</span><strong>Push starts the work</strong><p>It restores the conversation and runs your chosen coding agent in the background.</p></div>
+  <div><span>03</span><strong>Get the result</strong><p>Push saves the response and sends it back to the same chat.</p></div>
 </div>
 
-Push is a gateway, not another agent runtime. You own a Git-versioned assistant
-repository containing identity, context, and jobs. Your backend continues to
-own models, tools, MCP servers, skills, permissions, and authentication.
+Push does not replace your coding agent. It handles chat, history, schedules,
+approvals, and delivery. Claude Code, Codex, or Pi keeps control of models,
+tools, skills, permissions, and authentication.
 
 [See the full architecture](architecture.md){ .push-inline-link }
 
@@ -106,9 +107,9 @@ own models, tools, MCP servers, skills, permissions, and authentication.
 
 <section class="push-paths" markdown>
 
-<span class="push-section-label">Set up Push</span>
+<span class="push-section-label">Get started</span>
 
-## Build your assistant
+## Build your AI chief of staff
 
 <div class="grid cards" markdown>
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -304,10 +304,35 @@ pre {
   font-weight: 650;
 }
 
+.push-demo,
+.push-outcomes {
+  margin: 0 0 clamp(4rem, 8vw, 6.5rem);
+}
+
+.push-section-heading {
+  max-width: 43rem;
+  margin: 0 auto 2.25rem;
+  text-align: center;
+}
+
+.push-section-heading > p:first-child,
+.push-outcomes > p:first-child {
+  margin: 0;
+}
+
+.push-section-heading > p:last-child {
+  max-width: 36rem;
+  margin-inline: auto;
+  color: var(--push-muted);
+  font-size: 0.9rem;
+}
+
 .push-paths {
   margin: 0 0 5rem;
 }
 
+.push-demo h2,
+.push-outcomes > h2,
 .push-paths > h2,
 .push-model > h2,
 .push-doc-map > h2 {
@@ -316,6 +341,140 @@ pre {
   font-weight: 400;
   letter-spacing: -0.045em;
   line-height: 1;
+}
+
+.push-chat {
+  max-width: 48rem;
+  margin-inline: auto;
+  overflow: hidden;
+  background: var(--push-surface);
+  border: 1px solid var(--push-line-strong);
+  border-radius: 0.65rem;
+  box-shadow: 0 1.5rem 4rem rgb(41 42 37 / 7%);
+}
+
+.push-chat-bar,
+.push-chat-footer,
+.push-chat-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--push-muted);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.68rem;
+}
+
+.push-chat-bar {
+  min-height: 2.6rem;
+  padding: 0 1rem;
+  border-bottom: 1px solid var(--push-line);
+}
+
+.push-chat-bar span:last-child {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.push-chat-bar i {
+  width: 0.42rem;
+  height: 0.42rem;
+  background: var(--push-moss);
+  border-radius: 50%;
+}
+
+.push-chat-body {
+  padding: clamp(1.25rem, 4vw, 2.25rem);
+}
+
+.push-chat-message {
+  width: fit-content;
+  max-width: min(78%, 34rem);
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--push-line);
+  border-radius: 0.55rem;
+}
+
+.push-chat-message > span {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: var(--push-moss);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.65rem;
+}
+
+.push-chat-message p {
+  margin: 0;
+  color: var(--push-ink);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.push-chat-message--user {
+  margin-left: auto;
+  background: var(--push-moss-soft);
+  border-color: color-mix(in srgb, var(--push-moss) 28%, var(--push-line));
+}
+
+.push-chat-message--assistant {
+  background: var(--push-paper);
+}
+
+.push-chat-status {
+  margin: 1.25rem 0;
+  padding: 0.55rem 0.75rem;
+  border-left: 2px solid var(--push-moss);
+  background: color-mix(in srgb, var(--push-moss-soft) 55%, transparent);
+}
+
+.push-chat-footer {
+  min-height: 2.5rem;
+  padding: 0 1rem;
+  background: color-mix(in srgb, var(--push-moss-soft) 40%, transparent);
+  border-top: 1px solid var(--push-line);
+}
+
+.push-outcomes > h2 {
+  max-width: 16ch;
+  margin-bottom: 2rem;
+}
+
+.push-use-cases {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  border-block: 1px solid var(--push-line);
+}
+
+.push-use-cases article {
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.push-use-cases article:nth-child(even) {
+  border-left: 1px solid var(--push-line);
+}
+
+.push-use-cases article:nth-child(n + 3) {
+  border-top: 1px solid var(--push-line);
+}
+
+.push-use-cases article > span,
+.push-steps > div > span {
+  color: var(--push-moss);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.68rem;
+}
+
+.push-use-cases h3 {
+  margin: 1.1rem 0 0.45rem;
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.push-use-cases p {
+  margin: 0;
+  color: var(--push-muted);
+  font-size: 0.78rem;
 }
 
 .md-typeset .grid.cards {
@@ -364,9 +523,42 @@ pre {
   color: var(--push-muted);
 }
 
-.push-model pre {
-  max-width: 48rem;
-  margin: 1.75rem 0;
+.push-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin: 2rem 0;
+  border-block: 1px solid var(--push-line);
+}
+
+.push-steps > div {
+  padding: 1.5rem 1.5rem 1.5rem 0;
+}
+
+.push-steps > div + div {
+  padding-left: 1.5rem;
+  border-left: 1px solid var(--push-line);
+}
+
+.push-steps strong {
+  display: block;
+  margin: 0.65rem 0 0.35rem;
+  color: var(--push-ink);
+  font-size: 0.82rem;
+}
+
+.push-steps p {
+  margin: 0;
+  color: var(--push-muted);
+  font-size: 0.74rem;
+}
+
+.md-typeset .push-inline-link {
+  display: inline-block;
+  margin-top: 0.75rem;
+  color: var(--push-ink);
+  font-weight: 650;
+  text-decoration: none;
+  border-bottom: 1px solid var(--push-line-strong);
 }
 
 .push-doc-map {
@@ -418,6 +610,33 @@ pre {
   .md-typeset .grid.cards,
   .md-typeset .grid.cards > ul {
     grid-template-columns: 1fr;
+  }
+
+  .push-use-cases,
+  .push-steps {
+    grid-template-columns: 1fr;
+  }
+
+  .push-use-cases article:nth-child(even) {
+    border-left: 0;
+  }
+
+  .push-use-cases article:nth-child(n + 2) {
+    border-top: 1px solid var(--push-line);
+  }
+
+  .push-steps > div {
+    padding: 1.25rem 0;
+  }
+
+  .push-steps > div + div {
+    padding-left: 0;
+    border-top: 1px solid var(--push-line);
+    border-left: 0;
+  }
+
+  .push-chat-message {
+    max-width: 92%;
   }
 
   .md-typeset ul.push-signals li + li {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Push
 site_description: Turn Claude Code, Codex, or Pi into an always-on personal assistant.
-site_url: https://owainlewis.github.io/push/
+site_url: https://pushassistant.com/
 repo_url: https://github.com/owainlewis/push
 repo_name: owainlewis/push
 edit_uri: edit/main/docs/


### PR DESCRIPTION
## Summary

- refocus the homepage hero on Push as a personal assistant powered by the user's existing coding agent
- add a rendered chat example and four concrete assistant use cases before the technical explanation
- replace the architecture-first section with a simpler three-step product story while preserving the gateway boundary and the newer Designing an assistant path
- add responsive styling for the conversation, use-case grid, and process steps
- set the production MkDocs origin to `https://pushassistant.com/`

## Why

The existing homepage explained setup and architecture clearly, but it did not show what using Push feels like. This change leads with outcomes, gives the product more character, and makes the phone-to-agent-to-chat loop tangible without claiming capabilities that Push itself does not own.

## Test plan

- `mkdocs build --strict`
- `cargo test --locked --test docs`
- `git diff --cached --check`
- browser checks at 1440x1000, 700x900, and 390x844
- verified no horizontal overflow, zero console errors, one rendered assistant response with no leaked HTML/code block, four use cases, and three process steps
- independent diff review: approved after narrowing the local-state privacy claim

## Risks

The homepage now contains more custom HTML and CSS inside MkDocs. The key rendered structures and all responsive breakpoints were checked in the live browser. The example task is illustrative and remains within the capabilities of a configured coding-agent backend.

## Related issue

None.