### PR TITLE
chore(release): prepare v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "push"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "push"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 license = "MIT"
 description = "A tiny messaging gateway that turns coding agents into a personal assistant you text."

--- a/tests/release-version.sh
+++ b/tests/release-version.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 check="$repo_root/scripts/check-release-version.sh"
 
-"$check" v0.8.1
+"$check" v0.8.2
 
-for invalid_tag in 0.8.1 v0.8.0 v0.8.1-rc.1 refs/tags/v0.8.1; do
+for invalid_tag in 0.8.2 v0.8.1 v0.8.2-rc.1 refs/tags/v0.8.2; do
   if "$check" "$invalid_tag" >/dev/null 2>&1; then
     echo "release version check accepted invalid tag: $invalid_tag" >&2
     exit 1


### PR DESCRIPTION
## What changed

- bump the package and lockfile version to `0.8.2`
- update the release-version fixture for `v0.8.2`

## Why

Release the direct assistant-repository job fix merged in PR #150 after `v0.8.1`.

## Validation

- `bash tests/release-version.sh`
- `cargo fmt --check`
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- independent review: approved