### PR TITLE
feat(init): install managed Push skill

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,7 +110,7 @@ Push divides ownership among three systems:
 | Owner | Responsibilities |
 | --- | --- |
 | Push runtime | channels, allowlists, routing, scheduling, canonical history, cursors, session mappings, audit, retries, and delivery |
-| Assistant repository | `SOUL.md`, shared instructions, context, evals, jobs, and optional project skills |
+| Assistant repository | user-owned `SOUL.md`, shared instructions, context, evals, jobs, optional project skills, and the Push-managed capability skill |
 | Agent runtime | reasoning, models, tools, global skills, MCP, authentication, sandbox, and interactive permissions |
 
 ### Channel Contract
@@ -477,6 +477,22 @@ File: [`src/pi.rs`](src/pi.rs)
 Pi owns its session ID and reports it in the JSON event stream. Prompts are
 written to stdin so large requests do not depend on command-line argument
 limits.
+
+### Project Skill Contract
+
+`push init` installs one canonical capability at `skills/push/`. Relative
+directory links expose it at `.agents/skills/push` for Codex and Pi and at
+`.claude/skills/push` for Claude Code. This matches each runtime's project
+discovery rules without copying instruction bodies or making Pi discover the
+same skill twice.
+
+The canonical directory contains a versioned checksum manifest. Initialization
+creates missing provider directories and links idempotently. It refreshes an
+older skill only when the installed content still matches its recorded
+checksum. A modified skill, unexpected provider path, symlinked canonical file,
+or newer managed version is preserved and returns actionable guidance instead
+of being overwritten. `SOUL.md`, `AGENTS.md`, and user-created skills remain
+user-owned.
 
 ### Adding a Backend
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ push init ~/Code/assistant
 
 This creates a Git repository containing `SOUL.md`, shared instructions in
 `AGENTS.md`, a `CLAUDE.md` reference to those instructions, `context/`, `evals/`,
-and `jobs/`, then records its path in `~/.push/config.toml`.
+`jobs/`, and a versioned Push capability skill for Claude Code, Codex, and Pi.
+It then records the repository path in `~/.push/config.toml`.
 
 Edit `~/.push/config.toml` to connect a chat channel. A small Telegram setup
 looks like this:

--- a/assistant/skills/push/SKILL.md
+++ b/assistant/skills/push/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: push
+description: Operate a Push personal assistant, inspect its health and jobs, and author or validate Push job runbooks. Use when a request concerns Push setup, CLI commands, assistant files, scheduled jobs, or delivery behavior.
+license: MIT
+compatibility: Requires the Push CLI and an initialized assistant repository.
+metadata:
+  push-managed-version: "1"
+---
+
+# Push
+
+Use Push as the gateway around the configured Claude Code, Codex, or Pi
+runtime. Push owns channels, scheduling, history, security checks, and delivery.
+The agent runtime owns reasoning, tools, skill execution, permissions, MCP
+servers, and authentication.
+
+## Work in the assistant repository
+
+- Treat `SOUL.md` as user-owned identity and `AGENTS.md` as user-owned repository
+  guidance. Do not edit either unless the user asks.
+- Read `context/README.md` first when durable user context is relevant. Keep
+  useful durable notes under `context/` and evaluation criteria under `evals/`.
+- Store complete job runbooks under `jobs/`.
+- Treat `skills/push/` and the `push` links under `.agents/skills/` and
+  `.claude/skills/` as Push-managed. Do not edit them. Codex and Pi share the
+  `.agents/skills/` discovery path.
+- Keep credentials, configuration containing credentials, sessions, databases,
+  audit logs, and job runtime files outside the assistant repository.
+
+## Use the current CLI
+
+Run `push help` when the accepted command forms are unclear. The stable commands
+are:
+
+- `push help`
+- `push version`
+- `push init [path]`
+- `push`
+- `push doctor`
+- `push reload` or `push restart`
+- `push job validate`
+- `push job list`
+- `push job show <name>`
+- `push job run <name>`
+- `push job runs [<name>]`
+
+All commands accept `--config <path>`. Do not assume machine-readable output
+unless `push help` documents it in the installed version. Never expose tokens,
+message content, or sensitive runtime state in diagnostics or replies.
+
+## Author jobs safely
+
+1. Read the job format and existing runbooks before editing.
+2. Write the complete Markdown runbook directly under `jobs/` when the user
+   asks to create or change a job.
+3. Keep secrets out of the runbook. Use the configured service or agent
+   environment for credentials.
+4. Run `push job validate` after every job change. Do not claim success if
+   validation fails.
+5. Use `push job show <name>` to inspect the installed result and
+   `push job runs <name>` to inspect execution and delivery history.
+6. Run `push job run <name>` only when the user asked for the job to execute or
+   when execution is a clearly authorized part of the task.
+
+## Reply normally
+
+For an ordinary conversation, return the final reply normally. Push sends it
+back through the originating channel. Do not invoke the Push CLI merely to send
+a chat reply.

--- a/docs/designing-an-assistant.md
+++ b/docs/designing-an-assistant.md
@@ -15,7 +15,14 @@ assistant/
 ├── README.md
 ├── context/
 ├── evals/
-└── jobs/
+├── jobs/
+├── skills/
+│   └── push/
+│       └── SKILL.md
+├── .agents/skills/
+│   └── push -> ../../skills/push
+└── .claude/skills/
+    └── push -> ../../skills/push
 ```
 
 `AGENTS.md` is the shared instruction source. `CLAUDE.md` contains only
@@ -135,15 +142,18 @@ description: Plan and prepare a technical YouTube video from a topic, transcript
 ```
 
 Save that file as `skills/youtube/SKILL.md`. Keep the description specific
-because both Codex and Claude use it to decide when the skill is relevant.
+because each supported runtime uses it to decide when the skill is relevant.
 
-### Share one skill between Codex and Claude
+### Share one skill between supported runtimes
 
 Codex discovers repository skills under `.agents/skills/`. Claude Code uses
-`.claude/skills/`. Both support skill directories that are symbolic links, so
-one canonical skill can serve both backends. See the official [Codex skills
-guide](https://learn.chatgpt.com/docs/build-skills.md) and [Claude Code skills
-guide](https://code.claude.com/docs/en/skills) for their discovery rules.
+`.claude/skills/`. Pi uses `.pi/skills/` and also recognizes
+`.agents/skills/`. These project locations support skill directories, and
+Codex and Claude Code explicitly follow directory links, so one canonical skill
+can serve every supported backend. See the official [Codex skills
+guide](https://developers.openai.com/codex/skills), [Claude Code skills
+guide](https://code.claude.com/docs/en/skills), and [Pi skills
+guide](https://pi.dev/docs/latest/skills) for their discovery rules.
 
 ```text
 assistant/
@@ -157,8 +167,8 @@ assistant/
         └── youtube -> ../../skills/youtube
 ```
 
-After creating the canonical skill, expose it to both agents from the assistant
-root:
+After creating a canonical user-owned skill, expose it to all three agents with
+two links from the assistant root. Pi and Codex share `.agents/skills/`:
 
 ```sh
 mkdir -p .agents/skills .claude/skills
@@ -167,9 +177,15 @@ ln -s ../../skills/youtube .claude/skills/youtube
 ```
 
 Use relative links so the repository remains portable when cloned elsewhere.
-Commit the canonical skill and the links. `push init` does not currently create
-or synchronize skill links, and Pi skill discovery remains controlled by Pi's
-own configuration.
+Commit the canonical skill and the links.
+
+Push itself manages only `skills/push/` and the two `push` exposure links.
+Its hidden manifest records the installed content version and checksum. A later
+`push init` refreshes an older copy only when its checksum still matches the
+managed content. If you modify the managed skill or replace a provider link,
+Push preserves it and asks you to move your changes to a differently named
+skill or restore the managed path. Push does not edit `SOUL.md`, `AGENTS.md`, or
+skills you create.
 
 ## Use jobs for scheduled outcomes
 
@@ -245,6 +261,7 @@ becoming a mixture of preferences, procedures, schedules, and secrets.
 - `SOUL.md` contains only durable identity and working style.
 - `AGENTS.md` is the shared repository guidance.
 - `CLAUDE.md` references `AGENTS.md` instead of copying it.
+- `skills/push/` and its provider links remain Push-managed.
 - `context/README.md` indexes focused, current context files.
 - each skill owns its instructions and supporting tooling.
 - each job requests one self-contained outcome.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,11 +76,12 @@ push init ~/Code/assistant
 
 Push creates one Git-versioned repository containing `SOUL.md`, shared
 instructions in `AGENTS.md`, a `CLAUDE.md` reference to those instructions,
-`README.md`, `context/`, and empty `evals/` and `jobs/` directories. It records
+`README.md`, `context/`, empty `evals/` and `jobs/` directories, and one
+versioned Push capability skill shared by Claude Code, Codex, and Pi. It records
 the canonical root in the selected config file. A new config starts with
 Telegram, Codex, and an empty `telegram.allow_user_ids` list that you must fill
-in. Edit `SOUL.md` to define identity and operating style, then add durable
-user context under `context/`.
+in. Edit `SOUL.md` to define identity and operating style, then add durable user
+context under `context/`.
 Push reads these files at run time and never writes machine-specific paths into
 the repository. Read [Designing an assistant](designing-an-assistant.md) for a
 practical structure for identity, context, shared skills, jobs, and evals.
@@ -147,8 +148,9 @@ have a configured model provider or authenticated account for the service user.
 
 If you replace the config file created by `push init`, keep its
 `assistant_root` setting. Running the same init command again is safe for a
-complete assistant repository and restores the setting without overwriting
-user files.
+complete assistant repository. It preserves user-owned files and refreshes the
+Push-managed skill only when the installed checksum proves that the managed
+copy is unmodified.
 
 ## 5. Validate and run
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -46,8 +46,16 @@ settings from the current shell.
 
 `push init` accepts an empty target, the selected config by itself, or a
 complete existing assistant layout. It refuses unrelated and partial non-empty
-directories, never overwrites an existing assistant file, persists one
+directories, preserves user-owned `SOUL.md` and `AGENTS.md`, persists one
 canonical `assistant_root`, and initializes Git when needed.
+
+Initialization also installs the versioned Push capability skill at
+`skills/push/` and exposes that one directory through relative links under
+`.agents/skills/` for Codex and Pi and `.claude/skills/` for Claude Code.
+Repeating `push init` is safe. An unmodified managed copy is refreshed after a
+Push upgrade; if the skill or an exposure link has diverged, Push leaves it
+unchanged and reports how to move or restore the conflicting content.
+User-created skills and global agent skills are not copied or managed.
 
 ## Commands sent in chat
 

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256};
 
 use crate::config::{
     validate_inline_slack_token_location, validate_inline_token_location,
@@ -44,8 +45,11 @@ This Git repository contains the durable, user-owned parts of one Push assistant
 - `context/` contains durable context the assistant may read and update.
 - `evals/` contains reusable agent evaluation criteria.
 - `jobs/` contains installed Push job runbooks.
+- `skills/` contains reusable capabilities.
 
-Push owns channels, scheduling, history, security, and delivery outside this repository. Project skills may live here, while the configured agent runtime owns discovery, execution, global skills, MCP servers, and authentication. Chats preserve configured agent permissions. Codex and Claude jobs bypass interactive permissions so unattended work can finish.
+You own `SOUL.md`, `AGENTS.md`, context, evals, jobs, and any skills you add. Push manages only `skills/push/` and its `push` discovery links under `.agents/skills/` and `.claude/skills/`; Codex and Pi share the `.agents/skills/` path. Rerun `push init` after an upgrade to refresh an unmodified managed skill. Push never silently replaces a modified managed copy.
+
+Push owns channels, scheduling, history, security, and delivery outside this repository. The configured agent runtime owns skill discovery and execution, global skills, MCP servers, permissions, and authentication. Chats preserve configured agent permissions. Codex and Claude jobs bypass interactive permissions so unattended work can finish.
 "#;
 
 const CONTEXT_README: &str = r#"# Context
@@ -54,6 +58,12 @@ Store durable facts and working context here when they should be available acros
 
 Good examples include preferences, active projects, people, recurring processes, and reference notes. Keep secrets out of this repository. Start with small, focused Markdown files and update or remove stale information.
 "#;
+
+const PUSH_SKILL: &str = include_str!("../assistant/skills/push/SKILL.md");
+const PUSH_SKILL_VERSION: u32 = 1;
+const PUSH_SKILL_LINK: &str = "../../skills/push";
+const PUSH_SKILL_MANIFEST: &str = ".push-managed.json";
+const PUSH_SKILL_PROVIDERS: [&str; 2] = [".agents", ".claude"];
 
 const DEFAULT_CONFIG: &str = r#"# Telegram quick start.
 channel = "telegram"
@@ -347,7 +357,203 @@ fn scaffold(root: &Path) -> Result<()> {
     create_file(&root.join("CLAUDE.md"), CLAUDE)?;
     create_file(&root.join("README.md"), README)?;
     create_file(&root.join("context/README.md"), CONTEXT_README)?;
+    install_push_skill(root)?;
     Ok(())
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct ManagedSkillManifest {
+    version: u32,
+    sha256: String,
+}
+
+fn install_push_skill(root: &Path) -> Result<()> {
+    let skills = root.join("skills");
+    let skill_dir = skills.join("push");
+    let skill_path = skill_dir.join("SKILL.md");
+    let manifest_path = skill_dir.join(PUSH_SKILL_MANIFEST);
+    create_directory(&skills)?;
+    create_directory(&skill_dir)?;
+
+    let actual = read_optional_regular_file(&skill_path)?;
+    let manifest = read_skill_manifest(&manifest_path)?;
+    match manifest {
+        Some(manifest) => {
+            if manifest.version > PUSH_SKILL_VERSION {
+                bail!(
+                    "{} is managed by Push skill version {}, which is newer than this Push binary supports (version {}). Upgrade Push instead of downgrading the skill.",
+                    skill_path.display(),
+                    manifest.version,
+                    PUSH_SKILL_VERSION
+                );
+            }
+            match actual.as_deref() {
+                Some(actual) if actual == PUSH_SKILL.as_bytes() => {
+                    if manifest.version != PUSH_SKILL_VERSION
+                        || manifest.sha256 != sha256(PUSH_SKILL.as_bytes())
+                    {
+                        write_skill_manifest(&manifest_path)?;
+                    }
+                }
+                Some(actual) if sha256(actual) != manifest.sha256 => {
+                    return Err(user_modified_skill_error(&skill_path));
+                }
+                Some(_) => {
+                    if manifest.version == PUSH_SKILL_VERSION {
+                        return Err(user_modified_skill_error(&skill_path));
+                    }
+                    write_atomic_file(&skill_path, PUSH_SKILL.as_bytes())?;
+                    write_skill_manifest(&manifest_path)?;
+                }
+                None => {
+                    write_atomic_file(&skill_path, PUSH_SKILL.as_bytes())?;
+                    write_skill_manifest(&manifest_path)?;
+                }
+            }
+        }
+        None => match actual.as_deref() {
+            None => {
+                write_atomic_file(&skill_path, PUSH_SKILL.as_bytes())?;
+                write_skill_manifest(&manifest_path)?;
+            }
+            Some(actual) if actual == PUSH_SKILL.as_bytes() => {
+                write_skill_manifest(&manifest_path)?;
+            }
+            Some(_) => {
+                bail!(
+                    "Push found an existing unmanaged skill at {} and left it unchanged. Rename that skill, or move it to a different skill directory, then rerun `push init`.",
+                    skill_path.display()
+                );
+            }
+        },
+    }
+
+    for provider in PUSH_SKILL_PROVIDERS {
+        let provider_skills = root.join(provider).join("skills");
+        create_directory(&root.join(provider))?;
+        create_directory(&provider_skills)?;
+        create_skill_link(&provider_skills.join("push"))?;
+    }
+    Ok(())
+}
+
+fn read_optional_regular_file(path: &Path) -> Result<Option<Vec<u8>>> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => fs::read(path)
+            .map(Some)
+            .with_context(|| format!("read {}", path.display())),
+        Ok(_) => bail!(
+            "{} must be a regular file inside the assistant repository; Push left it unchanged",
+            path.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("inspect {}", path.display())),
+    }
+}
+
+fn read_skill_manifest(path: &Path) -> Result<Option<ManagedSkillManifest>> {
+    let Some(raw) = read_optional_regular_file(path)? else {
+        return Ok(None);
+    };
+    serde_json::from_slice(&raw)
+        .with_context(|| {
+            format!(
+                "parse managed skill metadata {}. Push left the skill unchanged; restore this file or move the skill before rerunning `push init`",
+                path.display()
+            )
+        })
+        .map(Some)
+}
+
+fn write_skill_manifest(path: &Path) -> Result<()> {
+    let manifest = ManagedSkillManifest {
+        version: PUSH_SKILL_VERSION,
+        sha256: sha256(PUSH_SKILL.as_bytes()),
+    };
+    let mut raw = serde_json::to_vec_pretty(&manifest).context("serialize Push skill metadata")?;
+    raw.push(b'\n');
+    write_atomic_file(path, &raw)
+}
+
+fn sha256(contents: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(contents))
+}
+
+fn user_modified_skill_error(path: &Path) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Push found a user-modified managed skill at {} and left it unchanged. Move your changes to a differently named skill or restore the managed copy, then rerun `push init`.",
+        path.display()
+    )
+}
+
+fn write_atomic_file(path: &Path, contents: &[u8]) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if !metadata.file_type().is_file() {
+                bail!(
+                    "{} must be a regular file inside the assistant repository; Push left it unchanged",
+                    path.display()
+                );
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| format!("inspect managed file {}", path.display()))
+        }
+    }
+    let parent = path.parent().context("managed file path has no parent")?;
+    let name = path
+        .file_name()
+        .context("managed file path has no file name")?
+        .to_string_lossy();
+    let temporary = parent.join(format!(".{name}.push-init-{}", uuid::Uuid::new_v4()));
+    let result = (|| -> Result<()> {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+            .with_context(|| format!("create temporary managed file {}", temporary.display()))?;
+        file.write_all(contents)
+            .with_context(|| format!("write temporary managed file {}", temporary.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync temporary managed file {}", temporary.display()))?;
+        fs::rename(&temporary, path)
+            .with_context(|| format!("replace managed file {}", path.display()))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn create_skill_link(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let target = fs::read_link(path)
+                .with_context(|| format!("read skill link {}", path.display()))?;
+            if target == Path::new(PUSH_SKILL_LINK) {
+                return Ok(());
+            }
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            #[cfg(unix)]
+            {
+                std::os::unix::fs::symlink(PUSH_SKILL_LINK, path)
+                    .with_context(|| format!("create skill link {}", path.display()))?;
+                return Ok(());
+            }
+            #[cfg(not(unix))]
+            bail!("Push project skills require symbolic link support");
+        }
+        Err(error) => {
+            return Err(error).with_context(|| format!("inspect skill link {}", path.display()))
+        }
+    }
+    bail!(
+        "Push found a conflicting provider skill at {} and left it unchanged. Move or remove that path, then rerun `push init`.",
+        path.display()
+    )
 }
 
 fn create_directory(path: &Path) -> Result<()> {
@@ -570,6 +776,17 @@ mod tests {
         assert!(target.join("evals").is_dir());
         assert!(target.join("jobs").is_dir());
         assert_eq!(fs::read_dir(target.join("jobs")).unwrap().count(), 0);
+        assert_eq!(
+            fs::read_to_string(target.join("skills/push/SKILL.md")).unwrap(),
+            PUSH_SKILL
+        );
+        let manifest: ManagedSkillManifest = serde_json::from_str(
+            &fs::read_to_string(target.join("skills/push/.push-managed.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(manifest.version, PUSH_SKILL_VERSION);
+        assert_eq!(manifest.sha256, sha256(PUSH_SKILL.as_bytes()));
+        assert_push_skill_links(&target);
         assert!(target.join(".git").exists());
         let raw = fs::read_to_string(config).unwrap();
         assert!(raw.contains(&format!(
@@ -586,6 +803,7 @@ mod tests {
         let config = parent.join("push.toml");
         init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
         fs::write(target.join("SOUL.md"), "My identity\n").unwrap();
+        fs::write(target.join("AGENTS.md"), "My repository rules\n").unwrap();
         fs::write(target.join("context/private.md"), "Keep me\n").unwrap();
         fs::remove_file(target.join("CLAUDE.md")).unwrap();
         let config_before = fs::read_to_string(&config).unwrap();
@@ -598,6 +816,10 @@ mod tests {
             "My identity\n"
         );
         assert_eq!(
+            fs::read_to_string(target.join("AGENTS.md")).unwrap(),
+            "My repository rules\n"
+        );
+        assert_eq!(
             fs::read_to_string(target.join("context/private.md")).unwrap(),
             "Keep me\n"
         );
@@ -605,7 +827,137 @@ mod tests {
             fs::read_to_string(target.join("CLAUDE.md")).unwrap(),
             CLAUDE
         );
+        assert_eq!(
+            fs::read_to_string(target.join("skills/push/SKILL.md")).unwrap(),
+            PUSH_SKILL
+        );
+        assert_push_skill_links(&target);
         assert_eq!(fs::read_to_string(config).unwrap(), config_before);
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[test]
+    fn refreshes_an_unmodified_older_managed_skill() {
+        let parent = temp_dir("assistant-skill-upgrade");
+        let target = parent.join("assistant");
+        let config = parent.join("push.toml");
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+        let skill_path = target.join("skills/push/SKILL.md");
+        let manifest_path = target.join("skills/push/.push-managed.json");
+        let old_skill = b"---\nname: push\ndescription: Old managed Push skill.\n---\n";
+        fs::write(&skill_path, old_skill).unwrap();
+        fs::write(
+            &manifest_path,
+            serde_json::to_vec_pretty(&ManagedSkillManifest {
+                version: 0,
+                sha256: sha256(old_skill),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+
+        assert_eq!(fs::read_to_string(skill_path).unwrap(), PUSH_SKILL);
+        let manifest: ManagedSkillManifest =
+            serde_json::from_str(&fs::read_to_string(manifest_path).unwrap()).unwrap();
+        assert_eq!(manifest.version, PUSH_SKILL_VERSION);
+        assert_eq!(manifest.sha256, sha256(PUSH_SKILL.as_bytes()));
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[test]
+    fn refuses_to_overwrite_a_user_modified_managed_skill() {
+        let parent = temp_dir("assistant-skill-modified");
+        let target = parent.join("assistant");
+        let config = parent.join("push.toml");
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+        let skill_path = target.join("skills/push/SKILL.md");
+        let modified = format!("{PUSH_SKILL}\nUser addition.\n");
+        fs::write(&skill_path, &modified).unwrap();
+        fs::write(target.join("SOUL.md"), "User identity.\n").unwrap();
+
+        let error = init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("user-modified managed skill"));
+        assert!(error.to_string().contains("left it unchanged"));
+        assert!(error.to_string().contains("differently named skill"));
+        assert_eq!(fs::read_to_string(skill_path).unwrap(), modified);
+        assert_eq!(
+            fs::read_to_string(target.join("SOUL.md")).unwrap(),
+            "User identity.\n"
+        );
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[test]
+    fn recreates_missing_provider_directories_and_links() {
+        let parent = temp_dir("assistant-skill-provider-directories");
+        let target = parent.join("assistant");
+        let config = parent.join("push.toml");
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+        for provider in PUSH_SKILL_PROVIDERS {
+            fs::remove_dir_all(target.join(provider)).unwrap();
+        }
+
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+
+        assert_push_skill_links(&target);
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_skill_paths_stay_inside_the_assistant() {
+        use std::os::unix::fs::symlink;
+
+        let parent = temp_dir("assistant-skill-path-safety");
+        let target = parent.join("assistant");
+        let config = parent.join("push.toml");
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+        assert_push_skill_links(&target);
+        for provider in PUSH_SKILL_PROVIDERS {
+            let link = target.join(provider).join("skills/push");
+            assert_eq!(fs::read_link(&link).unwrap(), Path::new(PUSH_SKILL_LINK));
+            assert_eq!(
+                fs::canonicalize(link).unwrap(),
+                fs::canonicalize(target.join("skills/push")).unwrap()
+            );
+        }
+
+        let outside = parent.join("outside-skill.md");
+        fs::write(&outside, "outside\n").unwrap();
+        let skill_path = target.join("skills/push/SKILL.md");
+        fs::remove_file(&skill_path).unwrap();
+        symlink(&outside, &skill_path).unwrap();
+
+        let error = init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("must be a regular file"));
+        assert_eq!(fs::read_to_string(outside).unwrap(), "outside\n");
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_to_replace_a_conflicting_provider_skill() {
+        use std::os::unix::fs::symlink;
+
+        let parent = temp_dir("assistant-skill-provider-conflict");
+        let target = parent.join("assistant");
+        let config = parent.join("push.toml");
+        init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap();
+        let link = target.join(".claude/skills/push");
+        fs::remove_file(&link).unwrap();
+        symlink("../../skills/user-push", &link).unwrap();
+
+        let error = init(target.to_str().unwrap(), config.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("conflicting provider skill"));
+        assert_eq!(
+            fs::read_link(&link).unwrap(),
+            Path::new("../../skills/user-push")
+        );
         let _ = fs::remove_dir_all(parent);
     }
 
@@ -863,5 +1215,17 @@ mod tests {
         assert!(error.to_string().contains("inline Slack tokens"));
         assert!(!target.join("SOUL.md").exists());
         let _ = fs::remove_dir_all(target);
+    }
+
+    fn assert_push_skill_links(root: &Path) {
+        let canonical = fs::canonicalize(root.join("skills/push")).unwrap();
+        for provider in PUSH_SKILL_PROVIDERS {
+            let link = root.join(provider).join("skills/push");
+            assert!(fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink());
+            assert_eq!(fs::canonicalize(link).unwrap(), canonical);
+        }
     }
 }

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -90,6 +90,22 @@ fn init_without_path_creates_assistant_in_current_directory() {
     assert!(assistant.join("context/README.md").is_file());
     assert!(assistant.join("evals").is_dir());
     assert!(assistant.join("jobs").is_dir());
+    let canonical_skill = assistant.join("skills/push/SKILL.md");
+    let skill = std::fs::read_to_string(&canonical_skill).unwrap();
+    assert!(skill.contains("name: push"));
+    assert!(skill.contains("push-managed-version: \"1\""));
+    assert!(!skill.contains(&root.to_string_lossy().to_string()));
+    for provider in [".agents", ".claude"] {
+        let exposure = assistant.join(provider).join("skills/push");
+        assert!(std::fs::symlink_metadata(&exposure)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            std::fs::canonicalize(exposure).unwrap(),
+            std::fs::canonicalize(assistant.join("skills/push")).unwrap()
+        );
+    }
     assert!(assistant.join(".git").exists());
     let config_path = home.join(".push/config.toml");
     let config = std::fs::read_to_string(&config_path).unwrap();


### PR DESCRIPTION
## Summary

`push init` now installs one canonical, versioned Push capability skill and exposes it to Claude Code, Codex, and Pi through their supported project discovery paths. A checksum manifest makes repeat initialization and upgrades idempotent while preserving modified or conflicting user content with actionable errors. The skill documents current stable CLI commands, job authoring, workspace ownership, sensitive state, and ordinary reply behavior.

## Why

Push assistants need one discoverable capability contract across all supported agent runtimes without copying instructions into provider-specific files or taking ownership of `SOUL.md`, `AGENTS.md`, user skills, credentials, or runtime state.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (354 unit, 1 doc, 12 init CLI, and 3 manual job tests passed)
- Focused assistant initialization tests passed 20/20, covering new and repeat initialization, version refresh, user modification, missing provider directories, conflicting links, and path safety
- Fresh independent subagent review: approved with no findings
- Rebased onto `origin/main` at `08fd740`; exact `range-diff` equality confirms the reviewed patch is unchanged after PR #171

## Risks

Live discovery was not exercised against installed Claude Code, Codex, and Pi binaries. GitHub CI provides cross-platform and strict documentation-build coverage.

## Related issue

Closes #168