### PR TITLE
test: explicitly release stale claim lock

### DIFF
--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -5384,6 +5384,10 @@ printf '%s\n' '{"type":"thread.started","thread_id":"limited"}'
         let mut restarted = Ledger::open(&cfg.paths.database).unwrap();
         restarted.recover_stale_runs(&cfg, 61_000).unwrap();
         assert_eq!(restarted.state(&id), "running");
+        // Release the OS lock explicitly before asking the restarted ledger
+        // to recover the claim. This keeps the test independent of when the
+        // file-handle destructor is observed by the runner.
+        lock._file.unlock().unwrap();
         drop(lock);
         restarted.recover_stale_runs(&cfg, 62_000).unwrap();
 


### PR DESCRIPTION
## Summary

- make the stale scheduled-claim restart test explicitly release its OS file lock before recovery
- preserve the existing explicit lease timestamps and all production recovery assertions
- keep the change test-only and scoped to the flaky regression

Closes #179

## Validation

- `cargo fmt --all --check` passed
- `git diff --check` passed

The focused `cargo test --locked` command could not compile this Windows checkout because the repository currently imports Unix-only APIs (`std::os::unix`, `tokio::signal::unix`) in the default test build. The patch uses the same explicit `lock._file.unlock()` pattern already present in `lock_and_ledger_prevent_overlap_and_recover_stale_claim`.

AI-assisted contribution. I reviewed the test path and existing lock-release precedent manually.