### PR TITLE
feat(telegram): support inbound images

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -309,7 +309,7 @@ The main pipeline lives in [`src/gateway/mod.rs`](src/gateway/mod.rs) and
  5. HISTORY INSERT       persist accepted inbound message in push.db
  6. ROUTE                select backend by exact thread, parent, channel, default
  7. ENQUEUE              place message on its per-thread bounded queue
- 8. PREPARE              resolve session, workspace, identity, optional voice
+ 8. PREPARE              resolve session, workspace, identity, voice, and images
  9. COMPOSE              frame system sections and untrusted fresh context
 10. RUN BACKEND          invoke the selected agent CLI with a timeout
 11. HISTORY INSERT       persist generated outbound response
@@ -437,6 +437,8 @@ File: [`src/telegram.rs`](src/telegram.rs)
 - Splits rich Markdown within Telegram's 4,096-character limit.
 - Refreshes typing activity during long runs.
 - Downloads voice notes only after allowlist acceptance.
+- Downloads supported images only after allowlist acceptance, validates their
+  signatures, and removes private handoff files after the Codex turn.
 - Sends text and optional generated voice replies.
 
 ### Slack
@@ -493,6 +495,7 @@ File: [`src/codex.rs`](src/codex.rs)
 | New chat | `codex exec --json` |
 | Resumed chat | `codex exec resume <thread-id> --json` |
 | Instructions | `-c developer_instructions=<composed system sections>` |
+| Images | repeated `--image <private-temporary-path>` on new and resumed chats |
 | Unattended job | full access with approval prompts disabled |
 | Evaluator | read-only, ephemeral, tools and project instructions disabled |
 
@@ -877,6 +880,7 @@ result before proactive delivery.
 | [`src/pi.rs`](src/pi.rs) | Pi CLI adapter |
 | [`src/store.rs`](src/store.rs) | transactional SQLite cursor/session state and legacy JSON migration |
 | [`src/history.rs`](src/history.rs) | SQLite schema, conversation history, delivery, and migrations |
+| [`src/image.rs`](src/image.rs) | image limits, signature validation, and private temporary-file cleanup |
 | [`src/jobs.rs`](src/jobs.rs) | runbook validation, execution, evaluation, scheduler, and ledger |
 | [`src/audit.rs`](src/audit.rs) | redacted JSONL audit log |
 | [`src/prompt.rs`](src/prompt.rs) | system-section and untrusted prompt-content composition |

--- a/docs/security.md
+++ b/docs/security.md
@@ -83,6 +83,12 @@ variable or move the config outside. When `voice.openai_api_key` is configured,
 chmod 600 "${PUSH_HOME:-$HOME/.push}/config.toml"
 ```
 
+Accepted Telegram images are briefly written under `$PUSH_HOME/cache` with
+owner-only permissions, passed to the selected Codex model provider, and
+removed when the turn ends. Conversation history retains only the caption or an
+image placeholder. Protect the cache directory while Push is running and
+review the configured model provider's image data controls.
+
 Push rejects any overlap between `assistant_root` and `PUSH_HOME`, including
 overlap through symlinks or existing ancestors. Keep the runtime root private
 to Push and keep the assistant as a separate user-owned Git repository.

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -50,6 +50,29 @@ Doctor validates that a token is available without displaying its value. A
 Telegram-only preflight does not open `chat.db` and does not require macOS or
 `osascript`.
 
+## Image Messages
+
+With Codex selected for the conversation, send the bot a Telegram photo or an
+image document. Push accepts JPEG, PNG, and WebP files. A caption becomes the
+message text; an image without a caption is still accepted. Telegram media
+groups are processed as separate messages.
+
+Push downloads an image only after the private-chat and sender allowlist checks
+pass. The declared and downloaded size must fit within the 6 MiB per-message
+limit, and Push verifies the downloaded file signature instead of trusting the
+provider MIME type. Unsupported, malformed, or oversized files receive a text
+reply and do not reach Codex.
+
+Validated bytes are written to an owner-only temporary directory under
+`$PUSH_HOME/cache`, attached to the Codex turn, and removed after success,
+failure, timeout, interruption, or session recovery. Push stores the caption or
+an `[Image attachment]` placeholder in conversation history, not the image
+bytes. The image is sent through the configured Codex model provider, so review
+that provider's image and data controls before using this feature.
+
+Image input for Claude Code and Pi, and sending generated images back through
+Telegram, are not supported yet.
+
 ## Voice Messages
 
 Add the optional OpenAI API key to `$PUSH_HOME/config.toml` to enable both incoming
@@ -100,10 +123,12 @@ channel can add those transport operations without changing the OpenAI layer.
 
 An incoming Telegram update reaches the agent only when all of these are true:
 
-- it is a normal text message or voice note in a private chat
+- it is a normal text message, voice note, photo, or image document in a private
+  chat
 - its numeric sender id is in `telegram.allow_user_ids`, or its numeric chat id
   is in `telegram.allow_chat_ids`
-- the message contains non-empty text or a voice attachment
+- the message contains non-empty text, a voice attachment, or an image
+  attachment
 
 Group chats, channels, group forum topics, edited messages, and other update
 types are out of scope and ignored. The private-chat thread key is

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,7 @@
 //! Agent backend boundary. The gateway owns messaging and assistant context;
 //! concrete agent CLIs own reasoning, tools, and execution.
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 use uuid::Uuid;
@@ -15,6 +16,7 @@ pub struct Request<'a> {
     pub work_dir: &'a str,
     pub instructions: &'a str,
     pub prompt: &'a str,
+    pub images: &'a [PathBuf],
 }
 
 /// A completed agent turn.
@@ -122,6 +124,17 @@ impl Runner {
         matches!(self, Runner::Claude(_))
     }
 
+    pub fn supports_images(&self) -> bool {
+        if matches!(self, Runner::Codex(_)) {
+            return true;
+        }
+        #[cfg(test)]
+        if let Self::Fake(runner) = self {
+            return runner.backend == AgentBackend::Codex;
+        }
+        false
+    }
+
     pub async fn run(&self, req: Request<'_>, timeout: Duration) -> Result<RunOutput, RunError> {
         match self {
             Runner::Claude(r) => r.run(req, timeout).await,
@@ -185,6 +198,7 @@ pub struct FakeRunCall {
     pub work_dir: String,
     pub prompt: String,
     pub instructions: String,
+    pub images: Vec<PathBuf>,
 }
 
 #[cfg(test)]
@@ -196,6 +210,7 @@ impl FakeRunner {
             work_dir: req.work_dir.to_string(),
             prompt: req.prompt.to_string(),
             instructions: req.instructions.to_string(),
+            images: req.images.to_vec(),
         });
         if !req.is_new
             && self

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -392,6 +392,7 @@ mod tests {
             is_group: false,
             text: "secret request".to_string(),
             voice: None,
+            images: Vec::new(),
             is_from_me: false,
             is_supported: true,
             thread_id: None,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -7,6 +7,7 @@ use anyhow::{bail, Context, Result};
 
 use crate::approval::AnswerOrigin;
 use crate::config::{ChannelKind, Config};
+use crate::image::DownloadedImage;
 use crate::imessage::{Poller as IMessagePoller, Sender as IMessageSender};
 use crate::slack::{parse_message_target, Slack};
 use crate::telegram::Telegram;
@@ -26,6 +27,16 @@ pub struct InboundVoice {
 }
 
 #[derive(Debug, Clone)]
+pub struct InboundImage {
+    /// Channel-owned file identifier. The gateway treats this as opaque.
+    pub locator: String,
+    pub file_size: Option<usize>,
+    pub mime_type: Option<String>,
+    /// Tests and channels that already own the bytes may provide them directly.
+    pub data: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone)]
 pub struct RawMessage {
     pub row_id: i64,
     /// Provider-stable identifier used for durable deduplication when it is
@@ -37,6 +48,7 @@ pub struct RawMessage {
     pub is_group: bool,
     pub text: String,
     pub voice: Option<InboundVoice>,
+    pub images: Vec<InboundImage>,
     pub is_from_me: bool,
     pub is_supported: bool,
     /// Channel-specific thread/topic id (Telegram `message_thread_id`).
@@ -108,6 +120,7 @@ trait ChannelContract {
 
     async fn download_voice(&self, voice: &InboundVoice) -> Result<AudioClip>;
     async fn send_voice(&self, target: &str, clip: &AudioClip) -> Result<()>;
+    async fn download_image(&self, image: &InboundImage) -> Result<DownloadedImage>;
 
     fn delivery_semantics(&self) -> DeliverySemantics {
         DeliverySemantics {
@@ -306,6 +319,14 @@ impl Channel {
         }
     }
 
+    pub async fn download_image(&self, image: &InboundImage) -> Result<DownloadedImage> {
+        match self {
+            Self::IMessage(channel) => ChannelContract::download_image(channel, image).await,
+            Self::Telegram(channel) => ChannelContract::download_image(channel, image).await,
+            Self::Slack(channel) => ChannelContract::download_image(channel, image).await,
+        }
+    }
+
     pub fn delivery_semantics(&self) -> DeliverySemantics {
         match self {
             Self::IMessage(channel) => ChannelContract::delivery_semantics(channel),
@@ -358,6 +379,7 @@ impl ChannelContract for IMessageChannel {
                 is_group: message.is_group,
                 text: message.text,
                 voice: None,
+                images: Vec::new(),
                 is_from_me: message.is_from_me,
                 is_supported: true,
                 thread_id: None,
@@ -451,6 +473,15 @@ impl ChannelContract for IMessageChannel {
 
     async fn send_voice(&self, _target: &str, _clip: &AudioClip) -> Result<()> {
         bail!("iMessage voice replies are not supported yet")
+    }
+
+    async fn download_image(&self, image: &InboundImage) -> Result<DownloadedImage> {
+        let Some(bytes) = &image.data else {
+            bail!("iMessage image attachments are not supported yet");
+        };
+        Ok(DownloadedImage {
+            bytes: bytes.clone(),
+        })
     }
 }
 
@@ -575,6 +606,10 @@ impl ChannelContract for Telegram {
     async fn send_voice(&self, target: &str, clip: &AudioClip) -> Result<()> {
         self.send_voice(target, clip).await
     }
+
+    async fn download_image(&self, image: &InboundImage) -> Result<DownloadedImage> {
+        self.download_image(image).await
+    }
 }
 
 impl ChannelContract for Slack {
@@ -671,6 +706,15 @@ impl ChannelContract for Slack {
         bail!("Slack voice replies are not supported")
     }
 
+    async fn download_image(&self, image: &InboundImage) -> Result<DownloadedImage> {
+        let Some(bytes) = &image.data else {
+            bail!("Slack image attachments are not supported yet");
+        };
+        Ok(DownloadedImage {
+            bytes: bytes.clone(),
+        })
+    }
+
     fn delivery_semantics(&self) -> DeliverySemantics {
         DeliverySemantics {
             // Slack's HTTP client bounds each request. A zero gateway timeout
@@ -689,7 +733,8 @@ fn common_reject_reason(message: &RawMessage) -> Option<&'static str> {
         Some("unsupported_update")
     } else if message.is_group {
         Some("group_chat")
-    } else if message.text.trim().is_empty() && message.voice.is_none() {
+    } else if message.text.trim().is_empty() && message.voice.is_none() && message.images.is_empty()
+    {
         Some("empty_message")
     } else {
         None
@@ -784,6 +829,7 @@ mod tests {
             is_group: false,
             text: "hello".to_string(),
             voice: None,
+            images: Vec::new(),
             is_from_me,
             is_supported: true,
             thread_id: None,
@@ -800,6 +846,7 @@ mod tests {
             is_group,
             text: "hello".to_string(),
             voice: None,
+            images: Vec::new(),
             is_from_me: false,
             is_supported: true,
             thread_id: None,
@@ -894,6 +941,7 @@ mod tests {
             is_group: false,
             text: "hello".to_string(),
             voice: None,
+            images: Vec::new(),
             is_from_me: false,
             is_supported: true,
             thread_id: None,

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -230,6 +230,7 @@ mod tests {
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: &instructions,
                     prompt: &prompt,
+                    images: &[],
                 },
                 Duration::from_secs(5),
             )
@@ -272,6 +273,7 @@ mod tests {
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: "assistant identity",
                     prompt: "continue",
+                    images: &[],
                 },
                 Duration::from_secs(5),
             )
@@ -349,6 +351,7 @@ mod tests {
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: "",
                     prompt: "continue",
+                    images: &[],
                 },
                 Duration::from_secs(5),
             )
@@ -448,6 +451,7 @@ mod tests {
             work_dir,
             instructions: "",
             prompt: "hello",
+            images: &[],
         }
     }
 
@@ -547,6 +551,7 @@ mod tests {
             work_dir,
             instructions: String::new(),
             prompt: "hello".to_string(),
+            images: Vec::new(),
         }
     }
 }

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -188,6 +188,9 @@ impl Runner {
                     .arg("--ephemeral")
                     .arg("--ignore-user-config");
             }
+            for image in req.images {
+                cmd.arg("--image").arg(image);
+            }
             cmd.arg(req.prompt);
         } else {
             cmd.arg("exec");
@@ -196,6 +199,9 @@ impl Runner {
                 .arg("--skip-git-repo-check")
                 .arg("-o")
                 .arg(out_path);
+            for image in req.images {
+                cmd.arg("--image").arg(image);
+            }
             cmd.arg(req.session_id).arg(req.prompt);
         }
         cmd.current_dir(req.work_dir);
@@ -331,6 +337,7 @@ mod tests {
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: &instructions,
                     prompt: &prompt,
+                    images: &[],
                 },
                 Duration::from_secs(5),
             )
@@ -367,6 +374,7 @@ mod tests {
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: "assistant identity",
                     prompt: "continue",
+                    images: &[],
                 },
                 Duration::from_secs(5),
             )
@@ -384,6 +392,74 @@ mod tests {
         assert_arg_pair(&args, "-c", &developer_instructions("assistant identity"));
         assert_eq!(args.last().unwrap(), "continue");
         assert!(!args.contains(&"-C".to_string()));
+    }
+
+    #[tokio::test]
+    async fn attaches_images_to_new_and_resumed_sessions() {
+        let work_dir = temp_dir("codex-images-work");
+        let first_image = temp_path("codex-first-image.png");
+        let second_image = temp_path("codex-second-image.webp");
+        std::fs::write(&first_image, b"first").unwrap();
+        std::fs::write(&second_image, b"second").unwrap();
+
+        let new_args = temp_path("codex-new-image-args");
+        let new_cli = FakeCli::new(
+            "codex",
+            &codex_success_script(&new_args, "new reply", Some("codex-thread")),
+        );
+        runner(new_cli.bin())
+            .run(
+                Request {
+                    session_id: "",
+                    is_new: true,
+                    work_dir: work_dir.to_str().unwrap(),
+                    instructions: "",
+                    prompt: "inspect",
+                    images: &[first_image.clone(), second_image.clone()],
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+        let args = read_args(&new_args);
+        let attached = args
+            .windows(2)
+            .filter(|pair| pair[0] == "--image")
+            .map(|pair| pair[1].as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            attached,
+            [
+                first_image.to_str().unwrap(),
+                second_image.to_str().unwrap()
+            ]
+        );
+
+        let resumed_args = temp_path("codex-resumed-image-args");
+        let resumed_cli = FakeCli::new(
+            "codex",
+            &codex_success_script(&resumed_args, "resumed reply", None),
+        );
+        runner(resumed_cli.bin())
+            .run(
+                Request {
+                    session_id: "codex-thread",
+                    is_new: false,
+                    work_dir: work_dir.to_str().unwrap(),
+                    instructions: "",
+                    prompt: "inspect again",
+                    images: std::slice::from_ref(&first_image),
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+        let args = read_args(&resumed_args);
+        assert_arg_sequence(&args, &["exec", "resume"]);
+        assert_arg_pair(&args, "--image", first_image.to_str().unwrap());
+
+        let _ = std::fs::remove_file(first_image);
+        let _ = std::fs::remove_file(second_image);
     }
 
     #[tokio::test]
@@ -439,6 +515,7 @@ mod tests {
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: "",
                     prompt: "continue",
+                    images: &[],
                 },
                 Duration::from_secs(5),
             )
@@ -545,6 +622,7 @@ sleep 2
             work_dir,
             instructions: "",
             prompt: "hello",
+            images: &[],
         }
     }
 
@@ -690,6 +768,7 @@ sleep 2
             work_dir,
             instructions: String::new(),
             prompt: "hello".to_string(),
+            images: Vec::new(),
         }
     }
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -19,7 +19,7 @@ use tracing::{error, info, warn};
 use crate::agent::Runner;
 use crate::approval::{AnswerOrigin, AnswerOutcome};
 use crate::audit::{AuditEvent, AuditLog};
-use crate::channel::{Channel, InboundVoice, RawMessage};
+use crate::channel::{Channel, InboundImage, InboundVoice, RawMessage};
 use crate::config::{AgentBackend, ChannelKind, Config, PrimaryDeliveryConfig};
 use crate::history::{History, OutboundOrigin};
 use crate::jobs;
@@ -42,6 +42,7 @@ struct Job {
     text: String,
     reply_with_voice: bool,
     voice_attachment: Option<InboundVoice>,
+    image_attachments: Vec<InboundImage>,
     approval_origin: AnswerOrigin,
 }
 
@@ -601,11 +602,13 @@ impl Gateway {
                 let reply_with_voice = m.voice.is_some();
                 let message_text = if reply_with_voice {
                     "[Voice message]".to_string()
+                } else if m.text.trim().is_empty() && !m.images.is_empty() {
+                    "[Image attachment]".to_string()
                 } else {
                     m.text.trim().to_string()
                 };
                 let approval_origin = self.channel.approval_origin(m, &thread);
-                let approval = if reply_with_voice {
+                let approval = if reply_with_voice || !m.images.is_empty() {
                     Ok(AnswerOutcome::NotAnAnswer)
                 } else {
                     self.ctx.history.lock().unwrap().answer_question(
@@ -799,9 +802,11 @@ impl Gateway {
                     text: message_text,
                     reply_with_voice,
                     voice_attachment: m.voice.clone(),
+                    image_attachments: m.images.clone(),
                     approval_origin,
                 };
-                if job.text.trim().eq_ignore_ascii_case("/stop") {
+                if job.image_attachments.is_empty() && job.text.trim().eq_ignore_ascii_case("/stop")
+                {
                     if !self.stop(job).await {
                         return;
                     }

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -2,7 +2,7 @@ use super::worker::{handle, run_with_periodic_activity, SESSION_SETUP_FAILURE};
 use super::*;
 use crate::agent::{FakeRunCall, FakeRunner};
 use crate::approval::Question;
-use crate::channel::{normalize_handle, thread_handle, InboundVoice};
+use crate::channel::{normalize_handle, thread_handle, InboundImage, InboundVoice};
 use crate::history::DeliveryStatus;
 use crate::imessage::{Poller, Sender};
 use crate::voice::{AudioClip, VoiceFuture, VoiceProvider};
@@ -160,6 +160,7 @@ fn msg(chat: &str, handle: &str, from_me: bool, text: &str) -> RawMessage {
         chat_identifier: chat.to_string(),
         text: text.to_string(),
         voice: None,
+        images: Vec::new(),
         is_from_me: from_me,
         is_group: false,
         is_supported: true,
@@ -244,6 +245,7 @@ fn setup_failure_job(row_id: i64) -> Job {
         text: "hello".to_string(),
         reply_with_voice: false,
         voice_attachment: None,
+        image_attachments: Vec::new(),
         approval_origin: AnswerOrigin {
             channel: "imessage".to_string(),
             thread_key: "imessage:self:me".to_string(),
@@ -1034,11 +1036,14 @@ async fn missing_backend_session_rotates_and_rehydrates_once() {
         vec![message(1, "+15551234567", "+15551234567", false, "first")],
     )
     .await;
-    run_messages(
-        &mut gateway,
-        vec![message(2, "+15551234567", "+15551234567", false, "second")],
-    )
-    .await;
+    let mut second = message(2, "+15551234567", "+15551234567", false, "second");
+    second.images.push(InboundImage {
+        locator: "image-file".to_string(),
+        file_size: Some(12),
+        mime_type: Some("image/png".to_string()),
+        data: Some(b"\x89PNG\r\n\x1a\nbody".to_vec()),
+    });
+    run_messages(&mut gateway, vec![second]).await;
 
     let calls = calls.lock().unwrap();
     assert_eq!(calls.len(), 3);
@@ -1048,6 +1053,9 @@ async fn missing_backend_session_rotates_and_rehydrates_once() {
         Some("second")
     );
     assert!(calls[2].is_new);
+    assert_eq!(calls[1].images.len(), 1);
+    assert_eq!(calls[2].images, calls[1].images);
+    assert!(!calls[1].images[0].exists());
     assert!(calls[2]
         .prompt
         .contains(r#"{"role":"user","content":"first"}"#));
@@ -1072,6 +1080,7 @@ async fn missing_backend_session_rotates_and_rehydrates_once() {
 
     let _ = std::fs::remove_file(&state_path);
     let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(format!("{state_path}.cache"));
     let _ = std::fs::remove_file(format!("{state_path}.db"));
     let _ = std::fs::remove_dir_all(sessions_dir);
     let _ = std::fs::remove_dir_all(assistant_dir);
@@ -1512,7 +1521,11 @@ async fn telegram_filters_before_agent_and_replies_to_originating_chat() {
 
     gateway
         .tick_fake(vec![
-            telegram_message(10, 8, 8, false, "ignore me"),
+            {
+                let mut message = telegram_image_message(10, 8, 8, "ignore me");
+                message.images[0].data = Some(b"not an image".to_vec());
+                message
+            },
             telegram_message(11, 7, 7, false, "hello"),
             telegram_message(12, 7, -100, true, "group"),
         ])
@@ -1724,6 +1737,220 @@ async fn telegram_voice_is_transcribed_and_gets_text_and_voice_replies() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn telegram_image_is_available_to_the_agent_and_removed_after_the_turn() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("image-sessions");
+    let assistant_dir = temp_path("image-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::<FakeRunCall>::new()));
+    let observed = Arc::new(Mutex::new(false));
+    let hook_calls = calls.clone();
+    let hook_observed = observed.clone();
+    let hook = Arc::new(move || {
+        let calls = hook_calls.lock().unwrap();
+        let image = &calls.last().unwrap().images[0];
+        assert!(image.is_file());
+        assert!(std::fs::read(image)
+            .unwrap()
+            .starts_with(b"\x89PNG\r\n\x1a\n"));
+        *hook_observed.lock().unwrap() = true;
+    });
+    let mut cfg = test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    );
+    cfg.channel = "telegram".to_string();
+    cfg.telegram_bot_token = Some("secret".to_string());
+    cfg.telegram_allow_user_ids = vec![7];
+    let mut gateway = Gateway::new(cfg).unwrap();
+    gateway.ctx.runners = Arc::new(fake_runners_with_hook(calls.clone(), Some(hook)));
+
+    run_messages(
+        &mut gateway,
+        vec![
+            telegram_image_message(1, 7, 7, ""),
+            telegram_image_message(2, 7, 7, "/help"),
+            telegram_image_message(3, 7, 7, "/stop"),
+        ],
+    )
+    .await;
+
+    assert!(*observed.lock().unwrap());
+    let calls = calls.lock().unwrap();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(
+        crate::prompt::current_message(&calls[0].prompt).as_deref(),
+        Some("[Image attachment]")
+    );
+    assert_eq!(
+        crate::prompt::current_message(&calls[1].prompt).as_deref(),
+        Some("/help")
+    );
+    assert_eq!(
+        crate::prompt::current_message(&calls[2].prompt).as_deref(),
+        Some("/stop")
+    );
+    assert!(calls.iter().all(|call| call.images.len() == 1));
+    assert!(calls.iter().all(|call| !call.images[0].exists()));
+    drop(calls);
+    assert_eq!(gateway.store.lock().unwrap().cursor("telegram").unwrap(), 3);
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(format!("{state_path}.cache"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn telegram_image_is_removed_before_reply_delivery_finishes() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("image-delivery-sessions");
+    let assistant_dir = temp_path("image-delivery-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::<FakeRunCall>::new()));
+    let captured_path = Arc::new(Mutex::new(None));
+    let hook_calls = calls.clone();
+    let hook_path = captured_path.clone();
+    let hook = Arc::new(move || {
+        *hook_path.lock().unwrap() = Some(hook_calls.lock().unwrap()[0].images[0].clone());
+    });
+    let mut cfg = test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    );
+    cfg.channel = "telegram".to_string();
+    cfg.telegram_bot_token = Some("secret".to_string());
+    cfg.telegram_allow_user_ids = vec![7];
+    let mut gateway = Gateway::new(cfg).unwrap();
+    gateway.ctx.runners = Arc::new(fake_runners_with_hook(calls, Some(hook)));
+    *gateway.ctx.send_failures_remaining.lock().unwrap() = usize::MAX;
+
+    let task = tokio::spawn(async move {
+        run_messages(
+            &mut gateway,
+            vec![telegram_image_message(1, 7, 7, "inspect")],
+        )
+        .await;
+    });
+    let removed_path = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if let Some(path) = captured_path.lock().unwrap().clone() {
+                if !path.exists() {
+                    break path;
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("image should be removed while delivery keeps retrying");
+
+    assert!(!removed_path.exists());
+    assert!(!task.is_finished());
+    task.abort();
+    let _ = task.await;
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(format!("{state_path}.cache"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn invalid_and_oversized_telegram_images_fall_back_without_running_the_agent() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("invalid-image-sessions");
+    let assistant_dir = temp_path("invalid-image-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let mut cfg = test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    );
+    cfg.channel = "telegram".to_string();
+    cfg.telegram_bot_token = Some("secret".to_string());
+    cfg.telegram_allow_user_ids = vec![7];
+    let mut gateway = Gateway::new(cfg).unwrap();
+    gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+    let mut invalid = telegram_image_message(1, 7, 7, "inspect");
+    invalid.images[0].data = Some(b"not an image".to_vec());
+    let mut oversized = telegram_image_message(2, 7, 7, "inspect");
+    oversized.images[0].file_size = Some(crate::image::MAX_IMAGE_BYTES + 1);
+
+    run_messages(&mut gateway, vec![invalid, oversized]).await;
+
+    assert!(calls.lock().unwrap().is_empty());
+    let replies = gateway.ctx.sent_replies.lock().unwrap();
+    assert_eq!(replies.len(), 2);
+    assert!(replies
+        .iter()
+        .all(|(_, reply)| reply.contains("JPEG, PNG, or WebP")));
+    assert_eq!(gateway.store.lock().unwrap().cursor("telegram").unwrap(), 2);
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(format!("{state_path}.cache"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn telegram_image_on_unsupported_backend_falls_back_without_downloading() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("unsupported-image-sessions");
+    let assistant_dir = temp_path("unsupported-image-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let mut cfg = test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    );
+    cfg.channel = "telegram".to_string();
+    cfg.agent = "pi".to_string();
+    cfg.telegram_bot_token = Some("secret".to_string());
+    cfg.telegram_allow_user_ids = vec![7];
+    let mut gateway = Gateway::new(cfg).unwrap();
+    gateway.ctx.runners = Arc::new(HashMap::from([(
+        AgentBackend::Pi,
+        Runner::Fake(FakeRunner {
+            backend: AgentBackend::Pi,
+            session_id: "fake-session".to_string(),
+            calls: calls.clone(),
+            before_return: None,
+            wait_for_release: None,
+            failure: None,
+            resume_missing_once: None,
+        }),
+    )]));
+    let mut message = telegram_image_message(1, 7, 7, "inspect");
+    message.images[0].data = Some(b"not an image".to_vec());
+
+    run_messages(&mut gateway, vec![message]).await;
+
+    assert!(calls.lock().unwrap().is_empty());
+    assert_eq!(
+        gateway.ctx.sent_replies.lock().unwrap()[0].1,
+        "Image messages are currently supported only when this conversation routes to Codex."
+    );
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(format!("{state_path}.cache"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn telegram_voice_without_openai_key_falls_back_without_running_agent() {
     let state_path = temp_state_path();
     let sessions_dir = temp_path("voice-missing-key-sessions");
@@ -1859,6 +2086,7 @@ async fn closed_worker_queue_is_recovered_without_another_message() {
         text: "recover older".to_string(),
         reply_with_voice: false,
         voice_attachment: None,
+        image_attachments: Vec::new(),
         approval_origin: AnswerOrigin {
             channel: "imessage".to_string(),
             thread_key: thread.to_string(),
@@ -1940,9 +2168,14 @@ async fn stop_interrupts_active_run_and_preserves_queued_messages() {
     );
     gateway.ctx.runners = Arc::new(runners);
 
-    gateway
-        .tick_fake(vec![message(1, "me@icloud.com", "", true, "slow")])
-        .await;
+    let mut slow = message(1, "me@icloud.com", "", true, "slow");
+    slow.images.push(InboundImage {
+        locator: "image-file".to_string(),
+        file_size: Some(12),
+        mime_type: Some("image/png".to_string()),
+        data: Some(b"\x89PNG\r\n\x1a\nbody".to_vec()),
+    });
+    gateway.tick_fake(vec![slow]).await;
     tokio::time::timeout(Duration::from_secs(1), async {
         loop {
             if !calls.lock().unwrap().is_empty() {
@@ -1953,6 +2186,8 @@ async fn stop_interrupts_active_run_and_preserves_queued_messages() {
     })
     .await
     .expect("first run should become active");
+    let image_path = calls.lock().unwrap()[0].images[0].clone();
+    assert!(image_path.exists());
 
     gateway
         .tick_fake(vec![
@@ -1977,6 +2212,7 @@ async fn stop_interrupts_active_run_and_preserves_queued_messages() {
     })
     .await
     .expect("active run should stop before the queued run starts");
+    assert!(!image_path.exists());
     release.notify_one();
     gateway.queues.clear();
     gateway.drain_workers().await;
@@ -2007,6 +2243,7 @@ async fn stop_interrupts_active_run_and_preserves_queued_messages() {
     let _ = std::fs::remove_file(&state_path);
     let _ = std::fs::remove_file(format!("{state_path}.db"));
     let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(format!("{state_path}.cache"));
     let _ = std::fs::remove_dir_all(sessions_dir);
     let _ = std::fs::remove_dir_all(assistant_dir);
 }
@@ -2159,6 +2396,7 @@ async fn stop_targets_the_current_row_ahead_of_retained_failures() {
         text: text.to_string(),
         reply_with_voice: false,
         voice_attachment: None,
+        image_attachments: Vec::new(),
         approval_origin: AnswerOrigin {
             channel: "imessage".to_string(),
             thread_key: thread.to_string(),
@@ -3140,6 +3378,7 @@ fn message(row_id: i64, chat: &str, handle: &str, is_from_me: bool, text: &str) 
         chat_identifier: chat.to_string(),
         text: text.to_string(),
         voice: None,
+        images: Vec::new(),
         is_from_me,
         is_group: false,
         is_supported: true,
@@ -3162,6 +3401,7 @@ fn telegram_message(
         chat_identifier: chat_id.to_string(),
         text: text.to_string(),
         voice: None,
+        images: Vec::new(),
         is_from_me: false,
         is_group,
         is_supported: true,
@@ -3177,6 +3417,17 @@ fn telegram_voice_message(row_id: i64, user_id: i64, chat_id: i64) -> RawMessage
         mime_type: "audio/ogg".to_string(),
         filename: "voice.ogg".to_string(),
         data: Some(vec![1, 2, 3]),
+    });
+    message
+}
+
+fn telegram_image_message(row_id: i64, user_id: i64, chat_id: i64, caption: &str) -> RawMessage {
+    let mut message = telegram_message(row_id, user_id, chat_id, false, caption);
+    message.images.push(InboundImage {
+        locator: "image-file".to_string(),
+        file_size: Some(12),
+        mime_type: Some("image/png".to_string()),
+        data: Some(b"\x89PNG\r\n\x1a\nbody".to_vec()),
     });
     message
 }

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -2,15 +2,17 @@
 //! outcome in canonical history, and delivers the reply.
 
 use std::future::{pending, Future};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tokio::sync::{mpsc, watch};
 use tracing::{error, info, warn};
 
 use crate::agent::{Request, RunError};
 use crate::history::{DeliveryStatus, OutboundMessage, OutboundOrigin};
+use crate::image::{PreparedImages, MAX_IMAGE_BYTES, MAX_IMAGE_COUNT};
 use crate::prompt::{ComposedPrompt, Composer};
 use crate::voice::MAX_AUDIO_BYTES;
 
@@ -100,24 +102,26 @@ where
         }
     }
 
-    if let Some(reply) = command(ctx, &job) {
-        let delivery = record_and_deliver(ctx, &job, OutboundOrigin::Gateway, &reply).await;
-        if delivery.is_ok() {
-            info!(
-                "[{}] command reply sent via {}",
-                job.thread,
-                ctx.channel.id()
+    if job.image_attachments.is_empty() {
+        if let Some(reply) = command(ctx, &job) {
+            let delivery = record_and_deliver(ctx, &job, OutboundOrigin::Gateway, &reply).await;
+            if delivery.is_ok() {
+                info!(
+                    "[{}] command reply sent via {}",
+                    job.thread,
+                    ctx.channel.id()
+                );
+            }
+            report_delivery(
+                ctx,
+                &job,
+                delivery,
+                &reply,
+                "command",
+                "record command reply",
             );
+            return;
         }
-        report_delivery(
-            ctx,
-            &job,
-            delivery,
-            &reply,
-            "command",
-            "record command reply",
-        );
-        return;
     }
 
     let Some(runner) = ctx.runners.get(&job.backend) else {
@@ -139,6 +143,21 @@ where
         complete_job(ctx, &job, "missing_runner");
         return;
     };
+
+    if !job.image_attachments.is_empty() && !runner.supports_images() {
+        let reply =
+            "Image messages are currently supported only when this conversation routes to Codex.";
+        let delivery = record_and_deliver(ctx, &job, OutboundOrigin::Gateway, reply).await;
+        report_delivery(
+            ctx,
+            &job,
+            delivery,
+            reply,
+            "image_backend_unsupported",
+            "deliver image backend fallback",
+        );
+        return;
+    }
 
     let session_result = {
         let initial_session_id = runner.initial_session_id();
@@ -220,6 +239,41 @@ where
         }
     };
 
+    let prepared_images = if job.image_attachments.is_empty() {
+        None
+    } else {
+        match prepare_images(ctx, &job).await {
+            Ok(images) => Some(images),
+            Err(error) => {
+                warn!("[{}] {error:#}", job.thread);
+                audit(
+                    ctx,
+                    ctx.audit.failed(
+                        "image_preparation_failed",
+                        job.row_id,
+                        &job.thread,
+                        Some(job.backend),
+                        error.to_string(),
+                    ),
+                );
+                let reply = "I could not use that image. Send up to 4 JPEG, PNG, or WebP images with a combined size under 6 MiB, then try again.";
+                let delivery = record_and_deliver(ctx, &job, OutboundOrigin::Gateway, reply).await;
+                report_delivery(
+                    ctx,
+                    &job,
+                    delivery,
+                    reply,
+                    "image_preparation_failed",
+                    "deliver image fallback",
+                );
+                return;
+            }
+        }
+    };
+    let image_paths = prepared_images
+        .as_ref()
+        .map_or_else(Vec::new, |images| images.paths().to_vec());
+
     let run = async {
         let mut session_id = session_id;
         let mut prompt = match conversation_prompt(ctx, &job, &composer, is_new) {
@@ -254,7 +308,7 @@ where
         );
         let mut result = runner
             .run(
-                backend_request(&session_id, is_new, &work_dir, &prompt),
+                backend_request(&session_id, is_new, &work_dir, &prompt, &image_paths),
                 ctx.run_timeout,
             )
             .await;
@@ -269,7 +323,7 @@ where
                     })?;
                     result = runner
                         .run(
-                            backend_request(&session_id, false, &work_dir, &prompt),
+                            backend_request(&session_id, false, &work_dir, &prompt, &image_paths),
                             ctx.run_timeout,
                         )
                         .await;
@@ -323,7 +377,7 @@ where
             );
             result = runner
                 .run(
-                    backend_request(&session_id, true, &work_dir, &prompt),
+                    backend_request(&session_id, true, &work_dir, &prompt, &image_paths),
                     ctx.run_timeout,
                 )
                 .await;
@@ -351,12 +405,14 @@ where
             run.await
         }
     };
-    tokio::pin!(run);
+    let mut run = Box::pin(run);
     tokio::pin!(interrupt);
     let result = tokio::select! {
         result = &mut run => Some(result),
         _ = &mut interrupt => None,
     };
+    drop(run);
+    drop(prepared_images);
 
     match result {
         Some(Ok(out)) => {
@@ -619,6 +675,35 @@ async fn prepare_voice(ctx: &Ctx, job: &Job) -> std::result::Result<String, Voic
         .replace_inbound_content(job.inbound_id, &transcript)
         .map_err(VoicePreparationError::History)?;
     Ok(transcript)
+}
+
+async fn prepare_images(ctx: &Ctx, job: &Job) -> Result<PreparedImages> {
+    if job.image_attachments.len() > MAX_IMAGE_COUNT {
+        anyhow::bail!("image message has more than {MAX_IMAGE_COUNT} attachments");
+    }
+    let declared_total = job
+        .image_attachments
+        .iter()
+        .filter_map(|image| image.file_size)
+        .try_fold(0usize, |total, size| total.checked_add(size))
+        .context("image message size overflow")?;
+    if declared_total > MAX_IMAGE_BYTES {
+        anyhow::bail!("image message exceeds the 6 MiB limit");
+    }
+
+    let mut downloaded = Vec::with_capacity(job.image_attachments.len());
+    let mut actual_total = 0usize;
+    for attachment in &job.image_attachments {
+        let image = ctx.channel.download_image(attachment).await?;
+        actual_total = actual_total
+            .checked_add(image.bytes.len())
+            .context("image message size overflow")?;
+        if actual_total > MAX_IMAGE_BYTES {
+            anyhow::bail!("image message exceeds the 6 MiB limit");
+        }
+        downloaded.push(image);
+    }
+    PreparedImages::create(&ctx.cfg.paths.cache, downloaded)
 }
 
 /// Error and completion labels for one gateway-authored reply flow.
@@ -1003,6 +1088,7 @@ fn backend_request<'a>(
     is_new: bool,
     work_dir: &'a str,
     prompt: &'a ComposedPrompt,
+    images: &'a [PathBuf],
 ) -> Request<'a> {
     Request {
         session_id,
@@ -1010,5 +1096,6 @@ fn backend_request<'a>(
         work_dir,
         instructions: &prompt.instructions,
         prompt: &prompt.content,
+        images,
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,0 +1,172 @@
+//! Provider-neutral inbound image validation and temporary-file lifecycle.
+
+use std::fs::{DirBuilder, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use uuid::Uuid;
+
+pub const MAX_IMAGE_COUNT: usize = 4;
+pub const MAX_IMAGE_BYTES: usize = 6 * 1024 * 1024;
+
+#[derive(Debug)]
+pub struct DownloadedImage {
+    pub bytes: Vec<u8>,
+}
+
+pub struct PreparedImages {
+    directory: PathBuf,
+    paths: Vec<PathBuf>,
+}
+
+impl PreparedImages {
+    pub fn create(cache_dir: &Path, images: Vec<DownloadedImage>) -> Result<Self> {
+        if images.is_empty() {
+            return Ok(Self {
+                directory: PathBuf::new(),
+                paths: Vec::new(),
+            });
+        }
+        if images.len() > MAX_IMAGE_COUNT {
+            bail!("image message has more than {MAX_IMAGE_COUNT} attachments");
+        }
+        let total = images
+            .iter()
+            .try_fold(0usize, |total, image| total.checked_add(image.bytes.len()))
+            .context("image message size overflow")?;
+        if total > MAX_IMAGE_BYTES {
+            bail!("image message exceeds the 6 MiB limit");
+        }
+
+        std::fs::create_dir_all(cache_dir)
+            .with_context(|| format!("create image cache directory {}", cache_dir.display()))?;
+        crate::util::restrict_permissions(cache_dir, true)
+            .with_context(|| format!("restrict image cache directory {}", cache_dir.display()))?;
+        let directory = cache_dir.join(format!("images-{}", Uuid::new_v4()));
+        DirBuilder::new()
+            .mode(0o700)
+            .create(&directory)
+            .with_context(|| format!("create temporary image directory {}", directory.display()))?;
+
+        let mut prepared = Self {
+            directory,
+            paths: Vec::with_capacity(images.len()),
+        };
+        for (index, image) in images.into_iter().enumerate() {
+            let extension = image_extension(&image.bytes)?;
+            let path = prepared
+                .directory
+                .join(format!("image-{}.{}", index + 1, extension));
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&path)
+                .with_context(|| format!("create temporary image {}", path.display()))?;
+            prepared.paths.push(path.clone());
+            file.write_all(&image.bytes)
+                .with_context(|| format!("write temporary image {}", path.display()))?;
+            file.sync_all()
+                .with_context(|| format!("sync temporary image {}", path.display()))?;
+        }
+        Ok(prepared)
+    }
+
+    pub fn paths(&self) -> &[PathBuf] {
+        &self.paths
+    }
+}
+
+impl Drop for PreparedImages {
+    fn drop(&mut self) {
+        for path in &self.paths {
+            let _ = std::fs::remove_file(path);
+        }
+        if !self.directory.as_os_str().is_empty() {
+            let _ = std::fs::remove_dir(&self.directory);
+        }
+    }
+}
+
+fn image_extension(bytes: &[u8]) -> Result<&'static str> {
+    if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        return Ok("jpg");
+    }
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return Ok("png");
+    }
+    if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        return Ok("webp");
+    }
+    bail!("image attachment is not a supported JPEG, PNG, or WebP file")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::temp_dir;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn validates_writes_and_removes_supported_images() {
+        let cache = temp_dir("prepared-images");
+        let prepared = PreparedImages::create(
+            &cache,
+            vec![
+                DownloadedImage {
+                    bytes: b"\x89PNG\r\n\x1a\nbody".to_vec(),
+                },
+                DownloadedImage {
+                    bytes: b"RIFF\x04\x00\x00\x00WEBPbody".to_vec(),
+                },
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(prepared.paths().len(), 2);
+        assert_eq!(prepared.paths()[0].extension().unwrap(), "png");
+        assert_eq!(prepared.paths()[1].extension().unwrap(), "webp");
+        let directory = prepared.directory.clone();
+        for path in prepared.paths() {
+            assert_eq!(
+                std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+
+        drop(prepared);
+        assert!(!directory.exists());
+        let _ = std::fs::remove_dir(cache);
+    }
+
+    #[test]
+    fn rejects_unsupported_oversized_and_excess_images() {
+        let cache = temp_dir("rejected-images");
+        assert!(PreparedImages::create(
+            &cache,
+            vec![DownloadedImage {
+                bytes: b"not an image".to_vec(),
+            }],
+        )
+        .is_err());
+        assert!(PreparedImages::create(
+            &cache,
+            vec![DownloadedImage {
+                bytes: vec![0xff; MAX_IMAGE_BYTES + 1],
+            }],
+        )
+        .is_err());
+        assert!(PreparedImages::create(
+            &cache,
+            (0..=MAX_IMAGE_COUNT)
+                .map(|_| DownloadedImage {
+                    bytes: b"\xff\xd8\xffbody".to_vec(),
+                })
+                .collect(),
+        )
+        .is_err());
+        let _ = std::fs::remove_dir(cache);
+    }
+}

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -2967,6 +2967,7 @@ failure precisely. End with exactly one final line: VERDICT: PASS or VERDICT: FA
         work_dir: &workdir,
         instructions,
         prompt: &prompt,
+        images: &[],
     };
     match runner.run_evaluator(request, job.timeout).await {
         Ok(output) => evaluation_from_reply(output.reply),
@@ -3037,6 +3038,7 @@ async fn execute(cfg: &Config, job: &Job) -> std::result::Result<String, Executi
         work_dir: &workdir,
         instructions: &prompt.instructions,
         prompt: &prompt.content,
+        images: &[],
     };
     tracing::info!(
         "job {} starting: backend={} workdir={} timeout={}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod config;
 mod doctor;
 mod gateway;
 mod history;
+mod image;
 mod imessage;
 mod jobs;
 mod markdown;

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -275,6 +275,7 @@ mod tests {
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: &instructions,
                     prompt: &prompt,
+                    images: &[],
                 },
                 Duration::from_secs(5),
             )
@@ -381,6 +382,7 @@ mod tests {
                     work_dir: work_dir.to_str().unwrap(),
                     instructions: "SOUL instructions",
                     prompt: "continue",
+                    images: &[],
                 },
                 Duration::from_secs(5),
             )
@@ -553,6 +555,7 @@ printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"
             work_dir,
             instructions: "",
             prompt: "hello",
+            images: &[],
         }
     }
 
@@ -641,6 +644,7 @@ printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"
             work_dir,
             instructions: String::new(),
             prompt: "hello".to_string(),
+            images: Vec::new(),
         }
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -497,6 +497,7 @@ impl Inbox {
                     is_group: row.get(7)?,
                     text: row.get(5)?,
                     voice: None,
+                    images: Vec::new(),
                     is_from_me: row.get(8)?,
                     is_supported: row.get(9)?,
                     thread_id: None,

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -10,7 +10,8 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
-use crate::channel::{InboundVoice, RawMessage};
+use crate::channel::{InboundImage, InboundVoice, RawMessage};
+use crate::image::{DownloadedImage, MAX_IMAGE_BYTES};
 use crate::voice::{AudioClip, MAX_AUDIO_BYTES};
 
 pub const TEXT_LIMIT: usize = 4096;
@@ -29,7 +30,13 @@ trait Transport: Send + Sync {
     fn post<'a>(&'a self, token: &'a str, method: &'static str, body: Value)
         -> TransportFuture<'a>;
 
-    fn download<'a>(&'a self, _token: &'a str, _file_path: &'a str) -> BytesFuture<'a> {
+    fn download<'a>(
+        &'a self,
+        _token: &'a str,
+        _file_path: &'a str,
+        _max_bytes: usize,
+        _kind: &'static str,
+    ) -> BytesFuture<'a> {
         Box::pin(async { bail!("Telegram file download is not available") })
     }
 
@@ -73,7 +80,13 @@ impl Transport for ReqwestTransport {
         })
     }
 
-    fn download<'a>(&'a self, token: &'a str, file_path: &'a str) -> BytesFuture<'a> {
+    fn download<'a>(
+        &'a self,
+        token: &'a str,
+        file_path: &'a str,
+        max_bytes: usize,
+        kind: &'static str,
+    ) -> BytesFuture<'a> {
         Box::pin(async move {
             let url = format!("https://api.telegram.org/file/bot{token}/{file_path}");
             let mut response = self
@@ -82,30 +95,30 @@ impl Transport for ReqwestTransport {
                 .timeout(Duration::from_secs(HTTP_TIMEOUT_SECONDS))
                 .send()
                 .await
-                .map_err(|_| anyhow::anyhow!("Telegram voice download failed"))?;
+                .map_err(|_| anyhow::anyhow!("Telegram {kind} download failed"))?;
             let status = response.status();
             if !status.is_success() {
-                bail!("Telegram voice download returned HTTP {}", status.as_u16());
+                bail!("Telegram {kind} download returned HTTP {}", status.as_u16());
             }
             if response
                 .content_length()
-                .is_some_and(|size| size > MAX_AUDIO_BYTES as u64)
+                .is_some_and(|size| size > max_bytes as u64)
             {
-                bail!("Telegram voice message exceeds the 20 MB limit");
+                bail!("Telegram {kind} exceeds the configured size limit");
             }
             let mut bytes = Vec::with_capacity(
                 response
                     .content_length()
                     .unwrap_or_default()
-                    .min(MAX_AUDIO_BYTES as u64) as usize,
+                    .min(max_bytes as u64) as usize,
             );
             while let Some(chunk) = response
                 .chunk()
                 .await
-                .context("read Telegram voice message")?
+                .with_context(|| format!("read Telegram {kind}"))?
             {
-                if bytes.len().saturating_add(chunk.len()) > MAX_AUDIO_BYTES {
-                    bail!("Telegram voice message exceeds the 20 MB limit");
+                if bytes.len().saturating_add(chunk.len()) > max_bytes {
+                    bail!("Telegram {kind} exceeds the configured size limit");
                 }
                 bytes.extend_from_slice(&chunk);
             }
@@ -326,12 +339,54 @@ impl Telegram {
             .result
             .context("Telegram getFile omitted the file path")?
             .file_path;
-        let bytes = self.transport.download(&self.token, &file_path).await?;
+        let bytes = self
+            .transport
+            .download(&self.token, &file_path, MAX_AUDIO_BYTES, "voice message")
+            .await?;
         Ok(AudioClip {
             bytes,
             filename: voice.filename.clone(),
             mime_type: voice.mime_type.clone(),
         })
+    }
+
+    pub async fn download_image(&self, image: &InboundImage) -> Result<DownloadedImage> {
+        if let Some(bytes) = &image.data {
+            return Ok(DownloadedImage {
+                bytes: bytes.clone(),
+            });
+        }
+        if image.file_size.is_some_and(|size| size > MAX_IMAGE_BYTES) {
+            bail!("Telegram image exceeds the 6 MiB limit");
+        }
+        if !matches!(
+            image.mime_type.as_deref(),
+            Some("image/jpeg" | "image/png" | "image/webp")
+        ) {
+            bail!("Telegram image is not a supported JPEG, PNG, or WebP file");
+        }
+        let transport_response = self
+            .transport
+            .post(&self.token, "getFile", json!({"file_id": image.locator}))
+            .await?;
+        let response: ApiResponse<TelegramFile> =
+            serde_json::from_value(transport_response.body)
+                .map_err(|_| anyhow::anyhow!("Telegram getFile returned an invalid response"))?;
+        if !response.ok {
+            bail!(
+                "Telegram getFile returned HTTP {}",
+                transport_response.status
+            );
+        }
+        let file_path = response
+            .result
+            .context("Telegram getFile omitted the image path")?
+            .file_path;
+        let bytes = self
+            .transport
+            .download(&self.token, &file_path, MAX_IMAGE_BYTES, "image")
+            .await?;
+        Ok(DownloadedImage { bytes })
     }
 
     #[cfg_attr(test, allow(dead_code))]
@@ -458,11 +513,38 @@ impl Update {
                 is_group: false,
                 text: String::new(),
                 voice: None,
+                images: Vec::new(),
                 is_from_me: false,
                 is_supported: false,
                 thread_id: None,
             };
         };
+        let images = message
+            .photo
+            .into_iter()
+            .max_by_key(|photo| photo.file_size.unwrap_or_default())
+            .map(|photo| InboundImage {
+                locator: photo.file_id,
+                file_size: photo.file_size,
+                mime_type: Some("image/jpeg".to_string()),
+                data: None,
+            })
+            .or_else(|| {
+                message.document.and_then(|document| {
+                    document
+                        .mime_type
+                        .as_deref()
+                        .is_some_and(|mime| mime.starts_with("image/"))
+                        .then_some(InboundImage {
+                            locator: document.file_id,
+                            file_size: document.file_size,
+                            mime_type: document.mime_type,
+                            data: None,
+                        })
+                })
+            })
+            .into_iter()
+            .collect();
         RawMessage {
             row_id: self.update_id,
             provider_event_id: None,
@@ -473,7 +555,7 @@ impl Update {
                 .unwrap_or_default(),
             chat_identifier: message.chat.id.to_string(),
             is_group: message.chat.kind != "private",
-            text: message.text.unwrap_or_default(),
+            text: message.text.or(message.caption).unwrap_or_default(),
             voice: message.voice.map(|voice| InboundVoice {
                 locator: voice.file_id,
                 file_size: voice.file_size,
@@ -481,6 +563,7 @@ impl Update {
                 filename: "voice.ogg".to_string(),
                 data: None,
             }),
+            images,
             is_from_me: false,
             is_supported: true,
             thread_id: message.message_thread_id,
@@ -496,6 +579,12 @@ struct TelegramMessage {
     #[serde(default)]
     text: Option<String>,
     #[serde(default)]
+    caption: Option<String>,
+    #[serde(default)]
+    photo: Vec<TelegramPhoto>,
+    #[serde(default)]
+    document: Option<TelegramDocument>,
+    #[serde(default)]
     voice: Option<TelegramVoice>,
     #[serde(default)]
     message_thread_id: Option<i64>,
@@ -508,6 +597,22 @@ struct TelegramVoice {
     file_size: Option<usize>,
     #[serde(default)]
     mime_type: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct TelegramPhoto {
+    file_id: String,
+    #[serde(default)]
+    file_size: Option<usize>,
+}
+
+#[derive(Deserialize)]
+struct TelegramDocument {
+    file_id: String,
+    #[serde(default)]
+    mime_type: Option<String>,
+    #[serde(default)]
+    file_size: Option<usize>,
 }
 
 #[derive(Default, Deserialize)]
@@ -613,7 +718,13 @@ mod tests {
             })
         }
 
-        fn download<'a>(&'a self, _token: &'a str, file_path: &'a str) -> BytesFuture<'a> {
+        fn download<'a>(
+            &'a self,
+            _token: &'a str,
+            file_path: &'a str,
+            _max_bytes: usize,
+            _kind: &'static str,
+        ) -> BytesFuture<'a> {
             Box::pin(async move {
                 self.download_paths
                     .lock()
@@ -744,6 +855,9 @@ mod tests {
                     kind: "private".to_string(),
                 },
                 text: Some("hi".to_string()),
+                caption: None,
+                photo: Vec::new(),
+                document: None,
                 voice: None,
                 message_thread_id: None,
             }),
@@ -768,6 +882,9 @@ mod tests {
                     kind: "private".to_string(),
                 },
                 text: None,
+                caption: None,
+                photo: Vec::new(),
+                document: None,
                 voice: Some(TelegramVoice {
                     file_id: "file-123".to_string(),
                     file_size: Some(42),
@@ -783,6 +900,57 @@ mod tests {
         assert_eq!(voice.locator, "file-123");
         assert_eq!(voice.file_size, Some(42));
         assert!(voice.data.is_none());
+    }
+
+    #[test]
+    fn parses_caption_and_selects_the_largest_photo_without_downloading() {
+        let update: Update = serde_json::from_value(json!({
+            "update_id": 3,
+            "message": {
+                "from": {"id": 7},
+                "chat": {"id": 7, "type": "private"},
+                "caption": "inspect this",
+                "photo": [
+                    {"file_id": "small", "file_size": 10},
+                    {"file_id": "large", "file_size": 42}
+                ]
+            }
+        }))
+        .unwrap();
+
+        let message = update.into_raw();
+
+        assert_eq!(message.text, "inspect this");
+        assert_eq!(message.images.len(), 1);
+        assert_eq!(message.images[0].locator, "large");
+        assert_eq!(message.images[0].file_size, Some(42));
+        assert_eq!(message.images[0].mime_type.as_deref(), Some("image/jpeg"));
+        assert!(message.images[0].data.is_none());
+    }
+
+    #[test]
+    fn parses_image_document_metadata_without_downloading() {
+        let update: Update = serde_json::from_value(json!({
+            "update_id": 4,
+            "message": {
+                "from": {"id": 7},
+                "chat": {"id": 7, "type": "private"},
+                "document": {
+                    "file_id": "document-image",
+                    "file_name": "diagram.png",
+                    "mime_type": "image/png",
+                    "file_size": 120
+                }
+            }
+        }))
+        .unwrap();
+
+        let message = update.into_raw();
+
+        assert_eq!(message.text, "");
+        assert_eq!(message.images.len(), 1);
+        assert_eq!(message.images[0].locator, "document-image");
+        assert_eq!(message.images[0].mime_type.as_deref(), Some("image/png"));
     }
 
     #[tokio::test]
@@ -811,6 +979,52 @@ mod tests {
             fake.download_paths.lock().unwrap().as_slice(),
             ["voice/file.oga"]
         );
+    }
+
+    #[tokio::test]
+    async fn downloads_image_by_file_id_after_metadata_parsing() {
+        let fake = Arc::new(FakeTransport::with_responses(vec![json!({
+            "ok": true,
+            "result": {"file_path": "photos/file.png"}
+        })]));
+        fake.downloads
+            .lock()
+            .unwrap()
+            .push_back(b"\x89PNG\r\n\x1a\nbody".to_vec());
+        let telegram =
+            Telegram::with_transport("secret".to_string(), vec![7], vec![], fake.clone());
+        let image = InboundImage {
+            locator: "image-123".to_string(),
+            file_size: Some(12),
+            mime_type: Some("image/png".to_string()),
+            data: None,
+        };
+
+        let downloaded = telegram.download_image(&image).await.unwrap();
+
+        assert!(downloaded.bytes.starts_with(b"\x89PNG\r\n\x1a\n"));
+        assert_eq!(fake.calls.lock().unwrap()[0].0, "getFile");
+        assert_eq!(fake.calls.lock().unwrap()[0].1["file_id"], "image-123");
+        assert_eq!(
+            fake.download_paths.lock().unwrap().as_slice(),
+            ["photos/file.png"]
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_declared_image_before_requesting_the_file() {
+        let fake = Arc::new(FakeTransport::default());
+        let telegram =
+            Telegram::with_transport("secret".to_string(), vec![7], vec![], fake.clone());
+        let image = InboundImage {
+            locator: "svg-123".to_string(),
+            file_size: Some(12),
+            mime_type: Some("image/svg+xml".to_string()),
+            data: None,
+        };
+
+        assert!(telegram.download_image(&image).await.is_err());
+        assert!(fake.calls.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -522,7 +522,12 @@ impl Update {
         let images = message
             .photo
             .into_iter()
-            .max_by_key(|photo| photo.file_size.unwrap_or_default())
+            .max_by_key(|photo| {
+                (
+                    photo.width.saturating_mul(photo.height),
+                    photo.file_size.unwrap_or_default(),
+                )
+            })
             .map(|photo| InboundImage {
                 locator: photo.file_id,
                 file_size: photo.file_size,
@@ -602,6 +607,8 @@ struct TelegramVoice {
 #[derive(Deserialize)]
 struct TelegramPhoto {
     file_id: String,
+    width: usize,
+    height: usize,
     #[serde(default)]
     file_size: Option<usize>,
 }
@@ -911,8 +918,8 @@ mod tests {
                 "chat": {"id": 7, "type": "private"},
                 "caption": "inspect this",
                 "photo": [
-                    {"file_id": "small", "file_size": 10},
-                    {"file_id": "large", "file_size": 42}
+                    {"file_id": "small", "width": 90, "height": 90, "file_size": 42},
+                    {"file_id": "large", "width": 320, "height": 240}
                 ]
             }
         }))
@@ -923,7 +930,7 @@ mod tests {
         assert_eq!(message.text, "inspect this");
         assert_eq!(message.images.len(), 1);
         assert_eq!(message.images[0].locator, "large");
-        assert_eq!(message.images[0].file_size, Some(42));
+        assert_eq!(message.images[0].file_size, None);
         assert_eq!(message.images[0].mime_type.as_deref(), Some("image/jpeg"));
         assert!(message.images[0].data.is_none());
     }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -133,6 +133,7 @@ pub struct ContractRequest {
     pub work_dir: PathBuf,
     pub instructions: String,
     pub prompt: String,
+    pub images: Vec<PathBuf>,
 }
 
 impl ContractRequest {
@@ -143,6 +144,7 @@ impl ContractRequest {
             work_dir: self.work_dir.to_str().unwrap(),
             instructions: &self.instructions,
             prompt: &self.prompt,
+            images: &self.images,
         }
     }
 }


### PR DESCRIPTION
## Summary

- add a provider-neutral inbound image contract and secure temporary-file lifecycle
- accept Telegram photos and supported image documents, preserving captions and enforcing allowlist, type, count, and size limits
- attach images to new, resumed, and recovered Codex sessions while keeping bytes out of history and cleaning files before reply delivery
- document image limits, privacy behavior, and unsupported providers

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (446 tests passed across all targets)
- `mkdocs build --strict`
- independent code review completed with no remaining findings

Manual Telegram-to-real-Codex validation was not run because this environment does not have the bot credentials or a live test chat.

Closes #185