### PR TITLE
feat(pi): support image attachments

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -511,6 +511,7 @@ File: [`src/pi.rs`](src/pi.rs)
 | New chat | `pi --print --mode json` |
 | Resumed chat | `pi --print --mode json --session <session-id>` |
 | Instructions | `--append-system-prompt <composed system sections>` |
+| Images | repeated `@<private-temporary-path>` arguments on new and resumed chats |
 | Unattended job | `--approve` only when the project resources are trusted |
 | Evaluator | no approval, tools, extensions, skills, templates, context, or session |
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -52,26 +52,28 @@ Telegram-only preflight does not open `chat.db` and does not require macOS or
 
 ## Image Messages
 
-With Codex selected for the conversation, send the bot a Telegram photo or an
-image document. Push accepts JPEG, PNG, and WebP files. A caption becomes the
-message text; an image without a caption is still accepted. Telegram media
+With Codex or Pi selected for the conversation, send the bot a Telegram photo
+or an image document. Push accepts JPEG, PNG, and WebP files. A caption becomes
+the message text; an image without a caption is still accepted. Telegram media
 groups are processed as separate messages.
 
 Push downloads an image only after the private-chat and sender allowlist checks
 pass. The declared and downloaded size must fit within the 6 MiB per-message
 limit, and Push verifies the downloaded file signature instead of trusting the
 provider MIME type. Unsupported, malformed, or oversized files receive a text
-reply and do not reach Codex.
+reply and do not reach the agent.
 
 Validated bytes are written to an owner-only temporary directory under
-`$PUSH_HOME/cache`, attached to the Codex turn, and removed after success,
+`$PUSH_HOME/cache`, attached to the agent turn, and removed after success,
 failure, timeout, interruption, or session recovery. Push stores the caption or
 an `[Image attachment]` placeholder in conversation history, not the image
-bytes. The image is sent through the configured Codex model provider, so review
-that provider's image and data controls before using this feature.
+bytes. The image is sent through the configured Codex or Pi model provider, so
+review that provider's image and data controls before using this feature. Pi
+receives images using its native `@image-path` arguments while message text
+continues through standard input.
 
-Image input for Claude Code and Pi, and sending generated images back through
-Telegram, are not supported yet.
+Image input for Claude Code, and sending generated images back through Telegram,
+are not supported yet.
 
 ## Voice Messages
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -125,12 +125,12 @@ impl Runner {
     }
 
     pub fn supports_images(&self) -> bool {
-        if matches!(self, Runner::Codex(_)) {
+        if matches!(self, Runner::Codex(_) | Runner::Pi(_)) {
             return true;
         }
         #[cfg(test)]
         if let Self::Fake(runner) = self {
-            return runner.backend == AgentBackend::Codex;
+            return matches!(runner.backend, AgentBackend::Codex | AgentBackend::Pi);
         }
         false
     }

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -1805,6 +1805,68 @@ async fn telegram_image_is_available_to_the_agent_and_removed_after_the_turn() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn telegram_image_only_and_captioned_messages_reach_pi() {
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("pi-image-sessions");
+    let assistant_dir = temp_path("pi-image-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::<FakeRunCall>::new()));
+    let mut cfg = test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    );
+    cfg.channel = "telegram".to_string();
+    cfg.agent = "pi".to_string();
+    cfg.telegram_bot_token = Some("secret".to_string());
+    cfg.telegram_allow_user_ids = vec![7];
+    let mut gateway = Gateway::new(cfg).unwrap();
+    gateway.ctx.runners = Arc::new(HashMap::from([(
+        AgentBackend::Pi,
+        Runner::Fake(FakeRunner {
+            backend: AgentBackend::Pi,
+            session_id: "fake-session".to_string(),
+            calls: calls.clone(),
+            before_return: None,
+            wait_for_release: None,
+            failure: None,
+            resume_missing_once: None,
+        }),
+    )]));
+
+    run_messages(
+        &mut gateway,
+        vec![
+            telegram_image_message(1, 7, 7, ""),
+            telegram_image_message(2, 7, 7, "inspect this"),
+        ],
+    )
+    .await;
+
+    let calls = calls.lock().unwrap();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(
+        crate::prompt::current_message(&calls[0].prompt).as_deref(),
+        Some("[Image attachment]")
+    );
+    assert_eq!(
+        crate::prompt::current_message(&calls[1].prompt).as_deref(),
+        Some("inspect this")
+    );
+    assert!(calls.iter().all(|call| call.images.len() == 1));
+    assert!(calls.iter().all(|call| !call.images[0].exists()));
+    drop(calls);
+    assert_eq!(gateway.store.lock().unwrap().cursor("telegram").unwrap(), 2);
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_dir_all(format!("{state_path}.cache"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn telegram_image_is_removed_before_reply_delivery_finishes() {
     let state_path = temp_state_path();
     let sessions_dir = temp_path("image-delivery-sessions");
@@ -1915,14 +1977,14 @@ async fn telegram_image_on_unsupported_backend_falls_back_without_downloading() 
         assistant_dir.to_str().unwrap(),
     );
     cfg.channel = "telegram".to_string();
-    cfg.agent = "pi".to_string();
+    cfg.agent = "claude".to_string();
     cfg.telegram_bot_token = Some("secret".to_string());
     cfg.telegram_allow_user_ids = vec![7];
     let mut gateway = Gateway::new(cfg).unwrap();
     gateway.ctx.runners = Arc::new(HashMap::from([(
-        AgentBackend::Pi,
+        AgentBackend::Claude,
         Runner::Fake(FakeRunner {
-            backend: AgentBackend::Pi,
+            backend: AgentBackend::Claude,
             session_id: "fake-session".to_string(),
             calls: calls.clone(),
             before_return: None,
@@ -1939,7 +2001,7 @@ async fn telegram_image_on_unsupported_backend_falls_back_without_downloading() 
     assert!(calls.lock().unwrap().is_empty());
     assert_eq!(
         gateway.ctx.sent_replies.lock().unwrap()[0].1,
-        "Image messages are currently supported only when this conversation routes to Codex."
+        "Image messages are currently supported only when this conversation routes to Codex or Pi."
     );
 
     let _ = std::fs::remove_file(&state_path);

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -145,8 +145,7 @@ where
     };
 
     if !job.image_attachments.is_empty() && !runner.supports_images() {
-        let reply =
-            "Image messages are currently supported only when this conversation routes to Codex.";
+        let reply = "Image messages are currently supported only when this conversation routes to Codex or Pi.";
         let delivery = record_and_deliver(ctx, &job, OutboundOrigin::Gateway, reply).await;
         report_delivery(
             ctx,

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -1,5 +1,6 @@
 //! Runs the Pi coding agent headlessly for a single message.
 
+use std::ffi::OsString;
 use std::time::Duration;
 use std::{io, process::Stdio};
 
@@ -142,6 +143,11 @@ impl Runner {
         }
         if !req.is_new {
             cmd.arg("--session").arg(req.session_id);
+        }
+        for image in req.images {
+            let mut attachment = OsString::from("@");
+            attachment.push(image);
+            cmd.arg(attachment);
         }
         cmd.current_dir(req.work_dir);
         cmd.kill_on_drop(true);
@@ -397,6 +403,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn attaches_images_in_order_for_new_and_resumed_sessions() {
+        for (is_new, expected_session) in [(true, None), (false, Some("existing-session"))] {
+            let args_path = temp_path("pi-image-args");
+            let work_dir = temp_dir("pi-image-work");
+            let first = temp_path("pi-first.png");
+            let second = temp_path("pi-second.webp");
+            let cli = FakeCli::new("pi", &success_script(&args_path, "pi-session", "seen"));
+            let runner = Runner { bin: cli.bin() };
+
+            let output = runner
+                .run(
+                    Request {
+                        session_id: if is_new { "" } else { "existing-session" },
+                        is_new,
+                        work_dir: work_dir.to_str().unwrap(),
+                        instructions: "",
+                        prompt: "inspect these pixels",
+                        images: &[first.clone(), second.clone()],
+                    },
+                    Duration::from_secs(5),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(output.reply, "seen");
+            let args = read_args(&args_path);
+            let attachments = args
+                .iter()
+                .filter(|arg| arg.starts_with('@'))
+                .map(String::as_str)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                attachments,
+                [
+                    format!("@{}", first.display()),
+                    format!("@{}", second.display())
+                ]
+            );
+            assert_eq!(read_prompt(&args_path), "inspect these pixels");
+            assert!(!args.iter().any(|arg| arg == "inspect these pixels"));
+            assert_eq!(
+                args.windows(2)
+                    .find(|pair| pair[0] == "--session")
+                    .map(|pair| pair[1].as_str()),
+                expected_session
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn missing_resume_is_typed_for_rehydration() {
         let work_dir = temp_dir("pi-missing-work");
         let cli = FakeCli::new(
@@ -511,6 +567,41 @@ printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"
             .unwrap();
 
         assert_eq!(output.reply, "recovered");
+    }
+
+    #[tokio::test]
+    async fn image_model_rejection_is_not_retried_without_the_image() {
+        let work_dir = temp_dir("pi-image-rejection-work");
+        let args_path = temp_path("pi-image-rejection-args");
+        let calls_path = temp_path("pi-image-rejection-calls");
+        let image = temp_path("pi-rejected.png");
+        let script = format!(
+            "#!/bin/sh\nprintf x >> {}\nprintf '%s\\n' \"$@\" > {}\ncat > {}.stdin\nprintf '%s\\n' '{{\"type\":\"session\",\"id\":\"rejected-session\"}}'\nprintf '%s\\n' '{{\"type\":\"message_end\",\"message\":{{\"role\":\"assistant\",\"content\":[],\"stopReason\":\"error\"}}}}'\n",
+            sh_arg(&calls_path),
+            sh_arg(&args_path),
+            sh_arg(&args_path),
+        );
+        let cli = FakeCli::new("pi", &script);
+        let runner = Runner { bin: cli.bin() };
+
+        let error = runner
+            .run(
+                Request {
+                    prompt: "inspect",
+                    images: std::slice::from_ref(&image),
+                    ..request(work_dir.to_str().unwrap(), true)
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(failed_message(error).contains("Pi assistant request failed"));
+        assert_eq!(std::fs::read_to_string(calls_path).unwrap(), "x");
+        assert!(read_args(&args_path)
+            .iter()
+            .any(|arg| arg == &format!("@{}", image.display())));
+        assert_eq!(read_prompt(&args_path), "inspect");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #186

## Summary
- route validated Telegram images to Pi using ordered native `@path` arguments
- keep all caption and prompt text on stdin for new and resumed sessions
- preserve image cleanup and return a backend failure without a text-only retry when Pi rejects an image
- document Pi image behavior and keep Claude as the unsupported backend until #187

## Verification
- `cargo test --locked pi`
- `cargo test --locked gateway`
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (449 tests across unit and integration targets)
- independent implementation review: no findings

## Manual verification
Not run: live Telegram routing requires a configured vision-capable Pi model.
