### PR TITLE
feat(slack): support inbound image attachments

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -452,6 +452,10 @@ File: [`src/slack.rs`](src/slack.rs)
   message thread.
 - Commits accepted envelopes to a dedicated SQLite inbox before acknowledging
   them to Slack.
+- Persists only file IDs and safe size and MIME type hints, then resolves and
+  downloads supported images with the bot token after allowlist acceptance.
+- Applies the provider-neutral image count, byte, and signature checks before
+  passing private temporary paths to Claude Code, Codex, or Pi.
 - Continues receiving while the gateway processes earlier messages.
 - Deduplicates stable Slack `event_id` values.
 
@@ -630,7 +634,9 @@ crash, and the scheduler still revalidates the exact revision before planning.
 The Slack receiver stores accepted events in `<state_path>.slack-inbox.db`
 before acknowledging Socket Mode envelopes. Its local row ID becomes the
 gateway cursor. Ignored envelopes keep redacted rejection metadata rather than
-message content.
+message or attachment content. Accepted image events persist only file IDs and
+safe size and MIME type hints. Private download URLs and file bytes are never
+stored.
 
 ### Audit Log
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,8 +136,8 @@ practical structure for identity, context, shared skills, jobs, and evals.
 === "Slack"
 
     Create a Slack app with Socket Mode, `connections:write`, `im:history`,
-    `chat:write`, and the `message.im` bot event. Set the two tokens in the
-    service environment, then edit `$PUSH_HOME/config.toml`:
+    `chat:write`, `files:read`, and the `message.im` bot event. Set the two
+    tokens in the service environment, then edit `$PUSH_HOME/config.toml`:
 
     ```toml
     channel = "slack"

--- a/docs/security.md
+++ b/docs/security.md
@@ -83,11 +83,16 @@ variable or move the config outside. When `voice.openai_api_key` is configured,
 chmod 600 "${PUSH_HOME:-$HOME/.push}/config.toml"
 ```
 
-Accepted Telegram images are briefly written under `$PUSH_HOME/cache` with
-owner-only permissions, passed to the selected Codex model provider, and
+Accepted Telegram and Slack images are briefly written under `$PUSH_HOME/cache`
+with owner-only permissions, passed to the selected agent backend, and
 removed when the turn ends. Conversation history retains only the caption or an
 image placeholder. Protect the cache directory while Push is running and
 review the configured model provider's image data controls.
+
+Slack's recovery inbox persists file IDs and safe size and MIME type hints, but
+not private download URLs or file bytes. Push resolves and downloads a Slack
+file with the bot token only after workspace, direct-message, and sender
+allowlist checks pass. Rejected events retain no message or attachment content.
 
 Push rejects any overlap between `assistant_root` and `PUSH_HOME`, including
 overlap through symlinks or existing ancestors. Keep the runtime root private

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -11,7 +11,7 @@ messages.
 1. Create a Slack app for one workspace and enable Socket Mode.
 2. Create an app-level token with `connections:write`. App tokens start with
    `xapp-`.
-3. Add the bot token scopes `im:history` and `chat:write`.
+3. Add the bot token scopes `im:history`, `chat:write`, and `files:read`.
 4. Under Event Subscriptions, subscribe to the bot event `message.im`.
 5. Install or reinstall the app and open its Messages tab.
 6. Copy your stable Slack member ID, such as `U012ABCDEF`, from your profile.
@@ -57,7 +57,19 @@ names are not accepted in the allowlist.
 
 Push validates the workspace, message shape, direct-message channel type,
 sender ID, and bot origin before an event can reach an agent. Ordinary text
-messages with no Slack message subtype are the supported first phase.
+messages and `file_share` messages are supported.
+
+Send up to four JPEG, PNG, or WebP images in one DM, with or without message
+text. Their combined size must be at most 6 MiB. Images work with Claude Code,
+Codex, and Pi. Push stores only Slack file IDs, sizes, and MIME type hints in
+the durable inbox before acknowledging the event. It never stores private
+download URLs or file bytes there. After the workspace, DM, and sender
+allowlist checks pass, Push resolves current file metadata with `files.info`,
+downloads the files using the bot token, validates the shared image limits and
+file signatures, and removes the private temporary files after the turn.
+Conversation history retains only the message text or an image placeholder.
+Review the configured model provider's image and data controls before using
+this feature.
 
 Each conversation uses the stable key
 `slack:dm:<workspace-id>:<dm-channel-id>`. Replies go to the Slack thread rooted
@@ -68,7 +80,8 @@ reply.
 
 Before acknowledging an accepted Socket Mode envelope, Push commits it to a
 private SQLite inbox beside `state_path`. Ignored envelopes retain only redacted
-rejection metadata, not message content, before they are acknowledged. Slack's globally unique Events API
+rejection metadata, not message text or attachment metadata, before they are
+acknowledged. Slack's globally unique Events API
 `event_id` is the durable deduplication key, while a local monotonic row ID
 drives ordered cursor recovery. A crash before acknowledgement causes Slack to
 redeliver the same event; a restart resumes committed rows above the saved cursor. Slack does
@@ -77,7 +90,9 @@ after Slack accepts a send can still produce an ambiguous delivery.
 
 Web API rate limits are retried once using Slack's `Retry-After` header, then
 the normal Push delivery retry path applies. Replies are split at 4,000 Unicode
-characters. Slack voice messages and replies are not supported.
+characters. If image metadata or download fails, Push sends a safe retry message
+without starting an agent. Sending generated images and Slack voice messages or
+replies is not supported.
 
 For scheduled delivery, use an allowlisted Slack user ID:
 
@@ -98,6 +113,6 @@ app's direct-message conversation.
 - If messages are ignored, confirm `message.im`, `im:history`, the exact member
   ID, and that the app was reinstalled after scope changes.
 - If Slack returns `missing_scope`, confirm `connections:write` is on the app
-  token and `im:history` plus `chat:write` are on the bot token.
+  token and `im:history`, `chat:write`, plus `files:read` are on the bot token.
 - Reconnect messages are expected because Slack refreshes Socket Mode
   connections periodically. Push's dedicated receiver reconnects automatically.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -707,12 +707,7 @@ impl ChannelContract for Slack {
     }
 
     async fn download_image(&self, image: &InboundImage) -> Result<DownloadedImage> {
-        let Some(bytes) = &image.data else {
-            bail!("Slack image attachments are not supported yet");
-        };
-        Ok(DownloadedImage {
-            bytes: bytes.clone(),
-        })
+        self.download_image(image).await
     }
 
     fn delivery_semantics(&self) -> DeliverySemantics {

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -8,6 +8,8 @@ use crate::imessage::{Poller, Sender};
 use crate::voice::{AudioClip, VoiceFuture, VoiceProvider};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 use uuid::Uuid;
 
 struct FakeVoice;
@@ -1805,6 +1807,140 @@ async fn telegram_image_is_available_to_the_agent_and_removed_after_the_turn() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn slack_images_reach_every_agent_backend_and_are_removed_after_each_turn() {
+    for (backend, name) in [
+        (AgentBackend::Claude, "claude"),
+        (AgentBackend::Codex, "codex"),
+        (AgentBackend::Pi, "pi"),
+    ] {
+        let state_path = temp_state_path();
+        let sessions_dir = temp_path(&format!("slack-{name}-image-sessions"));
+        let assistant_dir = temp_path(&format!("slack-{name}-image-assistant"));
+        std::fs::create_dir_all(&assistant_dir).unwrap();
+        let calls = Arc::new(Mutex::new(Vec::<FakeRunCall>::new()));
+        let mut cfg = test_config(
+            &state_path,
+            sessions_dir.to_str().unwrap(),
+            assistant_dir.to_str().unwrap(),
+        );
+        cfg.channel = "slack".to_string();
+        cfg.agent = name.to_string();
+        cfg.slack_app_token = Some("xapp-test".to_string());
+        cfg.slack_bot_token = Some("xoxb-test".to_string());
+        cfg.slack_allow_user_ids = vec!["U1".to_string()];
+        let mut gateway = Gateway::new(cfg).unwrap();
+        gateway.ctx.runners = Arc::new(HashMap::from([(
+            backend,
+            Runner::Fake(FakeRunner {
+                backend,
+                session_id: "fake-session".to_string(),
+                calls: calls.clone(),
+                before_return: None,
+                wait_for_release: None,
+                failure: None,
+                resume_missing_once: None,
+            }),
+        )]));
+
+        run_messages(
+            &mut gateway,
+            vec![slack_image_message(1, "U1", "", Some(valid_png()))],
+        )
+        .await;
+
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "{name}");
+        assert_eq!(
+            crate::prompt::current_message(&calls[0].prompt).as_deref(),
+            Some("[Image attachment]"),
+            "{name}"
+        );
+        assert_eq!(calls[0].images.len(), 1, "{name}");
+        assert!(!calls[0].images[0].exists(), "{name}");
+        drop(calls);
+
+        let _ = std::fs::remove_file(&state_path);
+        let _ = std::fs::remove_file(format!("{state_path}.db"));
+        let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+        let _ = std::fs::remove_file(format!("{state_path}.slack-inbox.db"));
+        let _ = std::fs::remove_dir_all(format!("{state_path}.cache"));
+        let _ = std::fs::remove_dir_all(sessions_dir);
+        let _ = std::fs::remove_dir_all(assistant_dir);
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn slack_download_failure_replies_without_running_an_agent() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = [0_u8; 2048];
+        let read = stream.read(&mut request).await.unwrap();
+        let request = String::from_utf8_lossy(&request[..read]);
+        assert!(request.starts_with("POST /files.info HTTP/1.1"));
+        assert!(request.contains("authorization: Bearer xoxb-test"));
+        stream
+            .write_all(
+                b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 37\r\nconnection: close\r\n\r\n{\"ok\":false,\"error\":\"file_not_found\"}",
+            )
+            .await
+            .unwrap();
+    });
+    let state_path = temp_state_path();
+    let sessions_dir = temp_path("slack-download-failure-sessions");
+    let assistant_dir = temp_path("slack-download-failure-assistant");
+    std::fs::create_dir_all(&assistant_dir).unwrap();
+    let calls = Arc::new(Mutex::new(Vec::<FakeRunCall>::new()));
+    let mut cfg = test_config(
+        &state_path,
+        sessions_dir.to_str().unwrap(),
+        assistant_dir.to_str().unwrap(),
+    );
+    cfg.channel = "slack".to_string();
+    cfg.slack_app_token = Some("xapp-test".to_string());
+    cfg.slack_bot_token = Some("xoxb-test".to_string());
+    cfg.slack_allow_user_ids = vec!["U1".to_string()];
+    let inbox_path = cfg.paths.inbox.clone();
+    let mut gateway = Gateway::new(cfg).unwrap();
+    gateway.ctx.runners = Arc::new(fake_runners(calls.clone()));
+    let channel = Channel::Slack(
+        crate::slack::Slack::with_api_base(
+            "xapp-test".to_string(),
+            "xoxb-test".to_string(),
+            vec!["U1".to_string()],
+            &inbox_path,
+            format!("http://{address}"),
+        )
+        .unwrap(),
+    );
+    gateway.channel = channel.clone();
+    gateway.ctx.channel = channel;
+
+    run_messages(
+        &mut gateway,
+        vec![slack_image_message(1, "U1", "inspect", None)],
+    )
+    .await;
+
+    assert!(calls.lock().unwrap().is_empty());
+    assert_eq!(gateway.ctx.sent_replies.lock().unwrap().len(), 1);
+    assert!(gateway.ctx.sent_replies.lock().unwrap()[0]
+        .1
+        .contains("JPEG, PNG, or WebP"));
+    assert_eq!(gateway.store.lock().unwrap().cursor("slack").unwrap(), 1);
+    server.await.unwrap();
+
+    let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(format!("{state_path}.db"));
+    let _ = std::fs::remove_file(format!("{state_path}.audit.jsonl"));
+    let _ = std::fs::remove_file(inbox_path);
+    let _ = std::fs::remove_dir_all(format!("{state_path}.cache"));
+    let _ = std::fs::remove_dir_all(sessions_dir);
+    let _ = std::fs::remove_dir_all(assistant_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn telegram_image_only_and_captioned_messages_reach_pi() {
     let state_path = temp_state_path();
     let sessions_dir = temp_path("pi-image-sessions");
@@ -3496,4 +3632,35 @@ fn telegram_image_message(row_id: i64, user_id: i64, chat_id: i64, caption: &str
         data: Some(b"\x89PNG\r\n\x1a\nbody".to_vec()),
     });
     message
+}
+
+fn valid_png() -> Vec<u8> {
+    b"\x89PNG\r\n\x1a\nbody".to_vec()
+}
+
+fn slack_image_message(
+    row_id: i64,
+    user_id: &str,
+    text: &str,
+    data: Option<Vec<u8>>,
+) -> RawMessage {
+    RawMessage {
+        row_id,
+        provider_event_id: Some(format!("Ev{row_id}")),
+        channel: "slack",
+        handle: user_id.to_string(),
+        chat_identifier: "T1|D1|1.2".to_string(),
+        text: text.to_string(),
+        voice: None,
+        images: vec![InboundImage {
+            locator: "F1".to_string(),
+            file_size: Some(12),
+            mime_type: Some("image/png".to_string()),
+            data,
+        }],
+        is_from_me: false,
+        is_group: false,
+        is_supported: true,
+        thread_id: None,
+    }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -7,9 +7,9 @@ use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use futures_util::{SinkExt, StreamExt};
-use reqwest::{Client, StatusCode};
+use reqwest::{Client, StatusCode, Url};
 use rusqlite::{params, Connection, OptionalExtension};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::net::TcpStream;
 use tokio::sync::{Mutex as AsyncMutex, Notify};
@@ -17,7 +17,8 @@ use tokio::task::JoinHandle;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
-use crate::channel::RawMessage;
+use crate::channel::{InboundImage, RawMessage};
+use crate::image::{DownloadedImage, MAX_IMAGE_BYTES};
 
 const API_BASE: &str = "https://slack.com/api";
 pub(crate) const MAX_TEXT_CHARS: usize = 4_000;
@@ -69,6 +70,14 @@ struct Event {
     is_group: bool,
     is_from_me: bool,
     is_supported: bool,
+    files: Vec<SlackFile>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+struct SlackFile {
+    id: String,
+    size: Option<usize>,
+    mimetype: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -87,6 +96,16 @@ struct ApiResponse {
     url: Option<String>,
     team_id: Option<String>,
     user_id: Option<String>,
+    file: Option<ApiFile>,
+}
+
+#[derive(Deserialize)]
+struct ApiFile {
+    id: String,
+    size: Option<usize>,
+    mimetype: Option<String>,
+    url_private: Option<String>,
+    url_private_download: Option<String>,
 }
 
 impl Drop for ReceiverTask {
@@ -113,7 +132,7 @@ impl Slack {
         )
     }
 
-    fn with_api_base(
+    pub(crate) fn with_api_base(
         app_token: String,
         bot_token: String,
         allow_user_ids: Vec<String>,
@@ -131,6 +150,7 @@ impl Slack {
                 inbox: Mutex::new(Inbox::open(inbox_path)?),
                 client: Client::builder()
                     .timeout(Duration::from_secs(25))
+                    .redirect(reqwest::redirect::Policy::none())
                     .build()
                     .context("build Slack HTTP client")?,
                 api_base,
@@ -197,6 +217,72 @@ impl Slack {
             )
             .await?;
         Ok(())
+    }
+
+    pub async fn download_image(&self, image: &InboundImage) -> Result<DownloadedImage> {
+        if let Some(bytes) = &image.data {
+            return Ok(DownloadedImage {
+                bytes: bytes.clone(),
+            });
+        }
+        let response = self
+            .state
+            .api(
+                "files.info",
+                &self.state.bot_token,
+                json!({"file": image.locator}),
+            )
+            .await?;
+        let file = response.file.context("Slack files.info omitted file")?;
+        if file.id != image.locator {
+            bail!("Slack files.info returned a different file");
+        }
+        if !matches!(
+            file.mimetype.as_deref(),
+            Some("image/jpeg" | "image/png" | "image/webp")
+        ) {
+            bail!("Slack file is not a supported JPEG, PNG, or WebP image");
+        }
+        if file.size.is_some_and(|size| size > MAX_IMAGE_BYTES) {
+            bail!("Slack image exceeds the 6 MiB limit");
+        }
+        let private_url = file
+            .url_private_download
+            .or(file.url_private)
+            .context("Slack files.info omitted a private download URL")?;
+        let private_url = validated_private_url(&self.state.api_base, &private_url)?;
+        let mut response = self
+            .state
+            .client
+            .get(private_url)
+            .bearer_auth(&self.state.bot_token)
+            .send()
+            .await
+            .map_err(|_| anyhow::anyhow!("download Slack image failed"))?;
+        if !response.status().is_success() {
+            bail!(
+                "Slack image download failed with status {}",
+                response.status()
+            );
+        }
+        if response
+            .content_length()
+            .is_some_and(|size| size > MAX_IMAGE_BYTES as u64)
+        {
+            bail!("Slack image exceeds the 6 MiB limit");
+        }
+        let mut bytes = Vec::new();
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|_| anyhow::anyhow!("read Slack image download failed"))?
+        {
+            if bytes.len().saturating_add(chunk.len()) > MAX_IMAGE_BYTES {
+                bail!("Slack image exceeds the 6 MiB limit");
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        Ok(DownloadedImage { bytes })
     }
 
     fn resolve_target(&self, target: &str) -> Result<(String, Option<String>)> {
@@ -357,6 +443,7 @@ impl State {
                 && self.allow_user_ids.contains(&event.user);
             if !accepted {
                 event.text.clear();
+                event.files.clear();
             }
             self.inbox.lock().unwrap().insert(&event)?;
             true
@@ -378,6 +465,30 @@ impl State {
             .await
             .context("acknowledge Slack Socket Mode envelope")
     }
+}
+
+fn validated_private_url(api_base: &str, value: &str) -> Result<Url> {
+    let url = Url::parse(value).context("Slack returned an invalid private download URL")?;
+    let base = Url::parse(api_base).context("invalid Slack API base URL")?;
+    let host = url
+        .host_str()
+        .context("Slack private download URL omitted a host")?;
+    let is_production = base.host_str() == Some("slack.com") && base.scheme() == "https";
+    let allowed = if is_production {
+        url.scheme() == "https"
+            && (host == "slack.com"
+                || host.ends_with(".slack.com")
+                || host == "slack-files.com"
+                || host.ends_with(".slack-files.com"))
+    } else {
+        url.scheme() == base.scheme()
+            && url.host_str() == base.host_str()
+            && url.port_or_known_default() == base.port_or_known_default()
+    };
+    if !allowed {
+        bail!("Slack returned a private download URL outside its trusted origin");
+    }
+    Ok(url)
 }
 
 fn retry_after(headers: &reqwest::header::HeaderMap) -> Duration {
@@ -432,9 +543,22 @@ impl Inbox {
                 root_ts TEXT NOT NULL,
                 is_group INTEGER NOT NULL,
                 is_from_me INTEGER NOT NULL,
-                is_supported INTEGER NOT NULL
+                is_supported INTEGER NOT NULL,
+                files_json TEXT NOT NULL DEFAULT '[]'
             );",
         )?;
+        let has_files_json = connection
+            .prepare("PRAGMA table_info(slack_events)")?
+            .query_map([], |row| row.get::<_, String>(1))?
+            .collect::<std::result::Result<Vec<_>, _>>()?
+            .iter()
+            .any(|column| column == "files_json");
+        if !has_files_json {
+            connection.execute(
+                "ALTER TABLE slack_events ADD COLUMN files_json TEXT NOT NULL DEFAULT '[]'",
+                [],
+            )?;
+        }
         Ok(Self {
             connection,
             path: path.to_string_lossy().to_string(),
@@ -442,11 +566,13 @@ impl Inbox {
     }
 
     fn insert(&mut self, event: &Event) -> Result<i64> {
+        let files_json =
+            serde_json::to_string(&event.files).context("encode Slack file metadata")?;
         self.connection.execute(
             "INSERT INTO slack_events (
                 event_id, team_id, channel_id, user_id, text, root_ts,
-                is_group, is_from_me, is_supported
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                is_group, is_from_me, is_supported, files_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
              ON CONFLICT(event_id) DO NOTHING",
             params![
                 event.event_id,
@@ -458,6 +584,7 @@ impl Inbox {
                 event.is_group,
                 event.is_from_me,
                 event.is_supported,
+                files_json,
             ],
         )?;
         self.connection
@@ -480,7 +607,7 @@ impl Inbox {
     fn after(&self, since: i64) -> Result<Vec<RawMessage>> {
         let mut statement = self.connection.prepare(
             "SELECT id, event_id, team_id, channel_id, user_id, text, root_ts,
-                    is_group, is_from_me, is_supported
+                    is_group, is_from_me, is_supported, files_json
              FROM slack_events WHERE id > ?1 ORDER BY id",
         )?;
         let rows = statement
@@ -488,6 +615,14 @@ impl Inbox {
                 let team: String = row.get(2)?;
                 let channel: String = row.get(3)?;
                 let root: String = row.get(6)?;
+                let files_json: String = row.get(10)?;
+                let files: Vec<SlackFile> = serde_json::from_str(&files_json).map_err(|error| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        10,
+                        rusqlite::types::Type::Text,
+                        Box::new(error),
+                    )
+                })?;
                 Ok(RawMessage {
                     row_id: row.get(0)?,
                     provider_event_id: Some(row.get(1)?),
@@ -497,7 +632,15 @@ impl Inbox {
                     is_group: row.get(7)?,
                     text: row.get(5)?,
                     voice: None,
-                    images: Vec::new(),
+                    images: files
+                        .into_iter()
+                        .map(|file| InboundImage {
+                            locator: file.id,
+                            file_size: file.size,
+                            mime_type: file.mimetype,
+                            data: None,
+                        })
+                        .collect(),
                     is_from_me: row.get(8)?,
                     is_supported: row.get(9)?,
                     thread_id: None,
@@ -546,6 +689,26 @@ fn parse_event(payload: &Value, identity: &Identity) -> Option<Event> {
         .unwrap_or(ts)
         .to_string();
     let subtype = event.get("subtype").and_then(Value::as_str);
+    let files = event
+        .get("files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|file| {
+            let id = file.get("id")?.as_str()?.to_string();
+            (!id.is_empty()).then(|| SlackFile {
+                id,
+                size: file
+                    .get("size")
+                    .and_then(Value::as_u64)
+                    .and_then(|size| usize::try_from(size).ok()),
+                mimetype: file
+                    .get("mimetype")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+            })
+        })
+        .collect::<Vec<_>>();
     let is_from_me = event.get("bot_id").is_some()
         || event.get("bot_profile").is_some()
         || subtype == Some("bot_message")
@@ -553,10 +716,10 @@ fn parse_event(payload: &Value, identity: &Identity) -> Option<Event> {
     let is_group = channel_type != "im";
     let is_supported = team_id == identity.team_id
         && event_type == "message"
-        && subtype.is_none()
+        && (subtype.is_none() || subtype == Some("file_share"))
         && !channel.is_empty()
         && !user.is_empty()
-        && !text.trim().is_empty()
+        && (!text.trim().is_empty() || !files.is_empty())
         && !root_ts.is_empty();
     Some(Event {
         event_id,
@@ -568,6 +731,7 @@ fn parse_event(payload: &Value, identity: &Identity) -> Option<Event> {
         is_group,
         is_from_me,
         is_supported,
+        files,
     })
 }
 
@@ -850,7 +1014,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_only_plain_workspace_dm_messages() {
+    fn parses_text_and_file_share_workspace_dm_messages() {
         let accepted = parse_event(
             &payload(json!({
                 "type": "message", "channel_type": "im", "channel": "D1",
@@ -862,6 +1026,44 @@ mod tests {
         assert!(accepted.is_supported);
         assert!(!accepted.is_group);
         assert!(!accepted.is_from_me);
+        assert!(accepted.files.is_empty());
+
+        let image_only = parse_event(
+            &payload(json!({
+                "type": "message", "subtype": "file_share", "channel_type": "im",
+                "channel": "D1", "user": "U1", "text": "", "ts": "1.3",
+                "files": [{
+                    "id": "F1", "size": 12, "mimetype": "image/png",
+                    "url_private": "https://files.slack.com/private-secret"
+                }]
+            })),
+            &identity(),
+        )
+        .unwrap();
+        assert!(image_only.is_supported);
+        assert_eq!(
+            image_only.files,
+            vec![SlackFile {
+                id: "F1".to_string(),
+                size: Some(12),
+                mimetype: Some("image/png".to_string()),
+            }]
+        );
+
+        let text_and_images = parse_event(
+            &payload(json!({
+                "type": "message", "channel_type": "im", "channel": "D1",
+                "user": "U1", "text": "compare", "ts": "1.4",
+                "files": [
+                    {"id": "F1", "size": 12, "mimetype": "image/png"},
+                    {"id": "F2", "size": 20, "mimetype": "image/jpeg"}
+                ]
+            })),
+            &identity(),
+        )
+        .unwrap();
+        assert!(text_and_images.is_supported);
+        assert_eq!(text_and_images.files.len(), 2);
 
         for event in [
             json!({"type":"message","channel_type":"channel","channel":"C1","user":"U1","text":"no","ts":"1"}),
@@ -882,7 +1084,11 @@ mod tests {
         let event = parse_event(
             &payload(json!({
                 "type": "message", "channel_type": "im", "channel": "D1",
-                "user": "U1", "text": "hello", "ts": "1.2"
+                "user": "U1", "text": "hello", "ts": "1.2",
+                "files": [{
+                    "id": "F1", "size": 12, "mimetype": "image/png",
+                    "url_private_download": "https://files.slack.com/private-secret"
+                }]
             })),
             &identity(),
         )
@@ -895,7 +1101,162 @@ mod tests {
         let rows = inbox.after(0).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].event_id(), "slack:Ev1");
+        assert_eq!(rows[0].images.len(), 1);
+        assert_eq!(rows[0].images[0].locator, "F1");
+        assert_eq!(rows[0].images[0].file_size, Some(12));
+        assert_eq!(rows[0].images[0].mime_type.as_deref(), Some("image/png"));
+        assert!(rows[0].images[0].data.is_none());
+        let files_json: String = inbox
+            .connection
+            .query_row("SELECT files_json FROM slack_events", [], |row| row.get(0))
+            .unwrap();
+        assert!(!files_json.contains("private"));
         assert_eq!(inbox.latest_cursor().unwrap(), 1);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn inbox_migrates_legacy_rows_without_losing_queued_events() {
+        let path = temp_path("slack-legacy-inbox");
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE slack_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    event_id TEXT NOT NULL UNIQUE,
+                    team_id TEXT NOT NULL,
+                    channel_id TEXT NOT NULL,
+                    user_id TEXT NOT NULL,
+                    text TEXT NOT NULL,
+                    root_ts TEXT NOT NULL,
+                    is_group INTEGER NOT NULL,
+                    is_from_me INTEGER NOT NULL,
+                    is_supported INTEGER NOT NULL
+                );
+                INSERT INTO slack_events (
+                    event_id, team_id, channel_id, user_id, text, root_ts,
+                    is_group, is_from_me, is_supported
+                ) VALUES ('EvLegacy', 'T1', 'D1', 'U1', 'queued', '1.2', 0, 0, 1);",
+            )
+            .unwrap();
+        drop(connection);
+
+        let inbox = Inbox::open(&path).unwrap();
+        let rows = inbox.after(0).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].event_id(), "slack:EvLegacy");
+        assert_eq!(rows[0].text, "queued");
+        assert!(rows[0].images.is_empty());
+        let columns = inbox
+            .connection
+            .prepare("PRAGMA table_info(slack_events)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(columns.iter().any(|column| column == "files_json"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn downloads_private_images_with_the_bot_token_after_metadata_resolution() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let image = b"\x89PNG\r\n\x1a\nbody";
+        let server = tokio::spawn(async move {
+            let (mut info_stream, _) = listener.accept().await.unwrap();
+            let info_request = read_http_request(&mut info_stream).await;
+            write_json_response(
+                &mut info_stream,
+                &format!(
+                    r#"{{"ok":true,"file":{{"id":"F1","size":{},"mimetype":"image/png","url_private_download":"http://{address}/private/F1"}}}}"#,
+                    image.len()
+                ),
+            )
+            .await;
+
+            let (mut download_stream, _) = listener.accept().await.unwrap();
+            let download_request = read_http_request(&mut download_stream).await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: image/png\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                image.len()
+            );
+            download_stream
+                .write_all(response.as_bytes())
+                .await
+                .unwrap();
+            download_stream.write_all(image).await.unwrap();
+            (info_request, download_request)
+        });
+        let path = temp_path("slack-image-download");
+        let slack = Slack::with_api_base(
+            "xapp-test".to_string(),
+            "xoxb-secret".to_string(),
+            vec!["U1".to_string()],
+            &path,
+            format!("http://{address}"),
+        )
+        .unwrap();
+
+        let downloaded = slack
+            .download_image(&InboundImage {
+                locator: "F1".to_string(),
+                file_size: Some(image.len()),
+                mime_type: Some("image/png".to_string()),
+                data: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(downloaded.bytes, image);
+        let (info_request, download_request) = server.await.unwrap();
+        assert!(info_request.starts_with("POST /files.info HTTP/1.1"));
+        assert!(info_request.contains("authorization: Bearer xoxb-secret"));
+        assert!(info_request.contains(r#"{"file":"F1"}"#));
+        assert!(download_request.starts_with("GET /private/F1 HTTP/1.1"));
+        assert!(download_request.contains("authorization: Bearer xoxb-secret"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn rejects_untrusted_private_urls_without_exposing_urls_or_tokens() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = read_http_request(&mut stream).await;
+            write_json_response(
+                &mut stream,
+                r#"{"ok":true,"file":{"id":"F1","size":12,"mimetype":"image/png","url_private_download":"https://evil.example/private-secret"}}"#,
+            )
+            .await;
+        });
+        let path = temp_path("slack-untrusted-image");
+        let slack = Slack::with_api_base(
+            "xapp-test".to_string(),
+            "xoxb-secret".to_string(),
+            vec!["U1".to_string()],
+            &path,
+            format!("http://{address}"),
+        )
+        .unwrap();
+
+        let error = slack
+            .download_image(&InboundImage {
+                locator: "F1".to_string(),
+                file_size: Some(12),
+                mime_type: Some("image/png".to_string()),
+                data: None,
+            })
+            .await
+            .unwrap_err();
+
+        let detail = format!("{error:#}");
+        assert!(!detail.contains("evil.example"));
+        assert!(!detail.contains("private-secret"));
+        assert!(!detail.contains("xoxb-secret"));
+        server.await.unwrap();
         let _ = std::fs::remove_file(path);
     }
 
@@ -1069,8 +1430,12 @@ mod tests {
             "type": "events_api",
             "envelope_id": "env-1",
             "payload": payload(json!({
-                "type": "message", "channel_type": "im", "channel": "D1",
-                "user": "U1", "text": "hello", "ts": "1.2"
+                "type": "message", "subtype": "file_share", "channel_type": "im",
+                "channel": "D1", "user": "U1", "text": "", "ts": "1.2",
+                "files": [{
+                    "id": "F1", "size": 12, "mimetype": "image/png",
+                    "url_private_download": "https://files.slack.com/private-secret"
+                }]
             }))
         })
         .to_string();
@@ -1103,6 +1468,9 @@ mod tests {
         let first = slack.poll(0).await.unwrap();
         assert_eq!(first.len(), 1);
         assert_eq!(first[0].event_id(), "slack:Ev1");
+        assert_eq!(first[0].images.len(), 1);
+        assert_eq!(first[0].images[0].locator, "F1");
+        assert_eq!(first[0].images[0].file_size, Some(12));
         assert!(slack.poll(1).await.is_err());
         let (first_ack, second_ack) = server.await.unwrap();
         assert_eq!(first_ack, r#"{"envelope_id":"env-1"}"#);
@@ -1223,6 +1591,12 @@ mod tests {
                     "type":"message", "channel_type":channel_type, "channel":"D1",
                     "user":user, "text":"message", "ts":"1.2"
                 });
+                if envelope_id == "env-unauthorized" {
+                    event["files"] = json!([{
+                        "id": "FSECRET", "size": 12, "mimetype": "image/png",
+                        "url_private_download": "https://files.slack.com/private-secret"
+                    }]);
+                }
                 if let Some(subtype) = subtype {
                     event["subtype"] = Value::String(subtype.to_string());
                     event["bot_id"] = Value::String("B1".to_string());
@@ -1273,12 +1647,18 @@ mod tests {
         let channel = crate::channel::Channel::Slack(slack.clone());
         for row in &rows[..3] {
             assert!(row.text.is_empty());
+            assert!(row.images.is_empty());
             assert!(channel.accept(row).is_none());
         }
         assert_eq!(rows[3].event_id(), "slack:EvV");
         assert_eq!(rows[3].handle, "U1");
         assert_eq!(rows[3].text, "message");
         assert!(channel.accept(&rows[3]).is_some());
+        let database = std::fs::read(&path).unwrap();
+        assert!(!database.windows(7).any(|window| window == b"FSECRET"));
+        assert!(!database
+            .windows(14)
+            .any(|window| window == b"private-secret"));
 
         let requests = http_server.await.unwrap();
         assert!(requests[0].starts_with("POST /auth.test HTTP/1.1"));

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -250,15 +250,35 @@ impl Slack {
             .url_private_download
             .or(file.url_private)
             .context("Slack files.info omitted a private download URL")?;
-        let private_url = validated_private_url(&self.state.api_base, &private_url)?;
-        let mut response = self
-            .state
-            .client
-            .get(private_url)
-            .bearer_auth(&self.state.bot_token)
-            .send()
-            .await
-            .map_err(|_| anyhow::anyhow!("download Slack image failed"))?;
+        let mut private_url = validated_private_url(&self.state.api_base, &private_url)?;
+        let mut redirects = 0;
+        let mut response = loop {
+            let response = self
+                .state
+                .client
+                .get(private_url.clone())
+                .bearer_auth(&self.state.bot_token)
+                .send()
+                .await
+                .map_err(|_| anyhow::anyhow!("download Slack image failed"))?;
+            if !response.status().is_redirection() {
+                break response;
+            }
+            if redirects == 3 {
+                bail!("Slack image download exceeded the redirect limit");
+            }
+            let location = response
+                .headers()
+                .get(reqwest::header::LOCATION)
+                .context("Slack image redirect omitted a destination")?
+                .to_str()
+                .map_err(|_| anyhow::anyhow!("Slack image redirect was invalid"))?;
+            let next = private_url
+                .join(location)
+                .map_err(|_| anyhow::anyhow!("Slack image redirect was invalid"))?;
+            private_url = validated_private_url(&self.state.api_base, next.as_str())?;
+            redirects += 1;
+        };
         if !response.status().is_success() {
             bail!(
                 "Slack image download failed with status {}",
@@ -1176,6 +1196,16 @@ mod tests {
             )
             .await;
 
+            let (mut redirect_stream, _) = listener.accept().await.unwrap();
+            let redirect_request = read_http_request(&mut redirect_stream).await;
+            let redirect = format!(
+                "HTTP/1.1 302 Found\r\nlocation: http://{address}/files-origin/F1\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+            );
+            redirect_stream
+                .write_all(redirect.as_bytes())
+                .await
+                .unwrap();
+
             let (mut download_stream, _) = listener.accept().await.unwrap();
             let download_request = read_http_request(&mut download_stream).await;
             let response = format!(
@@ -1187,7 +1217,7 @@ mod tests {
                 .await
                 .unwrap();
             download_stream.write_all(image).await.unwrap();
-            (info_request, download_request)
+            (info_request, redirect_request, download_request)
         });
         let path = temp_path("slack-image-download");
         let slack = Slack::with_api_base(
@@ -1210,11 +1240,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(downloaded.bytes, image);
-        let (info_request, download_request) = server.await.unwrap();
+        let (info_request, redirect_request, download_request) = server.await.unwrap();
         assert!(info_request.starts_with("POST /files.info HTTP/1.1"));
         assert!(info_request.contains("authorization: Bearer xoxb-secret"));
         assert!(info_request.contains(r#"{"file":"F1"}"#));
-        assert!(download_request.starts_with("GET /private/F1 HTTP/1.1"));
+        assert!(redirect_request.starts_with("GET /private/F1 HTTP/1.1"));
+        assert!(redirect_request.contains("authorization: Bearer xoxb-secret"));
+        assert!(download_request.starts_with("GET /files-origin/F1 HTTP/1.1"));
         assert!(download_request.contains("authorization: Bearer xoxb-secret"));
         let _ = std::fs::remove_file(path);
     }
@@ -1233,6 +1265,59 @@ mod tests {
             .await;
         });
         let path = temp_path("slack-untrusted-image");
+        let slack = Slack::with_api_base(
+            "xapp-test".to_string(),
+            "xoxb-secret".to_string(),
+            vec!["U1".to_string()],
+            &path,
+            format!("http://{address}"),
+        )
+        .unwrap();
+
+        let error = slack
+            .download_image(&InboundImage {
+                locator: "F1".to_string(),
+                file_size: Some(12),
+                mime_type: Some("image/png".to_string()),
+                data: None,
+            })
+            .await
+            .unwrap_err();
+
+        let detail = format!("{error:#}");
+        assert!(!detail.contains("evil.example"));
+        assert!(!detail.contains("private-secret"));
+        assert!(!detail.contains("xoxb-secret"));
+        server.await.unwrap();
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn rejects_untrusted_redirects_before_forwarding_the_bot_token() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut info_stream, _) = listener.accept().await.unwrap();
+            let _ = read_http_request(&mut info_stream).await;
+            write_json_response(
+                &mut info_stream,
+                &format!(
+                    r#"{{"ok":true,"file":{{"id":"F1","size":12,"mimetype":"image/png","url_private_download":"http://{address}/private/F1"}}}}"#
+                ),
+            )
+            .await;
+
+            let (mut redirect_stream, _) = listener.accept().await.unwrap();
+            let request = read_http_request(&mut redirect_stream).await;
+            assert!(request.contains("authorization: Bearer xoxb-secret"));
+            redirect_stream
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nlocation: https://evil.example/private-secret\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+        });
+        let path = temp_path("slack-untrusted-redirect");
         let slack = Slack::with_api_base(
             "xapp-test".to_string(),
             "xoxb-secret".to_string(),


### PR DESCRIPTION
Closes #188

## Summary
- persist only Slack file IDs and safe size/MIME hints before Socket Mode ACK, with a backward-compatible inbox migration
- resolve `files.info` and download trusted private Slack files with the bot token only after workspace, DM, and sender allowlist checks
- route image-only and text-plus-image DMs through the shared limits and Claude Code, Codex, or Pi image pipeline
- redact rejected attachment metadata and document `files:read`, limits, privacy, and failure behavior

## Verification
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked`
- `cargo test --locked` (427 unit tests and 31 integration tests)
- `uv run --with-requirements requirements-docs.txt mkdocs build --strict`
- fresh review agent: no actionable findings

## Manual verification
- Not run against a live Slack workspace because no workspace credentials were provided.
